### PR TITLE
Initialize default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/generic-issue-template.md
@@ -1,0 +1,23 @@
+---
+name: Generic issue template
+about: Should be used for all issues of this repository.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+#### Description
+_What, Why_
+
+#### Questions/Ideas
+- _A potential solution_
+  - _A potential solution detail_
+- _A potential problem_
+- _Something I still don't understand_
+
+### Context
+- Khiops version
+- Log file (use `khiops -e log.txt`)
+- Scenario file (use `khiops -o scenario._kh`)
+- OS description (use `khiops -s`)


### PR DESCRIPTION
Initialisation d'un template pour les issues. J'ai repris celui de [khiops-python](https://github.com/KhiopsML/khiops-python/blob/dev/.github/ISSUE_TEMPLATE/generic-issue-template.md) et j'ai ajouté la section sur le contexte.  C'est un brouillon pour discussion. 