### PR TITLE
29 unit tests in parallel fail in macos

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -37,13 +37,17 @@ jobs:
         if: success() || failure()
         run: build/${{ matrix.build-setup.cmake-preset }}/bin/norm_test --gtest_output="xml:${{github.workspace}}/reports/report-norm.xml"
 
-      - name: Run Unit Tests for the Parallel MPI Module in serial
+      - name: Run Unit Tests for the Parallel Module 
         if: success() || failure()
         run: build/${{ matrix.build-setup.cmake-preset }}/bin/parallel_test --gtest_output="xml:${{github.workspace}}/reports/report-parallel.xml"
 
+      - name: Run Unit Tests for the Parallel MPI Module in serial
+        if: success() || failure()
+        run: build/${{ matrix.build-setup.cmake-preset }}/bin/parallel_mpi_test --gtest_output="xml:${{github.workspace}}/reports/report-parallel-mpi-serial.xml"
+
       - name: Run Unit Tests for the Parallel MPI Module in parallel
         if: success() || failure()
-        run: mpiexec -n 4 build/${{ matrix.build-setup.cmake-preset }}/bin/parallel_mpi_test --gtest_output="xml:${{github.workspace}}/reports/report-parallel-mpi.xml"
+        run: mpiexec -n 4 build/${{ matrix.build-setup.cmake-preset }}/bin/parallel_mpi_test --gtest_output="xml:${{github.workspace}}/reports/report-parallel-mpi-parallel.xml"
 
       - name: Run Unit Tests for the Learning Module
         if: success() || failure()

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .vs/
 .vscode/
 
+# CMake User Preset
+CMakeUserPresets.json
+
 # Build directory
 build/
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -212,50 +212,42 @@
         {
             "name": "linux-clang-debug",
             "displayName": "Linux Clang Debug",
-            "configurePreset": "linux-clang-debug",
-            "jobs": 0
+            "configurePreset": "linux-clang-debug"
         },
         {
             "name": "linux-clang-release",
             "displayName": "Linux Clang Release",
-            "configurePreset": "linux-clang-release",
-            "jobs": 0
+            "configurePreset": "linux-clang-release"
         },
         {
             "name": "linux-gcc-debug",
             "displayName": "Linux GCC Debug",
-            "configurePreset": "linux-gcc-debug",
-            "jobs": 0
+            "configurePreset": "linux-gcc-debug"
         },
         {
             "name": "linux-gcc-release",
             "displayName": "Linux GCC Release",
-            "configurePreset": "linux-gcc-release",
-            "jobs": 0
+            "configurePreset": "linux-gcc-release"
         },
         {
             "name": "windows-msvc-debug",
             "displayName": "Windows MSVC Debug",
-            "configurePreset": "windows-msvc-debug",
-            "jobs": 0
+            "configurePreset": "windows-msvc-debug"
         },
         {
             "name": "windows-msvc-release",
             "displayName": "Windows MSVC Release",
-            "configurePreset": "windows-msvc-release",
-            "jobs": 0
+            "configurePreset": "windows-msvc-release"
         },
         {
             "name": "macos-clang-debug",
             "displayName": "macOS Clang Debug",
-            "configurePreset": "macos-clang-debug",
-            "jobs": 0
+            "configurePreset": "macos-clang-debug"
         },
         {
             "name": "macos-clang-release",
             "displayName": "macOS Clang Release",
-            "configurePreset": "macos-clang-release",
-            "jobs": 0
+            "configurePreset": "macos-clang-release"
         }
     ],
     "testPresets": [

--- a/packaging/conda/bld.bat
+++ b/packaging/conda/bld.bat
@@ -1,3 +1,3 @@
 % REM We use ninja for generator because VS does not work with conda build
 cmake --preset windows-msvc-release -G "Ninja" -DBUILD_JARS=OFF -DTESTING=OFF
-cmake --build --preset windows-msvc-release --target MODL --target MODL_Coclustering
+cmake --build --preset windows-msvc-release --parallel --target MODL --target MODL_Coclustering

--- a/packaging/conda/build.sh
+++ b/packaging/conda/build.sh
@@ -1,3 +1,3 @@
 # !/bin/bash
 cmake --preset linux-gcc-release -DBUILD_JARS=OFF -DTESTING=OFF
-cmake --build --preset linux-gcc-release --target MODL --target MODL_Coclustering
+cmake --build --preset linux-gcc-release --parallel --target MODL --target MODL_Coclustering

--- a/src/Norm/base/UIObject.cpp
+++ b/src/Norm/base/UIObject.cpp
@@ -1189,12 +1189,14 @@ JNIEnv* UIObject::GraphicGetJNIEnv()
 	ALString sTmp;
 	static boolean bGraphicIsLoaded = false;
 
-#ifdef __APPLE__
-	Global::AddFatalError("Java", "GUI", "Java GUI is not available on MacOS");
-#endif
-
 	cls = 0;
+
+#ifdef __APPLE__
+	Global::AddError("Java", "GUI", "Java GUI is not available on MacOS");
+	env = NULL;
+#else
 	env = GetJNIEnv();
+#endif
 
 	if (env != NULL and not bGraphicIsLoaded)
 	{

--- a/src/Norm/base/UserInterface.h
+++ b/src/Norm/base/UserInterface.h
@@ -300,7 +300,7 @@ public:
 
 	// Obtention de l'environnement Java JNI, utile pour toutes les methodes JNI
 	// (l'environnement est alloue a la premiere utilisation, et desalloue
-	// automatiquement des qu'il n'y a plus de UIObject en memoire
+	// automatiquement des qu'il n'y a plus de UIObject en memoire)
 	static JNIEnv* GetJNIEnv();
 
 	// Dechargement de la dll JVM si necessaire


### PR DESCRIPTION
In addition to the fix of the unit test I handled the [issue 32](https://github.com/KhiopsML/khiops/issues/32#issue-1781096435). A problem with the "jobs" option in the CMakePreset.

For this one the only way is to suppress this flag, there is no solution to add a max number of parallel level, it has to be an integer (there is an [open issue on cmake](https://gitlab.kitware.com/cmake/cmake/-/issues/23798)). In consequence, we have to add the `--parallel` flag to the `cmake --build` on the actions. The problematic issue is that on ours IDE, the build are in  serial. The solution to this is to add a `CMakeUserPresets` with the jobs  option.