### PR TITLE
Build macos conda package

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-2022"]
+        os: ["ubuntu-latest", "windows-2022","macos-latest"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -23,14 +23,13 @@ jobs:
         echo "ID=$ID" >> "$GITHUB_ENV"
         echo "VERSION_CODENAME=$VERSION_CODENAME" >> "$GITHUB_ENV"
        
-
     - name: Configure CMake
       run: cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DMPI=ON -DTESTING=OFF -DBUILD_JARS=ON
 
-    - name: Build
+    - name: Build Khiops executables
       run: cmake --build ${{github.workspace}}/build --parallel --target MODL MODL_Coclustering KhiopsNativeInterface
     
-    - name: Pack
+    - name: Build package with CPack
       run: cd ${{github.workspace}}/build && cpack -G DEB
     
     - name: Upload artifacts

--- a/.github/workflows/pack-macos.yml
+++ b/.github/workflows/pack-macos.yml
@@ -1,0 +1,32 @@
+name: Create macOS package
+  
+on:
+  workflow_dispatch:
+
+env:
+  PRESET_NAME: macos-clang-release
+
+jobs:
+  package-zip:
+    runs-on: macos-latest
+    
+    steps:
+    - name: Check out sources
+      uses: actions/checkout@v3
+
+    - name: Build Khiops executables
+      uses: ./.github/actions/build-khiops
+      with:
+        preset-name: ${{env.PRESET_NAME}}
+        targets: "MODL MODL_Coclustering KhiopsNativeInterface"
+        override-flags: -DBUILD_JARS=OFF -DTESTING=OFF
+     
+    - name: Build package with CPack
+      run: cd build/${{env.PRESET_NAME}} && cpack -G ZIP
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3.1.2
+      with:
+        name: macos
+        path: build/${{env.PRESET_NAME}}/packages/*.zip
+        if-no-files-found: error

--- a/.github/workflows/pack-rpm.yml
+++ b/.github/workflows/pack-rpm.yml
@@ -32,16 +32,11 @@ jobs:
         echo "MPI_SUFFIX=$MPI_SUFFIX" >> "$GITHUB_ENV"
         cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DTESTING=OFF -DBUILD_JARS=ON -DFEDORA=ON
 
-    - name: Build
+    - name: Build Khiops executables
       run: cmake --build build --parallel --target MODL${{ env.MPI_SUFFIX }} MODL_Coclustering KhiopsNativeInterface
     
-    - name: Pack
+    - name: Build package with CPack
       run: cd build && cpack -G RPM
-
-    - name: test
-      run: |
-        pwd
-        ls build
     
     - name: Upload artifacts
       uses: actions/upload-artifact@v3.1.2

--- a/packaging/conda/build.sh
+++ b/packaging/conda/build.sh
@@ -1,3 +1,16 @@
 # !/bin/bash
-cmake --preset linux-gcc-release -DBUILD_JARS=OFF -DTESTING=OFF
-cmake --build --preset linux-gcc-release --parallel --target MODL --target MODL_Coclustering
+
+# On macOS, we have to build with the compiler outside conda. With teh conda's clang the following error occurs:
+# ld: unsupported tapi file type '!tapi-tbd' in YAML file '/Applications/Xcode_14.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd' for architecture x86_64
+if [ "$(uname)" == "Darwin" ]
+then
+    cmake --preset macos-clang-release -DBUILD_JARS=OFF -DTESTING=OFF -DCMAKE_CXX_COMPILER=/usr/bin/clang++ 
+    cmake --build --preset macos-clang-release --parallel --target MODL MODL_Coclustering
+else
+    cmake --preset linux-gcc-release -DBUILD_JARS=OFF -DTESTING=OFF
+    cmake --build --preset linux-gcc-release --parallel --target MODL MODL_Coclustering
+fi
+
+
+
+

--- a/packaging/conda/install-khiops.sh
+++ b/packaging/conda/install-khiops.sh
@@ -3,7 +3,16 @@
 # Echo all output
 set -x
 
+
+# The binary location depends on the preset name used at the configure step (Cf. build.sh)
+if [ "$(uname)" == "Darwin" ]
+then
+    BUILD_DIR="macos-clang-release"
+else
+    BUILD_DIR="linux-gcc-release"
+fi
+
 # Copy the MODL binaries to the anaconda PREFIX path
 mkdir -p $PREFIX/bin
-cp build/linux-gcc-release/bin/MODL $PREFIX/bin
-cp build/linux-gcc-release/bin/MODL_Coclustering $PREFIX/bin
+cp build/$BUILD_DIR/bin/MODL $PREFIX/bin
+cp build/$BUILD_DIR/bin/MODL_Coclustering $PREFIX/bin

--- a/packaging/conda/install-khiops.sh
+++ b/packaging/conda/install-khiops.sh
@@ -3,7 +3,6 @@
 # Echo all output
 set -x
 
-
 # The binary location depends on the preset name used at the configure step (Cf. build.sh)
 if [ "$(uname)" == "Darwin" ]
 then

--- a/src/Learning/genum/CMakeLists.txt
+++ b/src/Learning/genum/CMakeLists.txt
@@ -1,7 +1,4 @@
 file(GLOB cppfiles ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 add_executable(genum ${cppfiles})
-
 set_khiops_options(genum)
-
 target_link_libraries(genum PUBLIC MHHistograms)
-set_khiops_options(genum)


### PR DESCRIPTION
Conda package is built but never tested.
I added a workflow for macOS packaging: It is a simple zip. The purpose is to make available the binaries for Khiops developers for tests. We can look further to `CPack` generators for macOS as `productbuild`, `FreeBSD` or `DragNDrop`. I'm not sure it's worth the effort: we will not distribute macOS installers.