### PR TITLE
Fix cmake error for Visual C++ 2022

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -49,7 +49,8 @@
             "Windows"
           ]
         }
-      }
+      },
+      "generator": "Visual Studio 17 2022"
     },
     {
       "name": "macos",


### PR DESCRIPTION
La correction se reduit a ajouter une ligne en fin de secton section "name": "windows", sous la ligne 52 du CMakePresets.json:
  "generator": "Visual Studio 17 2022"

Apparemment, l'auto-detection du compilateur ne marche plus depuis la version 17.6.5 de Visual C++ 2022

Attention, lors de l'installation de Visual C++ 2022, est sans doute nécessaire de verifier de cocher
  "Prise en charge de C++\CLI pour Build Tools"

Pour mémoire, voici ci dessous la liste des tentatives infructueuses prealables:
 - dans Visual C++, "Supprimer le cache et reconfigurer"
 - supression du repertoire build du repo git
 - supression du répertoire .vs du projet git
 - désinstallation complete de Visual C++ 2019 et 2022, puis reinstallation de Visual C++ 2022
 - relancer l'installeur Visual C++ 2022, avec option "Reparer"
 - installer sans oublier de cocher "Prise en charge de C++\CLI pour Build Tools"
   - il semble que cette option soit nécessaire, mais je n'ai pas vérifié qu'elle était indispensable
 - essai en positionnant directement kes variable d'environnement par vcvars64.bat
   - cela marche quand on lance la commande de CMake en dur dans un shell
   - comment forcer le lancement de ce script dans le repo local?
 - rechercher google de l'erreur "cl is not a full path and was not found in the PATH"
   - ajout du path de cl.exe dans la variable d'environnement PATH - nouvelle erreur The C++ compiler "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.36.32532\bin\Hostx64\x64\cl.exe" is not able to compile a simple test program. - tentative de corriger cette nouvelle erreur apres googling - nouvelle famille d'erreur
 - la piste de solution
   - https://stackoverflow.com/questions/35869564/cmake-on-windows
   - https://stackoverflow.com/questions/4101456/running-cmake-on-windows