### PR TITLE
Fix minor mac compilation issue

### DIFF
--- a/src/Norm/base/Portability.cpp
+++ b/src/Norm/base/Portability.cpp
@@ -526,8 +526,8 @@ int OpenApplication(const char* sApplicationExeName, const char* sApplicationLab
 
 #else
 // Implementation du lancement d'executable avec erreur pour les autres OS
-int OpenApplication(const char* sApplicationExeName, const char* sApplicationLabel, const char* sExtension,
-		    const char* sFileToOpen, char* sErrorMessage)
+int OpenApplication(const char* sApplicationExeName, const char* sApplicationLabel, const char* sFileToOpen,
+		    char* sErrorMessage)
 {
 	int ok;
 


### PR DESCRIPTION
The "OpenApplication" function in the "Portability.cpp" file had a parameter extra in the "else" "ifdef" branch and so it wasn't found by the linker.