### PR TITLE
Fix MODL_Coclustering double size in windows

### DIFF
--- a/src/Learning/MODL/CMakeLists.txt
+++ b/src/Learning/MODL/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB cppfiles ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
-# MODL executable On Fedora, binaries built with mpi must be suffixed by _mpich (in stored ${MPI_SUFFIX})
+# on fedora, binaries built with mpi must ended by _mpich suffix
 add_executable(MODL${MPI_SUFFIX} ${cppfiles} MODL.rc)
 target_link_libraries(MODL${MPI_SUFFIX} PUBLIC DTForest KMDRRuleLibrary KWLearningProblem)
 set_khiops_options(MODL${MPI_SUFFIX})
@@ -8,7 +8,6 @@ if(MPI)
   target_link_libraries(MODL${MPI_SUFFIX} PUBLIC PLMPI)
 endif()
 
-# MODL_SO (shared library)
 add_library(MODL_SO SHARED ${cppfiles})
 target_link_libraries(MODL_SO PUBLIC DTForest KMDRRuleLibrary KWLearningProblem)
 if(MPI)

--- a/src/Learning/MODL_Coclustering/CMakeLists.txt
+++ b/src/Learning/MODL_Coclustering/CMakeLists.txt
@@ -3,12 +3,7 @@ file(GLOB cppfiles ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 # on fedora, binaries built with mpi must ended by _mpich suffix
 add_executable(MODL_Coclustering${MPI_SUFFIX} ${cppfiles} MODL_Coclustering.rc)
 set_khiops_options(MODL_Coclustering${MPI_SUFFIX})
-
 target_link_libraries(MODL_Coclustering${MPI_SUFFIX} PUBLIC KMDRRuleLibrary KWLearningProblem)
-
-if(MSVC)
-  target_link_options(MODL_Coclustering${MPI_SUFFIX} PUBLIC "/INCREMENTAL")
-endif()
 
 add_library(MODL_Coclustering_SO SHARED ${cppfiles})
 target_link_libraries(MODL_Coclustering_SO PUBLIC KMDRRuleLibrary KWLearningProblem)


### PR DESCRIPTION
The MODL_Coclustering.exe executable in windows had doubled in size because the MSVC link option `/INCREMENTAL` was activated.

This wasn't the case for the original build with VS projects.