### PR TITLE
Fix in KWFileSorter::SplitDatabase

### DIFF
--- a/src/Learning/KWDataUtils/KWFileSorter.cpp
+++ b/src/Learning/KWDataUtils/KWFileSorter.cpp
@@ -648,7 +648,7 @@ KWSortBuckets* KWFileSorter::SplitDatabase(int nChunkSizeMin, int nChunkSize, KW
 	sFileURI = bucket->GetChunkFileNames()->GetAt(0);
 
 	// Pour minimiser le nombre de redecoupage (appel recursif de Splitdatabase)
-	// On vise une taille inferieur a la taille max
+	// On vise une taille inferieure a la taille max
 	nConservativeChunkSize = (int)(nChunkSize * dDeWittRatio);
 	if (nConservativeChunkSize < nChunkSizeMin)
 		nConservativeChunkSize = nChunkSizeMin;
@@ -665,6 +665,8 @@ KWSortBuckets* KWFileSorter::SplitDatabase(int nChunkSizeMin, int nChunkSize, KW
 				    ((1 - 1 / dSkew) * (1 - 1 / dSkew) * dSkew) +
 				1000);
 	ensure((nSampleSize * 1.0) / lLineNumber > 0);
+	if (nSampleSize > lLineNumber)
+		nSampleSize = (int)lLineNumber;
 
 	if (bTrace)
 	{


### PR DESCRIPTION
Assertion triggered in `LearningTest\TestKhiops\CrashTests\MaxLineLength_sort `
The sample may be larger the line number.