### PR TITLE
Fix bug in regex within multi-table-dictionary

### DIFF
--- a/src/Learning/KWDRRuleLibrary/KWDRString.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRString.cpp
@@ -968,6 +968,23 @@ boolean KWDRRegex::CheckCompleteness(const KWClass* kwcOwnerClass) const
 	return bOk;
 }
 
+void KWDRRegex::Compile(KWClass* kwcOwnerClass)
+{
+	int nRegexOperandIndex;
+
+	// Appel de la methode ancetre
+	KWDerivationRule::Compile(kwcOwnerClass);
+
+	// Acces a l'index de l'operande de regex: 2, sauf pour pour la regle Match
+	nRegexOperandIndex = 2;
+	if (GetOperandNumber() <= nRegexOperandIndex)
+		nRegexOperandIndex = GetOperandNumber() - 1;
+
+	// On ne verifie pas l'expression si elle a deja ete validee
+	if (not regEx.IsValid() or regEx.GetRegex() != GetOperandAt(nRegexOperandIndex)->GetSymbolConstant().GetValue())
+		regEx.Initialize(GetOperandAt(nRegexOperandIndex)->GetSymbolConstant().GetValue(), this);
+}
+
 //////////////////////////////////////////////////////////////////////////////////////
 
 KWDRRegexMatch::KWDRRegexMatch()

--- a/src/Learning/KWDRRuleLibrary/KWDRString.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRString.h
@@ -336,6 +336,9 @@ public:
 	// Verification qu'une regle est completement renseignee et compilable
 	boolean CheckCompleteness(const KWClass* kwcOwnerClass) const override;
 
+	// Compilation pour optimiser la gestion du format
+	void Compile(KWClass* kwcOwnerClass) override;
+
 	///////////////////////////////////////////
 	///// Implementation
 protected:


### PR DESCRIPTION
Probleme:
- les regex ne fonctionne pas dans certains cas (en release, dans le cas multi-table)
- du a une compilation des regex uniquement dans la methode CheckCompletness

Correction:
- compilation des regex dans la methode dediee KWDRRegex::Compile

Jeu de test dedie: LearningTest\TestKhiops\Rules\BugMultiTableRegexRules