### PR TITLE
Fix KNI crashes with java under linux

### DIFF
--- a/src/Learning/MODL/MODL.cpp
+++ b/src/Learning/MODL/MODL.cpp
@@ -8,6 +8,10 @@ int main(int argc, char** argv)
 {
 	MDKhiopsLearningProject learningProject;
 
+	// Activation de la gestion des signaux via des erreurs, pour afficher des messages d'erreur explicites
+	// A potentiellement commnter sur certian IDE lors des phases de debuggage
+	Global::ActivateSignalErrorManagement();
+
 	// Parametrage des logs memoires depuis les variables d'environnement, pris en compte dans KWLearningProject
 	//   KhiopsMemStatsLogFileName, KhiopsMemStatsLogFrequency, KhiopsMemStatsLogToCollect
 	// On ne tente d'ouvrir le fichier que si ces trois variables sont presentes et valides
@@ -17,10 +21,6 @@ int main(int argc, char** argv)
 	// FileService::SetIOStatsActive(true);
 	// MemoryStatsManager::OpenLogFile("D:\\temp\\KhiopsMemoryStats\\Test\\KhiopsMemoryStats.log", 10000,
 	// MemoryStatsManager::AllStats);
-
-	// Pour desactiver l'interception du signal "segmentation fault", pour permettre au debugger d'identifier le
-	// probleme
-	debug(signal(SIGSEGV, NULL));
 
 	// Parametrage de l'arret pour la memoire ou les interruptions utilisateurs
 	// MemSetAllocIndexExit(1674366);

--- a/src/Learning/MODL_Coclustering/MODL_Coclustering.cpp
+++ b/src/Learning/MODL_Coclustering/MODL_Coclustering.cpp
@@ -10,6 +10,10 @@ int main(int argc, char** argv)
 
 	// MemSetAllocIndexExit(1290133);
 
+	// Activation de la gestion des signaux via des erreurs, pour afficher des messages d'erreur explicites
+	// A potentiellement commnter sur certian IDE lors des phases de debuggage
+	Global::ActivateSignalErrorManagement();
+
 	// Lancement du projet
 	learningProject.Start(argc, argv);
 

--- a/src/Norm/base/Ermgt.h
+++ b/src/Norm/base/Ermgt.h
@@ -133,13 +133,16 @@ public:
 	// Est-ce qu'il y a eu au moins une erreur
 	static boolean IsAtLeastOneError();
 
+	// Activation de la gestion des signaux via des erreurs, pour afficher des messages d'erreur explicites
+	// A appeler en debut du main des executable.
+	// Attention, comportement indefini dans les environnements multi-thread.
+	// A ne pas appeler pour une DLL (par exemple, crash observe depuis Java sous linux)
+	static void ActivateSignalErrorManagement();
+	static boolean IsSignalErrorManagementActivated();
+
 	///////////////////////////////////////////////////////////
 	///// Implementation
 protected:
-	// Constructeur, qui au premier appel positionne les handlers de gestion des signaux
-	Global();
-	~Global();
-
 	// Indique s'il faut ignorer le controle de flow des erreurs, au moment de l'affichage
 	// A la difference de IgnoreErrorFlow qui n'effectue qu'un test, on peut exploiter un contexte
 	// d'usage pour l'affichage pour controler finement les erreurs a afficher effectivement
@@ -186,6 +189,9 @@ protected:
 
 	// Methode pour ignorer le controle de flow des erreurs
 	static ErrorFlowIgnoreFunction fErrorFlowIgnoreFunction;
+
+	// Mode d'activation de la gestion des erreurs pour les signaux
+	static boolean bIsSignalErrorManagementActivated;
 };
 
 // Prototype d'une fonction d'affichage d'une erreur a l'utilisateur


### PR DESCRIPTION
Les signaux sont delicats a utiliser:
- https://en.cppreference.com/w/cpp/utility/program/signal
  - nombreuses conditions d'usage
- https://learn.microsoft.com/fr-fr/cpp/c-runtime-library/reference/signal?view=msvc-170
  - N'emettez pas de routines d'E/S de bas niveau ou STDIO.H d'E/S (par exemple, printf ou fread).
  - N'appelez pas de routines de tas ou de routine qui utilise les routines de tas (par exemple, malloc, _strdupou _putenv).
  - ...
- https://wiki.sei.cmu.edu/confluence/display/c/CON37-C.+Do+not+call+signal%28%29+in+a+multithreaded+program
  - Do not call signal() in a multithreaded program

Impact dans classe Global
- SignalHandler: re-écriture plus basique, pour ne pas emettre une erreur fatale, qui passe par l'allocateur
- ActivateSignalErrorManagement: activation explicite de la gestion des signaux via des erreurs, a appelr dans les exe, mais pas dans les dll
  - message potentiellement utiles dans els exe, et apparement sans risque
  - appele dans le main de MODL et MODL_Coclustering
  - ne pas appeler dans les dll