### PR TITLE
Update copyright year from 2023 to 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The Clear BSD License
 
-Copyright (c) 2023 Orange S.A.
+Copyright (c) 2024 Orange S.A.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/packaging/common/khiops/README.txt
+++ b/packaging/common/khiops/README.txt
@@ -1,6 +1,6 @@
 Khiops 10.0
 ===========
-  (c) 2023 Orange - All rights reserved.
+  (c) 2024 Orange - All rights reserved.
   https://khiops.org
 
 Khiops is a fully automatic tool for mining large multi-table databases,

--- a/packaging/windows/nsis/khiops.nsi
+++ b/packaging/windows/nsis/khiops.nsi
@@ -146,7 +146,7 @@ Page custom RequirementsPageShow RequirementsPageLeave
 VIProductVersion "${KHIOPS_REDUCED_VERSION}.0"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "Khiops"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "Orange"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright (c) 2023 Orange"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright (c) 2024 Orange"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "Khiops Installer"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${KHIOPS_VERSION}"
 

--- a/src/Learning/DTForest/DTAttributeSelection.cpp
+++ b/src/Learning/DTForest/DTAttributeSelection.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTAttributeSelection.h
+++ b/src/Learning/DTForest/DTAttributeSelection.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTBaseLoader.cpp
+++ b/src/Learning/DTForest/DTBaseLoader.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTBaseLoader.h
+++ b/src/Learning/DTForest/DTBaseLoader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTBaseLoaderSplitter.cpp
+++ b/src/Learning/DTForest/DTBaseLoaderSplitter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTBaseLoaderSplitter.h
+++ b/src/Learning/DTForest/DTBaseLoaderSplitter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTConfig.cpp
+++ b/src/Learning/DTForest/DTConfig.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTConfig.h
+++ b/src/Learning/DTForest/DTConfig.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTCreationReport.cpp
+++ b/src/Learning/DTForest/DTCreationReport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTCreationReport.h
+++ b/src/Learning/DTForest/DTCreationReport.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionBinaryTreeCost.cpp
+++ b/src/Learning/DTForest/DTDecisionBinaryTreeCost.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionBinaryTreeCost.h
+++ b/src/Learning/DTForest/DTDecisionBinaryTreeCost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTree.cpp
+++ b/src/Learning/DTForest/DTDecisionTree.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTree.h
+++ b/src/Learning/DTForest/DTDecisionTree.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeCost.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeCost.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeCost.h
+++ b/src/Learning/DTForest/DTDecisionTreeCost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeCreationTask.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeCreationTask.h
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeCreationTaskSequential.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTaskSequential.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeCreationTaskSequential.h
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTaskSequential.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeCreationTaskSequentialView.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTaskSequentialView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeCreationTaskSequentialView.h
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTaskSequentialView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeCreationTaskView.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTaskView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeCreationTaskView.h
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTaskView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeDatabaseObject.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeDatabaseObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeDatabaseObject.h
+++ b/src/Learning/DTForest/DTDecisionTreeDatabaseObject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeGlobalCost.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeGlobalCost.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeGlobalCost.h
+++ b/src/Learning/DTForest/DTDecisionTreeGlobalCost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeNode.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeNode.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeNode.h
+++ b/src/Learning/DTForest/DTDecisionTreeNode.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeParameter.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeParameter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeParameter.h
+++ b/src/Learning/DTForest/DTDecisionTreeParameter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeParameterView.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeParameterView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeParameterView.h
+++ b/src/Learning/DTForest/DTDecisionTreeParameterView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeRecursiveCost.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeRecursiveCost.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeRecursiveCost.h
+++ b/src/Learning/DTForest/DTDecisionTreeRecursiveCost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeSpec.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDecisionTreeSpec.h
+++ b/src/Learning/DTForest/DTDecisionTreeSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDiscretizerMODL.cpp
+++ b/src/Learning/DTForest/DTDiscretizerMODL.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTDiscretizerMODL.h
+++ b/src/Learning/DTForest/DTDiscretizerMODL.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTForestAttributeSelection.cpp
+++ b/src/Learning/DTForest/DTForestAttributeSelection.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTForestAttributeSelection.h
+++ b/src/Learning/DTForest/DTForestAttributeSelection.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTForestParameter.cpp
+++ b/src/Learning/DTForest/DTForestParameter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTForestParameter.h
+++ b/src/Learning/DTForest/DTForestParameter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTForestParameterView.cpp
+++ b/src/Learning/DTForest/DTForestParameterView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTForestParameterView.h
+++ b/src/Learning/DTForest/DTForestParameterView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTGlobalTag.cpp
+++ b/src/Learning/DTForest/DTGlobalTag.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTGlobalTag.h
+++ b/src/Learning/DTForest/DTGlobalTag.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTGrouperMODL.cpp
+++ b/src/Learning/DTForest/DTGrouperMODL.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTGrouperMODL.h
+++ b/src/Learning/DTForest/DTGrouperMODL.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTGrouperMODLBasic.cpp
+++ b/src/Learning/DTForest/DTGrouperMODLBasic.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTGrouperMODLInternal.cpp
+++ b/src/Learning/DTForest/DTGrouperMODLInternal.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTGrouperMODLInternal.h
+++ b/src/Learning/DTForest/DTGrouperMODLInternal.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTGrouperMODLOptimization.cpp
+++ b/src/Learning/DTForest/DTGrouperMODLOptimization.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTStat.cpp
+++ b/src/Learning/DTForest/DTStat.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTStat.h
+++ b/src/Learning/DTForest/DTStat.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTUnivariatePartitionCost.cpp
+++ b/src/Learning/DTForest/DTUnivariatePartitionCost.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/DTForest/DTUnivariatePartitionCost.h
+++ b/src/Learning/DTForest/DTUnivariatePartitionCost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDClassBuilder.cpp
+++ b/src/Learning/KDDomainKnowledge/KDClassBuilder.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDClassBuilder.h
+++ b/src/Learning/KDDomainKnowledge/KDClassBuilder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDClassCompliantRules.cpp
+++ b/src/Learning/KDDomainKnowledge/KDClassCompliantRules.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDClassCompliantRules.h
+++ b/src/Learning/KDDomainKnowledge/KDClassCompliantRules.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDConstructedRule.cpp
+++ b/src/Learning/KDDomainKnowledge/KDConstructedRule.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDConstructedRule.h
+++ b/src/Learning/KDDomainKnowledge/KDConstructedRule.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDConstructionDomain.cpp
+++ b/src/Learning/KDDomainKnowledge/KDConstructionDomain.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDConstructionDomain.h
+++ b/src/Learning/KDDomainKnowledge/KDConstructionDomain.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDConstructionRule.cpp
+++ b/src/Learning/KDDomainKnowledge/KDConstructionRule.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDConstructionRule.h
+++ b/src/Learning/KDDomainKnowledge/KDConstructionRule.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDDomainConstraint.cpp
+++ b/src/Learning/KDDomainKnowledge/KDDomainConstraint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDDomainConstraint.h
+++ b/src/Learning/KDDomainKnowledge/KDDomainConstraint.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDEntity.cpp
+++ b/src/Learning/KDDomainKnowledge/KDEntity.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDEntity.h
+++ b/src/Learning/KDDomainKnowledge/KDEntity.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDFeatureConstruction.cpp
+++ b/src/Learning/KDDomainKnowledge/KDFeatureConstruction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDFeatureConstruction.h
+++ b/src/Learning/KDDomainKnowledge/KDFeatureConstruction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDMultiTableFeatureConstruction.cpp
+++ b/src/Learning/KDDomainKnowledge/KDMultiTableFeatureConstruction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDMultiTableFeatureConstruction.h
+++ b/src/Learning/KDDomainKnowledge/KDMultiTableFeatureConstruction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDMultinomialSampleGenerator.cpp
+++ b/src/Learning/KDDomainKnowledge/KDMultinomialSampleGenerator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDMultinomialSampleGenerator.h
+++ b/src/Learning/KDDomainKnowledge/KDMultinomialSampleGenerator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDSelectionOperandAnalyser.cpp
+++ b/src/Learning/KDDomainKnowledge/KDSelectionOperandAnalyser.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDSelectionOperandAnalyser.h
+++ b/src/Learning/KDDomainKnowledge/KDSelectionOperandAnalyser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDSelectionOperandDataSampler.cpp
+++ b/src/Learning/KDDomainKnowledge/KDSelectionOperandDataSampler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDSelectionOperandDataSampler.h
+++ b/src/Learning/KDDomainKnowledge/KDSelectionOperandDataSampler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDSelectionOperandSamplingTask.cpp
+++ b/src/Learning/KDDomainKnowledge/KDSelectionOperandSamplingTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDSelectionOperandSamplingTask.h
+++ b/src/Learning/KDDomainKnowledge/KDSelectionOperandSamplingTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDTextFeatureConstruction.cpp
+++ b/src/Learning/KDDomainKnowledge/KDTextFeatureConstruction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDTextFeatureConstruction.h
+++ b/src/Learning/KDDomainKnowledge/KDTextFeatureConstruction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDTextFeatureSpec.cpp
+++ b/src/Learning/KDDomainKnowledge/KDTextFeatureSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDTextFeatureSpec.h
+++ b/src/Learning/KDDomainKnowledge/KDTextFeatureSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.cpp
+++ b/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.h
+++ b/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDTokenFrequency.cpp
+++ b/src/Learning/KDDomainKnowledge/KDTokenFrequency.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KDDomainKnowledge/KDTokenFrequency.h
+++ b/src/Learning/KDDomainKnowledge/KDTokenFrequency.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIDRPredictor.cpp
+++ b/src/Learning/KIInterpretation/KIDRPredictor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIDRPredictor.h
+++ b/src/Learning/KIInterpretation/KIDRPredictor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIDRRegisterAllRules.cpp
+++ b/src/Learning/KIInterpretation/KIDRRegisterAllRules.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIDRRegisterAllRules.h
+++ b/src/Learning/KIInterpretation/KIDRRegisterAllRules.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIHowParameterView.cpp
+++ b/src/Learning/KIInterpretation/KIHowParameterView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIHowParameterView.h
+++ b/src/Learning/KIInterpretation/KIHowParameterView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIInterpretationDictionary.cpp
+++ b/src/Learning/KIInterpretation/KIInterpretationDictionary.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIInterpretationDictionary.h
+++ b/src/Learning/KIInterpretation/KIInterpretationDictionary.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIInterpretationSpec.cpp
+++ b/src/Learning/KIInterpretation/KIInterpretationSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIInterpretationSpec.h
+++ b/src/Learning/KIInterpretation/KIInterpretationSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIInterpretationSpecView.cpp
+++ b/src/Learning/KIInterpretation/KIInterpretationSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIInterpretationSpecView.h
+++ b/src/Learning/KIInterpretation/KIInterpretationSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KILeverVariablesSpecView.cpp
+++ b/src/Learning/KIInterpretation/KILeverVariablesSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KILeverVariablesSpecView.h
+++ b/src/Learning/KIInterpretation/KILeverVariablesSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIPredictorInterpretationView.cpp
+++ b/src/Learning/KIInterpretation/KIPredictorInterpretationView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIPredictorInterpretationView.h
+++ b/src/Learning/KIInterpretation/KIPredictorInterpretationView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIWhyParameterView.cpp
+++ b/src/Learning/KIInterpretation/KIWhyParameterView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KIInterpretation/KIWhyParameterView.h
+++ b/src/Learning/KIInterpretation/KIWhyParameterView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KMDRRuleLibrary/KMDRClassifier.cpp
+++ b/src/Learning/KMDRRuleLibrary/KMDRClassifier.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KMDRRuleLibrary/KMDRClassifier.h
+++ b/src/Learning/KMDRRuleLibrary/KMDRClassifier.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KMDRRuleLibrary/KMDRLocalModelChooser.cpp
+++ b/src/Learning/KMDRRuleLibrary/KMDRLocalModelChooser.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KMDRRuleLibrary/KMDRLocalModelChooser.h
+++ b/src/Learning/KMDRRuleLibrary/KMDRLocalModelChooser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KMDRRuleLibrary/KMDRRegisterAllRules.cpp
+++ b/src/Learning/KMDRRuleLibrary/KMDRRegisterAllRules.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KMDRRuleLibrary/KMDRRegisterAllRules.h
+++ b/src/Learning/KMDRRuleLibrary/KMDRRegisterAllRules.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNIDatabaseTransferView.cpp
+++ b/src/Learning/KNITransfer/KNIDatabaseTransferView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNIDatabaseTransferView.h
+++ b/src/Learning/KNITransfer/KNIDatabaseTransferView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNIRecodeFile.cpp
+++ b/src/Learning/KNITransfer/KNIRecodeFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNIRecodeFile.h
+++ b/src/Learning/KNITransfer/KNIRecodeFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNIRecodeMTFiles.cpp
+++ b/src/Learning/KNITransfer/KNIRecodeMTFiles.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNIRecodeMTFiles.h
+++ b/src/Learning/KNITransfer/KNIRecodeMTFiles.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNITransfer.cpp
+++ b/src/Learning/KNITransfer/KNITransfer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNITransfer.h
+++ b/src/Learning/KNITransfer/KNITransfer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNITransferProblem.cpp
+++ b/src/Learning/KNITransfer/KNITransferProblem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNITransferProblem.h
+++ b/src/Learning/KNITransfer/KNITransferProblem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNITransferProblemView.cpp
+++ b/src/Learning/KNITransfer/KNITransferProblemView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNITransferProblemView.h
+++ b/src/Learning/KNITransfer/KNITransferProblemView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNITransferProject.cpp
+++ b/src/Learning/KNITransfer/KNITransferProject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KNITransfer/KNITransferProject.h
+++ b/src/Learning/KNITransfer/KNITransferProject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRAll.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRAll.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRAll.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRAll.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRCompare.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRCompare.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRCompare.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRCompare.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRDateTime.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRDateTime.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRDateTime.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRDateTime.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRHashMap.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRHashMap.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRHashMap.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRHashMap.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRLogical.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRLogical.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRLogical.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRLogical.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRMath.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRMath.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRMath.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRMath.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRMultiTable.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRMultiTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRMultiTable.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRMultiTable.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRString.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRString.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRString.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRString.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRStringEncrypt.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRStringEncrypt.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRText.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRText.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRText.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRText.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRTextList.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRTextList.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRTextList.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRTextList.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRTextualAnalysis.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRTextualAnalysis.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRTextualAnalysis.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRTextualAnalysis.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRTextualAnalysisPROTO.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRTextualAnalysisPROTO.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRTextualAnalysisPROTO.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRTextualAnalysisPROTO.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRVector.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRVector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDRRuleLibrary/KWDRVector.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRVector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/JSONFile.cpp
+++ b/src/Learning/KWData/JSONFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/JSONFile.h
+++ b/src/Learning/KWData/JSONFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/JSONTokenizer.cpp
+++ b/src/Learning/KWData/JSONTokenizer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/JSONTokenizer.h
+++ b/src/Learning/KWData/JSONTokenizer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWAttribute.cpp
+++ b/src/Learning/KWData/KWAttribute.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWAttribute.h
+++ b/src/Learning/KWData/KWAttribute.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWAttributeBlock.cpp
+++ b/src/Learning/KWData/KWAttributeBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWAttributeBlock.h
+++ b/src/Learning/KWData/KWAttributeBlock.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWAttributeName.cpp
+++ b/src/Learning/KWData/KWAttributeName.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWAttributeName.h
+++ b/src/Learning/KWData/KWAttributeName.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWAttributePairName.cpp
+++ b/src/Learning/KWData/KWAttributePairName.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWAttributePairName.h
+++ b/src/Learning/KWData/KWAttributePairName.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWCDUniqueString.cpp
+++ b/src/Learning/KWData/KWCDUniqueString.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWCDUniqueString.h
+++ b/src/Learning/KWData/KWCDUniqueString.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWCYac.cpp
+++ b/src/Learning/KWData/KWCYac.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWCharFrequencyVector.cpp
+++ b/src/Learning/KWData/KWCharFrequencyVector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWCharFrequencyVector.h
+++ b/src/Learning/KWData/KWCharFrequencyVector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWClass.cpp
+++ b/src/Learning/KWData/KWClass.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWClassDomain.cpp
+++ b/src/Learning/KWData/KWClassDomain.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWClassDomain.h
+++ b/src/Learning/KWData/KWClassDomain.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWContinuous.cpp
+++ b/src/Learning/KWData/KWContinuous.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWContinuous.h
+++ b/src/Learning/KWData/KWContinuous.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDRRandom.cpp
+++ b/src/Learning/KWData/KWDRRandom.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDRRandom.h
+++ b/src/Learning/KWData/KWDRRandom.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDRReference.cpp
+++ b/src/Learning/KWData/KWDRReference.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDRReference.h
+++ b/src/Learning/KWData/KWDRReference.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDRStandard.cpp
+++ b/src/Learning/KWData/KWDRStandard.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDRStandard.h
+++ b/src/Learning/KWData/KWDRStandard.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDataItem.cpp
+++ b/src/Learning/KWData/KWDataItem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDataItem.h
+++ b/src/Learning/KWData/KWDataItem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDataTableDriver.cpp
+++ b/src/Learning/KWData/KWDataTableDriver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDataTableDriver.h
+++ b/src/Learning/KWData/KWDataTableDriver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDataTableDriverTextFile.cpp
+++ b/src/Learning/KWData/KWDataTableDriverTextFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDataTableDriverTextFile.h
+++ b/src/Learning/KWData/KWDataTableDriverTextFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDatabase.h
+++ b/src/Learning/KWData/KWDatabase.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDatabaseFormatDetector.cpp
+++ b/src/Learning/KWData/KWDatabaseFormatDetector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDatabaseFormatDetector.h
+++ b/src/Learning/KWData/KWDatabaseFormatDetector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDatabaseMemoryGuard.cpp
+++ b/src/Learning/KWData/KWDatabaseMemoryGuard.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDatabaseMemoryGuard.h
+++ b/src/Learning/KWData/KWDatabaseMemoryGuard.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDate.cpp
+++ b/src/Learning/KWData/KWDate.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDate.h
+++ b/src/Learning/KWData/KWDate.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDerivationRule.cpp
+++ b/src/Learning/KWData/KWDerivationRule.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDerivationRule.h
+++ b/src/Learning/KWData/KWDerivationRule.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWDerivationRuleOperand.cpp
+++ b/src/Learning/KWData/KWDerivationRuleOperand.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWIndexedKeyBlock.cpp
+++ b/src/Learning/KWData/KWIndexedKeyBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWIndexedKeyBlock.h
+++ b/src/Learning/KWData/KWIndexedKeyBlock.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWLoadIndex.cpp
+++ b/src/Learning/KWData/KWLoadIndex.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWLoadIndex.h
+++ b/src/Learning/KWData/KWLoadIndex.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWMTDatabase.h
+++ b/src/Learning/KWData/KWMTDatabase.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWMTDatabaseMapping.cpp
+++ b/src/Learning/KWData/KWMTDatabaseMapping.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWMTDatabaseMapping.h
+++ b/src/Learning/KWData/KWMTDatabaseMapping.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWMTDatabaseTextFile.cpp
+++ b/src/Learning/KWData/KWMTDatabaseTextFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWMTDatabaseTextFile.h
+++ b/src/Learning/KWData/KWMTDatabaseTextFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWMetaData.cpp
+++ b/src/Learning/KWData/KWMetaData.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWMetaData.h
+++ b/src/Learning/KWData/KWMetaData.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWObject.cpp
+++ b/src/Learning/KWData/KWObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWObject.h
+++ b/src/Learning/KWData/KWObject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWObjectKey.cpp
+++ b/src/Learning/KWData/KWObjectKey.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWObjectKey.h
+++ b/src/Learning/KWData/KWObjectKey.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWSTDatabase.cpp
+++ b/src/Learning/KWData/KWSTDatabase.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWSTDatabase.h
+++ b/src/Learning/KWData/KWSTDatabase.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWSTDatabaseTextFile.cpp
+++ b/src/Learning/KWData/KWSTDatabaseTextFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWSTDatabaseTextFile.h
+++ b/src/Learning/KWData/KWSTDatabaseTextFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWSortableIndex.cpp
+++ b/src/Learning/KWData/KWSortableIndex.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWSortableIndex.h
+++ b/src/Learning/KWData/KWSortableIndex.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWStructureRule.cpp
+++ b/src/Learning/KWData/KWStructureRule.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWStructureRule.h
+++ b/src/Learning/KWData/KWStructureRule.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWSymbol.cpp
+++ b/src/Learning/KWData/KWSymbol.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWSymbol.h
+++ b/src/Learning/KWData/KWSymbol.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWTime.cpp
+++ b/src/Learning/KWData/KWTime.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWTime.h
+++ b/src/Learning/KWData/KWTime.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWTimestamp.cpp
+++ b/src/Learning/KWData/KWTimestamp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWTimestamp.h
+++ b/src/Learning/KWData/KWTimestamp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWTimestampTZ.cpp
+++ b/src/Learning/KWData/KWTimestampTZ.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWTimestampTZ.h
+++ b/src/Learning/KWData/KWTimestampTZ.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWType.cpp
+++ b/src/Learning/KWData/KWType.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWType.h
+++ b/src/Learning/KWData/KWType.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWTypeAutomaticRecognition.cpp
+++ b/src/Learning/KWData/KWTypeAutomaticRecognition.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWTypeAutomaticRecognition.h
+++ b/src/Learning/KWData/KWTypeAutomaticRecognition.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWValueBlock.cpp
+++ b/src/Learning/KWData/KWValueBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWValueBlock.h
+++ b/src/Learning/KWData/KWValueBlock.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWValueDictionary.cpp
+++ b/src/Learning/KWData/KWValueDictionary.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWValueDictionary.h
+++ b/src/Learning/KWData/KWValueDictionary.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWValueSparseVector.cpp
+++ b/src/Learning/KWData/KWValueSparseVector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWData/KWValueSparseVector.h
+++ b/src/Learning/KWData/KWValueSparseVector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KDDataPreparationAttributeCreationTask.cpp
+++ b/src/Learning/KWDataPreparation/KDDataPreparationAttributeCreationTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KDDataPreparationAttributeCreationTask.h
+++ b/src/Learning/KWDataPreparation/KDDataPreparationAttributeCreationTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWAttributePairsSpec.cpp
+++ b/src/Learning/KWDataPreparation/KWAttributePairsSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWAttributePairsSpec.h
+++ b/src/Learning/KWDataPreparation/KWAttributePairsSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWAttributeStats.cpp
+++ b/src/Learning/KWDataPreparation/KWAttributeStats.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWAttributeStats.h
+++ b/src/Learning/KWDataPreparation/KWAttributeStats.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWAttributeSubsetStats.cpp
+++ b/src/Learning/KWDataPreparation/KWAttributeSubsetStats.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWAttributeSubsetStats.h
+++ b/src/Learning/KWDataPreparation/KWAttributeSubsetStats.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWClassStats.cpp
+++ b/src/Learning/KWDataPreparation/KWClassStats.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWClassStats.h
+++ b/src/Learning/KWDataPreparation/KWClassStats.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDGMPartMergeAction.cpp
+++ b/src/Learning/KWDataPreparation/KWDGMPartMergeAction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDGMPartMergeAction.h
+++ b/src/Learning/KWDataPreparation/KWDGMPartMergeAction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRDataGrid.cpp
+++ b/src/Learning/KWDataPreparation/KWDRDataGrid.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRDataGrid.h
+++ b/src/Learning/KWDataPreparation/KWDRDataGrid.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRDataGridBlock.cpp
+++ b/src/Learning/KWDataPreparation/KWDRDataGridBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRDataGridBlock.h
+++ b/src/Learning/KWDataPreparation/KWDRDataGridBlock.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRDataGridDeployment.cpp
+++ b/src/Learning/KWDataPreparation/KWDRDataGridDeployment.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRDataGridDeployment.h
+++ b/src/Learning/KWDataPreparation/KWDRDataGridDeployment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRPreprocessing.cpp
+++ b/src/Learning/KWDataPreparation/KWDRPreprocessing.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRPreprocessing.h
+++ b/src/Learning/KWDataPreparation/KWDRPreprocessing.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRTableBlock.cpp
+++ b/src/Learning/KWDataPreparation/KWDRTableBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRTableBlock.h
+++ b/src/Learning/KWDataPreparation/KWDRTableBlock.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRTablePartition.cpp
+++ b/src/Learning/KWDataPreparation/KWDRTablePartition.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDRTablePartition.h
+++ b/src/Learning/KWDataPreparation/KWDRTablePartition.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGrid.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGrid.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGrid.h
+++ b/src/Learning/KWDataPreparation/KWDataGrid.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridCosts.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridCosts.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridCosts.h
+++ b/src/Learning/KWDataPreparation/KWDataGridCosts.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridDeployment.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridDeployment.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridDeployment.h
+++ b/src/Learning/KWDataPreparation/KWDataGridDeployment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridManager.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridManager.h
+++ b/src/Learning/KWDataPreparation/KWDataGridManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridMerger.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridMerger.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridMerger.h
+++ b/src/Learning/KWDataPreparation/KWDataGridMerger.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridOptimizer.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridOptimizer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridOptimizer.h
+++ b/src/Learning/KWDataPreparation/KWDataGridOptimizer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridOptimizerParameters.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridOptimizerParameters.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridOptimizerParameters.h
+++ b/src/Learning/KWDataPreparation/KWDataGridOptimizerParameters.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridPostOptimizer.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridPostOptimizer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridPostOptimizer.h
+++ b/src/Learning/KWDataPreparation/KWDataGridPostOptimizer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridStats.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridStats.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataGridStats.h
+++ b/src/Learning/KWDataPreparation/KWDataGridStats.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataPreparationBivariateTask.cpp
+++ b/src/Learning/KWDataPreparation/KWDataPreparationBivariateTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataPreparationBivariateTask.h
+++ b/src/Learning/KWDataPreparation/KWDataPreparationBivariateTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataPreparationTask.cpp
+++ b/src/Learning/KWDataPreparation/KWDataPreparationTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataPreparationTask.h
+++ b/src/Learning/KWDataPreparation/KWDataPreparationTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataPreparationUnivariateTask.cpp
+++ b/src/Learning/KWDataPreparation/KWDataPreparationUnivariateTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDataPreparationUnivariateTask.h
+++ b/src/Learning/KWDataPreparation/KWDataPreparationUnivariateTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDescriptiveStats.cpp
+++ b/src/Learning/KWDataPreparation/KWDescriptiveStats.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDescriptiveStats.h
+++ b/src/Learning/KWDataPreparation/KWDescriptiveStats.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizer.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizer.h
+++ b/src/Learning/KWDataPreparation/KWDiscretizer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizerMODL.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizerMODL.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizerMODL.h
+++ b/src/Learning/KWDataPreparation/KWDiscretizerMODL.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizerMODLLine.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizerMODLLine.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizerMODLLine.h
+++ b/src/Learning/KWDataPreparation/KWDiscretizerMODLLine.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizerMODLOptimization.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizerMODLOptimization.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizerSpec.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizerSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizerSpec.h
+++ b/src/Learning/KWDataPreparation/KWDiscretizerSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizerUnsupervised.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizerUnsupervised.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWDiscretizerUnsupervised.h
+++ b/src/Learning/KWDataPreparation/KWDiscretizerUnsupervised.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWFrequencyVector.cpp
+++ b/src/Learning/KWDataPreparation/KWFrequencyVector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWFrequencyVector.h
+++ b/src/Learning/KWDataPreparation/KWFrequencyVector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWGrouper.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWGrouper.h
+++ b/src/Learning/KWDataPreparation/KWGrouper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWGrouperMODL.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperMODL.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWGrouperMODL.h
+++ b/src/Learning/KWDataPreparation/KWGrouperMODL.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWGrouperMODLBasic.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperMODLBasic.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWGrouperMODLInternal.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperMODLInternal.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWGrouperMODLInternal.h
+++ b/src/Learning/KWDataPreparation/KWGrouperMODLInternal.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWGrouperMODLOptimization.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperMODLOptimization.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWGrouperSpec.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWGrouperSpec.h
+++ b/src/Learning/KWDataPreparation/KWGrouperSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWLearningErrorManager.cpp
+++ b/src/Learning/KWDataPreparation/KWLearningErrorManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWLearningErrorManager.h
+++ b/src/Learning/KWDataPreparation/KWLearningErrorManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWLearningReport.cpp
+++ b/src/Learning/KWDataPreparation/KWLearningReport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWLearningReport.h
+++ b/src/Learning/KWDataPreparation/KWLearningReport.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWLearningSpec.cpp
+++ b/src/Learning/KWDataPreparation/KWLearningSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWLearningSpec.h
+++ b/src/Learning/KWDataPreparation/KWLearningSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWPreprocessingSpec.cpp
+++ b/src/Learning/KWDataPreparation/KWPreprocessingSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWPreprocessingSpec.h
+++ b/src/Learning/KWDataPreparation/KWPreprocessingSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWProbabilityTable.cpp
+++ b/src/Learning/KWDataPreparation/KWProbabilityTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWProbabilityTable.h
+++ b/src/Learning/KWDataPreparation/KWProbabilityTable.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWQuantileBuilder.cpp
+++ b/src/Learning/KWDataPreparation/KWQuantileBuilder.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWQuantileBuilder.h
+++ b/src/Learning/KWDataPreparation/KWQuantileBuilder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWStat.cpp
+++ b/src/Learning/KWDataPreparation/KWStat.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWStat.h
+++ b/src/Learning/KWDataPreparation/KWStat.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWStatisticalEvaluation.cpp
+++ b/src/Learning/KWDataPreparation/KWStatisticalEvaluation.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWStatisticalEvaluation.h
+++ b/src/Learning/KWDataPreparation/KWStatisticalEvaluation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWTupleTable.cpp
+++ b/src/Learning/KWDataPreparation/KWTupleTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWTupleTable.h
+++ b/src/Learning/KWDataPreparation/KWTupleTable.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWTupleTableCompareFunctions.cpp
+++ b/src/Learning/KWDataPreparation/KWTupleTableCompareFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWTupleTableLoader.cpp
+++ b/src/Learning/KWDataPreparation/KWTupleTableLoader.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWTupleTableLoader.h
+++ b/src/Learning/KWDataPreparation/KWTupleTableLoader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWUnivariatePartitionCost.cpp
+++ b/src/Learning/KWDataPreparation/KWUnivariatePartitionCost.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataPreparation/KWUnivariatePartitionCost.h
+++ b/src/Learning/KWDataPreparation/KWUnivariatePartitionCost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWArtificialDataset.cpp
+++ b/src/Learning/KWDataUtils/KWArtificialDataset.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWArtificialDataset.h
+++ b/src/Learning/KWDataUtils/KWArtificialDataset.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWChunkSorterTask.cpp
+++ b/src/Learning/KWDataUtils/KWChunkSorterTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWChunkSorterTask.h
+++ b/src/Learning/KWDataUtils/KWChunkSorterTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDataTableSliceSet.cpp
+++ b/src/Learning/KWDataUtils/KWDataTableSliceSet.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDataTableSliceSet.h
+++ b/src/Learning/KWDataUtils/KWDataTableSliceSet.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseBasicStatsTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseBasicStatsTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseBasicStatsTask.h
+++ b/src/Learning/KWDataUtils/KWDatabaseBasicStatsTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseCheckTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseCheckTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseCheckTask.h
+++ b/src/Learning/KWDataUtils/KWDatabaseCheckTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseChunkBuilder.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseChunkBuilder.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseChunkBuilder.h
+++ b/src/Learning/KWDataUtils/KWDatabaseChunkBuilder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseIndexer.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseIndexer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseIndexer.h
+++ b/src/Learning/KWDataUtils/KWDatabaseIndexer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseSlicerTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseSlicerTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseSlicerTask.h
+++ b/src/Learning/KWDataUtils/KWDatabaseSlicerTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseTask.h
+++ b/src/Learning/KWDataUtils/KWDatabaseTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseTransferTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTransferTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWDatabaseTransferTask.h
+++ b/src/Learning/KWDataUtils/KWDatabaseTransferTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWFileIndexerTask.cpp
+++ b/src/Learning/KWDataUtils/KWFileIndexerTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWFileIndexerTask.h
+++ b/src/Learning/KWDataUtils/KWFileIndexerTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWFileKeyExtractorTask.cpp
+++ b/src/Learning/KWDataUtils/KWFileKeyExtractorTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWFileKeyExtractorTask.h
+++ b/src/Learning/KWDataUtils/KWFileKeyExtractorTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWFileSorter.cpp
+++ b/src/Learning/KWDataUtils/KWFileSorter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWFileSorter.h
+++ b/src/Learning/KWDataUtils/KWFileSorter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKey.cpp
+++ b/src/Learning/KWDataUtils/KWKey.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKey.h
+++ b/src/Learning/KWDataUtils/KWKey.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKeyExtractor.cpp
+++ b/src/Learning/KWDataUtils/KWKeyExtractor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKeyExtractor.h
+++ b/src/Learning/KWDataUtils/KWKeyExtractor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKeyPositionFinderTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeyPositionFinderTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKeyPositionFinderTask.h
+++ b/src/Learning/KWDataUtils/KWKeyPositionFinderTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKeyPositionSampleExtractorTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeyPositionSampleExtractorTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKeyPositionSampleExtractorTask.h
+++ b/src/Learning/KWDataUtils/KWKeyPositionSampleExtractorTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKeySampleExtractorTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeySampleExtractorTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKeySampleExtractorTask.h
+++ b/src/Learning/KWDataUtils/KWKeySampleExtractorTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKeySizeEvaluatorTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeySizeEvaluatorTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWKeySizeEvaluatorTask.h
+++ b/src/Learning/KWDataUtils/KWKeySizeEvaluatorTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWSortBuckets.cpp
+++ b/src/Learning/KWDataUtils/KWSortBuckets.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWSortBuckets.h
+++ b/src/Learning/KWDataUtils/KWSortBuckets.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.cpp
+++ b/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.h
+++ b/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWTestDatabaseTransfer.cpp
+++ b/src/Learning/KWDataUtils/KWTestDatabaseTransfer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/KWTestDatabaseTransfer.h
+++ b/src/Learning/KWDataUtils/KWTestDatabaseTransfer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/PLDataTableDriverTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLDataTableDriverTextFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/PLDataTableDriverTextFile.h
+++ b/src/Learning/KWDataUtils/PLDataTableDriverTextFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/PLDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLDatabaseTextFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/PLDatabaseTextFile.h
+++ b/src/Learning/KWDataUtils/PLDatabaseTextFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.h
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/PLSTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLSTDatabaseTextFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/PLSTDatabaseTextFile.h
+++ b/src/Learning/KWDataUtils/PLSTDatabaseTextFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWDataUtils/PLUseMPI.h
+++ b/src/Learning/KWDataUtils/PLUseMPI.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWAnalysisResults.cpp
+++ b/src/Learning/KWLearningProblem/KWAnalysisResults.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWAnalysisResults.h
+++ b/src/Learning/KWLearningProblem/KWAnalysisResults.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWAnalysisResultsView.cpp
+++ b/src/Learning/KWLearningProblem/KWAnalysisResultsView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWAnalysisResultsView.h
+++ b/src/Learning/KWLearningProblem/KWAnalysisResultsView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWAnalysisSpec.cpp
+++ b/src/Learning/KWLearningProblem/KWAnalysisSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWAnalysisSpec.h
+++ b/src/Learning/KWLearningProblem/KWAnalysisSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWAnalysisSpecView.cpp
+++ b/src/Learning/KWLearningProblem/KWAnalysisSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWAnalysisSpecView.h
+++ b/src/Learning/KWLearningProblem/KWAnalysisSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWCrashTestParametersView.cpp
+++ b/src/Learning/KWLearningProblem/KWCrashTestParametersView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWCrashTestParametersView.h
+++ b/src/Learning/KWLearningProblem/KWCrashTestParametersView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProblem.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProblem.h
+++ b/src/Learning/KWLearningProblem/KWLearningProblem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProblemActionView.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblemActionView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProblemActionView.h
+++ b/src/Learning/KWLearningProblem/KWLearningProblemActionView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProblemComputeStats.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblemComputeStats.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProblemHelpCard.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblemHelpCard.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProblemHelpCard.h
+++ b/src/Learning/KWLearningProblem/KWLearningProblemHelpCard.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProblemTrain.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblemTrain.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProblemView.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblemView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProblemView.h
+++ b/src/Learning/KWLearningProblem/KWLearningProblemView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProject.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWLearningProject.h
+++ b/src/Learning/KWLearningProblem/KWLearningProject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWModelingAdvancedSpecView.cpp
+++ b/src/Learning/KWLearningProblem/KWModelingAdvancedSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWModelingAdvancedSpecView.h
+++ b/src/Learning/KWLearningProblem/KWModelingAdvancedSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWModelingSpec.cpp
+++ b/src/Learning/KWLearningProblem/KWModelingSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWModelingSpec.h
+++ b/src/Learning/KWLearningProblem/KWModelingSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWModelingSpecView.cpp
+++ b/src/Learning/KWLearningProblem/KWModelingSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWModelingSpecView.h
+++ b/src/Learning/KWLearningProblem/KWModelingSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWRecoderSpec.cpp
+++ b/src/Learning/KWLearningProblem/KWRecoderSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWRecoderSpec.h
+++ b/src/Learning/KWLearningProblem/KWRecoderSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWRecoderSpecView.cpp
+++ b/src/Learning/KWLearningProblem/KWRecoderSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWRecoderSpecView.h
+++ b/src/Learning/KWLearningProblem/KWRecoderSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWSystemParametersView.cpp
+++ b/src/Learning/KWLearningProblem/KWSystemParametersView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWLearningProblem/KWSystemParametersView.h
+++ b/src/Learning/KWLearningProblem/KWSystemParametersView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWAttributeConstructionReport.cpp
+++ b/src/Learning/KWModeling/KWAttributeConstructionReport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWAttributeConstructionReport.h
+++ b/src/Learning/KWModeling/KWAttributeConstructionReport.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWAttributeConstructionSpec.cpp
+++ b/src/Learning/KWModeling/KWAttributeConstructionSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWAttributeConstructionSpec.h
+++ b/src/Learning/KWModeling/KWAttributeConstructionSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWBenchmarkClassSpec.cpp
+++ b/src/Learning/KWModeling/KWBenchmarkClassSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWBenchmarkClassSpec.h
+++ b/src/Learning/KWModeling/KWBenchmarkClassSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWBenchmarkSpec.cpp
+++ b/src/Learning/KWModeling/KWBenchmarkSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWBenchmarkSpec.h
+++ b/src/Learning/KWModeling/KWBenchmarkSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWClassifierPostOptimizer.cpp
+++ b/src/Learning/KWModeling/KWClassifierPostOptimizer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWClassifierPostOptimizer.h
+++ b/src/Learning/KWModeling/KWClassifierPostOptimizer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWDRNBPredictor.cpp
+++ b/src/Learning/KWModeling/KWDRNBPredictor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWDRNBPredictor.h
+++ b/src/Learning/KWModeling/KWDRNBPredictor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWDRPredictor.cpp
+++ b/src/Learning/KWModeling/KWDRPredictor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWDRPredictor.h
+++ b/src/Learning/KWModeling/KWDRPredictor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWDataPreparationBase.cpp
+++ b/src/Learning/KWModeling/KWDataPreparationBase.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWDataPreparationBase.h
+++ b/src/Learning/KWModeling/KWDataPreparationBase.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWDataPreparationClass.cpp
+++ b/src/Learning/KWModeling/KWDataPreparationClass.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWDataPreparationClass.h
+++ b/src/Learning/KWModeling/KWDataPreparationClass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWLearningBenchmark.cpp
+++ b/src/Learning/KWModeling/KWLearningBenchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWLearningBenchmark.h
+++ b/src/Learning/KWModeling/KWLearningBenchmark.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWLearningBenchmarkBivariate.cpp
+++ b/src/Learning/KWModeling/KWLearningBenchmarkBivariate.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWLearningBenchmarkBivariate.h
+++ b/src/Learning/KWModeling/KWLearningBenchmarkBivariate.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWLearningBenchmarkUnivariate.cpp
+++ b/src/Learning/KWModeling/KWLearningBenchmarkUnivariate.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWLearningBenchmarkUnivariate.h
+++ b/src/Learning/KWModeling/KWLearningBenchmarkUnivariate.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictor.cpp
+++ b/src/Learning/KWModeling/KWPredictor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictor.h
+++ b/src/Learning/KWModeling/KWPredictor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorBaseline.cpp
+++ b/src/Learning/KWModeling/KWPredictorBaseline.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorBaseline.h
+++ b/src/Learning/KWModeling/KWPredictorBaseline.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorBivariate.cpp
+++ b/src/Learning/KWModeling/KWPredictorBivariate.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorBivariate.h
+++ b/src/Learning/KWModeling/KWPredictorBivariate.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorDataGrid.cpp
+++ b/src/Learning/KWModeling/KWPredictorDataGrid.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorDataGrid.h
+++ b/src/Learning/KWModeling/KWPredictorDataGrid.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorEvaluation.cpp
+++ b/src/Learning/KWModeling/KWPredictorEvaluation.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorEvaluation.h
+++ b/src/Learning/KWModeling/KWPredictorEvaluation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorEvaluationTask.cpp
+++ b/src/Learning/KWModeling/KWPredictorEvaluationTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorEvaluationTask.h
+++ b/src/Learning/KWModeling/KWPredictorEvaluationTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorNaiveBayes.cpp
+++ b/src/Learning/KWModeling/KWPredictorNaiveBayes.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorNaiveBayes.h
+++ b/src/Learning/KWModeling/KWPredictorNaiveBayes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorReport.cpp
+++ b/src/Learning/KWModeling/KWPredictorReport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorReport.h
+++ b/src/Learning/KWModeling/KWPredictorReport.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorSelectionScore.cpp
+++ b/src/Learning/KWModeling/KWPredictorSelectionScore.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorSelectionScore.h
+++ b/src/Learning/KWModeling/KWPredictorSelectionScore.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorSelectiveNaiveBayes.cpp
+++ b/src/Learning/KWModeling/KWPredictorSelectiveNaiveBayes.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorSelectiveNaiveBayes.h
+++ b/src/Learning/KWModeling/KWPredictorSelectiveNaiveBayes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorSelectiveNaiveBayesOptimization.cpp
+++ b/src/Learning/KWModeling/KWPredictorSelectiveNaiveBayesOptimization.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorSpec.cpp
+++ b/src/Learning/KWModeling/KWPredictorSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorSpec.h
+++ b/src/Learning/KWModeling/KWPredictorSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorUnivariate.cpp
+++ b/src/Learning/KWModeling/KWPredictorUnivariate.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWPredictorUnivariate.h
+++ b/src/Learning/KWModeling/KWPredictorUnivariate.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWRecodingSpec.cpp
+++ b/src/Learning/KWModeling/KWRecodingSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWRecodingSpec.h
+++ b/src/Learning/KWModeling/KWRecodingSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWSelectionParameters.cpp
+++ b/src/Learning/KWModeling/KWSelectionParameters.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWSelectionParameters.h
+++ b/src/Learning/KWModeling/KWSelectionParameters.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWTrainParameters.cpp
+++ b/src/Learning/KWModeling/KWTrainParameters.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWTrainParameters.h
+++ b/src/Learning/KWModeling/KWTrainParameters.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWTrainedPredictor.cpp
+++ b/src/Learning/KWModeling/KWTrainedPredictor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWModeling/KWTrainedPredictor.h
+++ b/src/Learning/KWModeling/KWTrainedPredictor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/CreateLargeFiles.cpp
+++ b/src/Learning/KWTest/CreateLargeFiles.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/CreateLargeFiles.h
+++ b/src/Learning/KWTest/CreateLargeFiles.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/Divers.cpp
+++ b/src/Learning/KWTest/Divers.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/Divers.h
+++ b/src/Learning/KWTest/Divers.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/HanoiTower.cpp
+++ b/src/Learning/KWTest/HanoiTower.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/HanoiTower.h
+++ b/src/Learning/KWTest/HanoiTower.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KDMultinomialSamplingStudy.cpp
+++ b/src/Learning/KWTest/KDMultinomialSamplingStudy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KDMultinomialSamplingStudy.h
+++ b/src/Learning/KWTest/KDMultinomialSamplingStudy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWDataGridTest.cpp
+++ b/src/Learning/KWTest/KWDataGridTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWDataGridTest.h
+++ b/src/Learning/KWTest/KWDataGridTest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWDensityEstimationTest.cpp
+++ b/src/Learning/KWTest/KWDensityEstimationTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWDensityEstimationTest.h
+++ b/src/Learning/KWTest/KWDensityEstimationTest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWDiscretizerTest.cpp
+++ b/src/Learning/KWTest/KWDiscretizerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWDiscretizerTest.h
+++ b/src/Learning/KWTest/KWDiscretizerTest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWGrouperTest.cpp
+++ b/src/Learning/KWTest/KWGrouperTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWGrouperTest.h
+++ b/src/Learning/KWTest/KWGrouperTest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWHierarchicalMultinomialStudy.cpp
+++ b/src/Learning/KWTest/KWHierarchicalMultinomialStudy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWHierarchicalMultinomialStudy.h
+++ b/src/Learning/KWTest/KWHierarchicalMultinomialStudy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWNewType.cpp
+++ b/src/Learning/KWTest/KWNewType.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWNewType.h
+++ b/src/Learning/KWTest/KWNewType.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWSNBStudy.cpp
+++ b/src/Learning/KWTest/KWSNBStudy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWSNBStudy.h
+++ b/src/Learning/KWTest/KWSNBStudy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWTextParser.cpp
+++ b/src/Learning/KWTest/KWTextParser.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/KWTextParser.h
+++ b/src/Learning/KWTest/KWTextParser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/SizeofStudy.cpp
+++ b/src/Learning/KWTest/SizeofStudy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/SizeofStudy.h
+++ b/src/Learning/KWTest/SizeofStudy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/SparseStudy.cpp
+++ b/src/Learning/KWTest/SparseStudy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/SparseStudy.h
+++ b/src/Learning/KWTest/SparseStudy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/StreamTest.cpp
+++ b/src/Learning/KWTest/StreamTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/StreamTest.h
+++ b/src/Learning/KWTest/StreamTest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/SystemDivers.cpp
+++ b/src/Learning/KWTest/SystemDivers.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/SystemDivers.h
+++ b/src/Learning/KWTest/SystemDivers.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/Test.cpp
+++ b/src/Learning/KWTest/Test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWTest/Test.h
+++ b/src/Learning/KWTest/Test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KDConstructionDomainView.cpp
+++ b/src/Learning/KWUserInterface/KDConstructionDomainView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KDConstructionDomainView.h
+++ b/src/Learning/KWUserInterface/KDConstructionDomainView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KDConstructionRuleArrayView.cpp
+++ b/src/Learning/KWUserInterface/KDConstructionRuleArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KDConstructionRuleArrayView.h
+++ b/src/Learning/KWUserInterface/KDConstructionRuleArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KDConstructionRuleView.cpp
+++ b/src/Learning/KWUserInterface/KDConstructionRuleView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KDConstructionRuleView.h
+++ b/src/Learning/KWUserInterface/KDConstructionRuleView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KDDataPreparationAttributeCreationTaskView.cpp
+++ b/src/Learning/KWUserInterface/KDDataPreparationAttributeCreationTaskView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KDDataPreparationAttributeCreationTaskView.h
+++ b/src/Learning/KWUserInterface/KDDataPreparationAttributeCreationTaskView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KDTextFeatureSpecView.cpp
+++ b/src/Learning/KWUserInterface/KDTextFeatureSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KDTextFeatureSpecView.h
+++ b/src/Learning/KWUserInterface/KDTextFeatureSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeConstructionSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWAttributeConstructionSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeConstructionSpecView.h
+++ b/src/Learning/KWUserInterface/KWAttributeConstructionSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeNameArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWAttributeNameArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeNameArrayView.h
+++ b/src/Learning/KWUserInterface/KWAttributeNameArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeNameView.cpp
+++ b/src/Learning/KWUserInterface/KWAttributeNameView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeNameView.h
+++ b/src/Learning/KWUserInterface/KWAttributeNameView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributePairNameArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWAttributePairNameArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributePairNameArrayView.h
+++ b/src/Learning/KWUserInterface/KWAttributePairNameArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributePairNameView.cpp
+++ b/src/Learning/KWUserInterface/KWAttributePairNameView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributePairNameView.h
+++ b/src/Learning/KWUserInterface/KWAttributePairNameView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributePairsSpecFileView.cpp
+++ b/src/Learning/KWUserInterface/KWAttributePairsSpecFileView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributePairsSpecFileView.h
+++ b/src/Learning/KWUserInterface/KWAttributePairsSpecFileView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributePairsSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWAttributePairsSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributePairsSpecView.h
+++ b/src/Learning/KWUserInterface/KWAttributePairsSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeSpec.cpp
+++ b/src/Learning/KWUserInterface/KWAttributeSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeSpec.h
+++ b/src/Learning/KWUserInterface/KWAttributeSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeSpecArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWAttributeSpecArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeSpecArrayView.h
+++ b/src/Learning/KWUserInterface/KWAttributeSpecArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWAttributeSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWAttributeSpecView.h
+++ b/src/Learning/KWUserInterface/KWAttributeSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWBenchmarkClassSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWBenchmarkClassSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWBenchmarkClassSpecView.h
+++ b/src/Learning/KWUserInterface/KWBenchmarkClassSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWBenchmarkSpecArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWBenchmarkSpecArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWBenchmarkSpecArrayView.h
+++ b/src/Learning/KWUserInterface/KWBenchmarkSpecArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWBenchmarkSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWBenchmarkSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWBenchmarkSpecView.h
+++ b/src/Learning/KWUserInterface/KWBenchmarkSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassAttributeHelpList.cpp
+++ b/src/Learning/KWUserInterface/KWClassAttributeHelpList.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassAttributeHelpList.h
+++ b/src/Learning/KWUserInterface/KWClassAttributeHelpList.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassBuilderView.cpp
+++ b/src/Learning/KWUserInterface/KWClassBuilderView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassBuilderView.h
+++ b/src/Learning/KWUserInterface/KWClassBuilderView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassManagement.cpp
+++ b/src/Learning/KWUserInterface/KWClassManagement.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassManagement.h
+++ b/src/Learning/KWUserInterface/KWClassManagement.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassManagementView.cpp
+++ b/src/Learning/KWUserInterface/KWClassManagementView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassManagementView.h
+++ b/src/Learning/KWUserInterface/KWClassManagementView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassSpec.cpp
+++ b/src/Learning/KWUserInterface/KWClassSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassSpec.h
+++ b/src/Learning/KWUserInterface/KWClassSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassSpecArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWClassSpecArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassSpecArrayView.h
+++ b/src/Learning/KWUserInterface/KWClassSpecArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWClassSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWClassSpecView.h
+++ b/src/Learning/KWUserInterface/KWClassSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDataGridOptimizerParametersView.cpp
+++ b/src/Learning/KWUserInterface/KWDataGridOptimizerParametersView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDataGridOptimizerParametersView.h
+++ b/src/Learning/KWUserInterface/KWDataGridOptimizerParametersView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDataTableKeyExtractorView.cpp
+++ b/src/Learning/KWUserInterface/KWDataTableKeyExtractorView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDataTableKeyExtractorView.h
+++ b/src/Learning/KWUserInterface/KWDataTableKeyExtractorView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDataTableSorterView.cpp
+++ b/src/Learning/KWUserInterface/KWDataTableSorterView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDataTableSorterView.h
+++ b/src/Learning/KWUserInterface/KWDataTableSorterView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDatabaseAttributeValuesHelpList.cpp
+++ b/src/Learning/KWUserInterface/KWDatabaseAttributeValuesHelpList.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDatabaseAttributeValuesHelpList.h
+++ b/src/Learning/KWUserInterface/KWDatabaseAttributeValuesHelpList.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDatabaseFormatDetectorView.cpp
+++ b/src/Learning/KWUserInterface/KWDatabaseFormatDetectorView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDatabaseFormatDetectorView.h
+++ b/src/Learning/KWUserInterface/KWDatabaseFormatDetectorView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDatabaseTransferView.cpp
+++ b/src/Learning/KWUserInterface/KWDatabaseTransferView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDatabaseTransferView.h
+++ b/src/Learning/KWUserInterface/KWDatabaseTransferView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDatabaseView.cpp
+++ b/src/Learning/KWUserInterface/KWDatabaseView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDatabaseView.h
+++ b/src/Learning/KWUserInterface/KWDatabaseView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDiscretizerSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWDiscretizerSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWDiscretizerSpecView.h
+++ b/src/Learning/KWUserInterface/KWDiscretizerSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWEvaluatedPredictorSpec.cpp
+++ b/src/Learning/KWUserInterface/KWEvaluatedPredictorSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWEvaluatedPredictorSpec.h
+++ b/src/Learning/KWUserInterface/KWEvaluatedPredictorSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWEvaluatedPredictorSpecArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWEvaluatedPredictorSpecArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWEvaluatedPredictorSpecArrayView.h
+++ b/src/Learning/KWUserInterface/KWEvaluatedPredictorSpecArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWEvaluatedPredictorSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWEvaluatedPredictorSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWEvaluatedPredictorSpecView.h
+++ b/src/Learning/KWUserInterface/KWEvaluatedPredictorSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWGrouperSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWGrouperSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWGrouperSpecView.h
+++ b/src/Learning/KWUserInterface/KWGrouperSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWLearningBenchmarkView.cpp
+++ b/src/Learning/KWUserInterface/KWLearningBenchmarkView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWLearningBenchmarkView.h
+++ b/src/Learning/KWUserInterface/KWLearningBenchmarkView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWMTClassBuilderView.cpp
+++ b/src/Learning/KWUserInterface/KWMTClassBuilderView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWMTClassBuilderView.h
+++ b/src/Learning/KWUserInterface/KWMTClassBuilderView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWMTDatabaseMappingArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWMTDatabaseMappingArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWMTDatabaseMappingArrayView.h
+++ b/src/Learning/KWUserInterface/KWMTDatabaseMappingArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWMTDatabaseMappingView.cpp
+++ b/src/Learning/KWUserInterface/KWMTDatabaseMappingView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWMTDatabaseMappingView.h
+++ b/src/Learning/KWUserInterface/KWMTDatabaseMappingView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWMTDatabaseTextFileView.cpp
+++ b/src/Learning/KWUserInterface/KWMTDatabaseTextFileView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWMTDatabaseTextFileView.h
+++ b/src/Learning/KWUserInterface/KWMTDatabaseTextFileView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorDataGridView.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorDataGridView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorDataGridView.h
+++ b/src/Learning/KWUserInterface/KWPredictorDataGridView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorEvaluator.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorEvaluator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorEvaluator.h
+++ b/src/Learning/KWUserInterface/KWPredictorEvaluator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorEvaluatorView.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorEvaluatorView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorEvaluatorView.h
+++ b/src/Learning/KWUserInterface/KWPredictorEvaluatorView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorSelectiveNaiveBayesView.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorSelectiveNaiveBayesView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorSelectiveNaiveBayesView.h
+++ b/src/Learning/KWUserInterface/KWPredictorSelectiveNaiveBayesView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorSpecArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorSpecArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorSpecArrayView.h
+++ b/src/Learning/KWUserInterface/KWPredictorSpecArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorSpecView.h
+++ b/src/Learning/KWUserInterface/KWPredictorSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorView.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPredictorView.h
+++ b/src/Learning/KWUserInterface/KWPredictorView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPreprocessingSpecArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWPreprocessingSpecArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPreprocessingSpecArrayView.h
+++ b/src/Learning/KWUserInterface/KWPreprocessingSpecArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPreprocessingSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWPreprocessingSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWPreprocessingSpecView.h
+++ b/src/Learning/KWUserInterface/KWPreprocessingSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWRecodingSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWRecodingSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWRecodingSpecView.h
+++ b/src/Learning/KWUserInterface/KWRecodingSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWSTDatabaseTextFileView.cpp
+++ b/src/Learning/KWUserInterface/KWSTDatabaseTextFileView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWSTDatabaseTextFileView.h
+++ b/src/Learning/KWUserInterface/KWSTDatabaseTextFileView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWSelectionParametersView.cpp
+++ b/src/Learning/KWUserInterface/KWSelectionParametersView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWSelectionParametersView.h
+++ b/src/Learning/KWUserInterface/KWSelectionParametersView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWSortAttributeNameArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWSortAttributeNameArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWSortAttributeNameArrayView.h
+++ b/src/Learning/KWUserInterface/KWSortAttributeNameArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWTrainParametersView.cpp
+++ b/src/Learning/KWUserInterface/KWTrainParametersView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUserInterface/KWTrainParametersView.h
+++ b/src/Learning/KWUserInterface/KWTrainParametersView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUtils/KWKhiopsVersion.h
+++ b/src/Learning/KWUtils/KWKhiopsVersion.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 
@@ -13,4 +13,4 @@
 #define KHIOPS_VERSION str(10.1.5)
 
 // Copyright
-#define KHIOPS_COPYRIGHT_LABEL str((c)2023 Orange - All rights reserved.)
+#define KHIOPS_COPYRIGHT_LABEL str((c)2024 Orange - All rights reserved.)

--- a/src/Learning/KWUtils/KWVersion.cpp
+++ b/src/Learning/KWUtils/KWVersion.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUtils/KWVersion.h
+++ b/src/Learning/KWUtils/KWVersion.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUtils/LMLicenseManager.cpp
+++ b/src/Learning/KWUtils/LMLicenseManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUtils/LMLicenseManager.h
+++ b/src/Learning/KWUtils/LMLicenseManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUtils/LMLicenseService.cpp
+++ b/src/Learning/KWUtils/LMLicenseService.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUtils/LMLicenseService.h
+++ b/src/Learning/KWUtils/LMLicenseService.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUtils/ProfileStats.cpp
+++ b/src/Learning/KWUtils/ProfileStats.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KWUtils/ProfileStats.h
+++ b/src/Learning/KWUtils/ProfileStats.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/KNIStream.cpp
+++ b/src/Learning/KhiopsNativeInterface/KNIStream.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/KNIStream.h
+++ b/src/Learning/KhiopsNativeInterface/KNIStream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/KWDataTableDriverStream.cpp
+++ b/src/Learning/KhiopsNativeInterface/KWDataTableDriverStream.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/KWDataTableDriverStream.h
+++ b/src/Learning/KhiopsNativeInterface/KWDataTableDriverStream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/KWMTDatabaseStream.cpp
+++ b/src/Learning/KhiopsNativeInterface/KWMTDatabaseStream.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/KWMTDatabaseStream.h
+++ b/src/Learning/KhiopsNativeInterface/KWMTDatabaseStream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/KWSTDatabaseStream.cpp
+++ b/src/Learning/KhiopsNativeInterface/KWSTDatabaseStream.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/KWSTDatabaseStream.h
+++ b/src/Learning/KhiopsNativeInterface/KWSTDatabaseStream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.cpp
+++ b/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.h
+++ b/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/KhiopsNativeInterface/resource.h
+++ b/src/Learning/KhiopsNativeInterface/resource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHBin.cpp
+++ b/src/Learning/MHHistograms/MHBin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHBin.h
+++ b/src/Learning/MHHistograms/MHBin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHContinuousLimits.cpp
+++ b/src/Learning/MHHistograms/MHContinuousLimits.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHContinuousLimits.h
+++ b/src/Learning/MHHistograms/MHContinuousLimits.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHDataSubset.cpp
+++ b/src/Learning/MHHistograms/MHDataSubset.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHDataSubset.h
+++ b/src/Learning/MHHistograms/MHDataSubset.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHDiscretizerHistogramMODL.cpp
+++ b/src/Learning/MHHistograms/MHDiscretizerHistogramMODL.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHDiscretizerHistogramMODL.h
+++ b/src/Learning/MHHistograms/MHDiscretizerHistogramMODL.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHDiscretizerHistogramMODL_fp.cpp
+++ b/src/Learning/MHHistograms/MHDiscretizerHistogramMODL_fp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHDiscretizerHistogramMODL_fp.h
+++ b/src/Learning/MHHistograms/MHDiscretizerHistogramMODL_fp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHEnumHistogramCost.cpp
+++ b/src/Learning/MHHistograms/MHEnumHistogramCost.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHEnumHistogramCost.h
+++ b/src/Learning/MHHistograms/MHEnumHistogramCost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHFloatingPointFrequencyTableBuilder.cpp
+++ b/src/Learning/MHHistograms/MHFloatingPointFrequencyTableBuilder.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHFloatingPointFrequencyTableBuilder.h
+++ b/src/Learning/MHHistograms/MHFloatingPointFrequencyTableBuilder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHHistogram.cpp
+++ b/src/Learning/MHHistograms/MHHistogram.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHHistogram.h
+++ b/src/Learning/MHHistograms/MHHistogram.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHHistogramSpec.cpp
+++ b/src/Learning/MHHistograms/MHHistogramSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHHistogramSpec.h
+++ b/src/Learning/MHHistograms/MHHistogramSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHHistogramSpecView.cpp
+++ b/src/Learning/MHHistograms/MHHistogramSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHHistogramSpecView.h
+++ b/src/Learning/MHHistograms/MHHistogramSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHHistogramVector.cpp
+++ b/src/Learning/MHHistograms/MHHistogramVector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHHistogramVector.h
+++ b/src/Learning/MHHistograms/MHHistogramVector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHHistogramVector_fp.cpp
+++ b/src/Learning/MHHistograms/MHHistogramVector_fp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHHistogramVector_fp.h
+++ b/src/Learning/MHHistograms/MHHistogramVector_fp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHKMHistogramCost.cpp
+++ b/src/Learning/MHHistograms/MHKMHistogramCost.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHKMHistogramCost.h
+++ b/src/Learning/MHHistograms/MHKMHistogramCost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHMODLHistogramCost.cpp
+++ b/src/Learning/MHHistograms/MHMODLHistogramCost.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHMODLHistogramCost.h
+++ b/src/Learning/MHHistograms/MHMODLHistogramCost.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHMODLHistogramCost_fp.cpp
+++ b/src/Learning/MHHistograms/MHMODLHistogramCost_fp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHMODLHistogramCost_fp.h
+++ b/src/Learning/MHHistograms/MHMODLHistogramCost_fp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHNMLStat.cpp
+++ b/src/Learning/MHHistograms/MHNMLStat.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHNMLStat.h
+++ b/src/Learning/MHHistograms/MHNMLStat.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHTruncationDiscretizerHistogramMODL_fp.cpp
+++ b/src/Learning/MHHistograms/MHTruncationDiscretizerHistogramMODL_fp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHTruncationDiscretizerHistogramMODL_fp.h
+++ b/src/Learning/MHHistograms/MHTruncationDiscretizerHistogramMODL_fp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHTruncationFloatingPointFrequencyTableBuilder.cpp
+++ b/src/Learning/MHHistograms/MHTruncationFloatingPointFrequencyTableBuilder.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MHHistograms/MHTruncationFloatingPointFrequencyTableBuilder.h
+++ b/src/Learning/MHHistograms/MHTruncationFloatingPointFrequencyTableBuilder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MDKhiopsLearningProblem.cpp
+++ b/src/Learning/MODL/MDKhiopsLearningProblem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MDKhiopsLearningProblem.h
+++ b/src/Learning/MODL/MDKhiopsLearningProblem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MDKhiopsLearningProblemView.cpp
+++ b/src/Learning/MODL/MDKhiopsLearningProblemView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MDKhiopsLearningProblemView.h
+++ b/src/Learning/MODL/MDKhiopsLearningProblemView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MDKhiopsLearningProject.cpp
+++ b/src/Learning/MODL/MDKhiopsLearningProject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MDKhiopsLearningProject.h
+++ b/src/Learning/MODL/MDKhiopsLearningProject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MDKhiopsModelingSpec.cpp
+++ b/src/Learning/MODL/MDKhiopsModelingSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MDKhiopsModelingSpec.h
+++ b/src/Learning/MODL/MDKhiopsModelingSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MDKhiopsModelingSpecView.cpp
+++ b/src/Learning/MODL/MDKhiopsModelingSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MDKhiopsModelingSpecView.h
+++ b/src/Learning/MODL/MDKhiopsModelingSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MODL.cpp
+++ b/src/Learning/MODL/MODL.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MODL.h
+++ b/src/Learning/MODL/MODL.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/MODL_dll.cpp
+++ b/src/Learning/MODL/MODL_dll.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 
@@ -53,7 +53,7 @@ KHIOPS_API int StartKhiops(const char* sInputScenario, const char* sLogFileName,
 	int nDaysBeforeExpiration;
 
 	// Mise en place d'une date de peremption
-	expirationDate.Init(2023, 6, 30);
+	expirationDate.Init(2024, 6, 30);
 	currentDate.SetCurrentDate();
 	nDaysBeforeExpiration = expirationDate.Diff(currentDate);
 	if (nDaysBeforeExpiration < 0)

--- a/src/Learning/MODL/MODL_dll.h
+++ b/src/Learning/MODL/MODL_dll.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL/resource.h
+++ b/src/Learning/MODL/resource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCAnalysisResults.cpp
+++ b/src/Learning/MODL_Coclustering/CCAnalysisResults.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCAnalysisResults.h
+++ b/src/Learning/MODL_Coclustering/CCAnalysisResults.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCAnalysisResultsView.cpp
+++ b/src/Learning/MODL_Coclustering/CCAnalysisResultsView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCAnalysisResultsView.h
+++ b/src/Learning/MODL_Coclustering/CCAnalysisResultsView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCAnalysisSpec.cpp
+++ b/src/Learning/MODL_Coclustering/CCAnalysisSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCAnalysisSpec.h
+++ b/src/Learning/MODL_Coclustering/CCAnalysisSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCAnalysisSpecView.cpp
+++ b/src/Learning/MODL_Coclustering/CCAnalysisSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCAnalysisSpecView.h
+++ b/src/Learning/MODL_Coclustering/CCAnalysisSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.cpp
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.h
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCCoclusteringReport.cpp
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringReport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCCoclusteringReport.h
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringReport.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCCoclusteringSpec.cpp
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCCoclusteringSpec.h
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCCoclusteringSpecView.cpp
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCCoclusteringSpecView.h
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpec.h
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpecView.cpp
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpecView.h
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCHierarchicalDataGrid.cpp
+++ b/src/Learning/MODL_Coclustering/CCHierarchicalDataGrid.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCHierarchicalDataGrid.h
+++ b/src/Learning/MODL_Coclustering/CCHierarchicalDataGrid.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblem.h
+++ b/src/Learning/MODL_Coclustering/CCLearningProblem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemActionView.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemActionView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemActionView.h
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemActionView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemClusterExtractionView.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemClusterExtractionView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemClusterExtractionView.h
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemClusterExtractionView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemDeploymentPreparationView.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemDeploymentPreparationView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemDeploymentPreparationView.h
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemDeploymentPreparationView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemPostOptimizationView.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemPostOptimizationView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemPostOptimizationView.h
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemPostOptimizationView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemPostProcessingView.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemPostProcessingView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemPostProcessingView.h
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemPostProcessingView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemToolView.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemToolView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemToolView.h
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemToolView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemView.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemView.h
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProject.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCLearningProject.h
+++ b/src/Learning/MODL_Coclustering/CCLearningProject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCPostProcessedAttribute.cpp
+++ b/src/Learning/MODL_Coclustering/CCPostProcessedAttribute.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCPostProcessedAttribute.h
+++ b/src/Learning/MODL_Coclustering/CCPostProcessedAttribute.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCPostProcessedAttributeArrayView.cpp
+++ b/src/Learning/MODL_Coclustering/CCPostProcessedAttributeArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCPostProcessedAttributeArrayView.h
+++ b/src/Learning/MODL_Coclustering/CCPostProcessedAttributeArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCPostProcessedAttributeView.cpp
+++ b/src/Learning/MODL_Coclustering/CCPostProcessedAttributeView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCPostProcessedAttributeView.h
+++ b/src/Learning/MODL_Coclustering/CCPostProcessedAttributeView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCPostProcessingSpec.cpp
+++ b/src/Learning/MODL_Coclustering/CCPostProcessingSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCPostProcessingSpec.h
+++ b/src/Learning/MODL_Coclustering/CCPostProcessingSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCPostProcessingSpecView.cpp
+++ b/src/Learning/MODL_Coclustering/CCPostProcessingSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/CCPostProcessingSpecView.h
+++ b/src/Learning/MODL_Coclustering/CCPostProcessingSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/MODL_Coclustering.cpp
+++ b/src/Learning/MODL_Coclustering/MODL_Coclustering.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/MODL_Coclustering.h
+++ b/src/Learning/MODL_Coclustering/MODL_Coclustering.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/MODL_Coclustering_dll.cpp
+++ b/src/Learning/MODL_Coclustering/MODL_Coclustering_dll.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/MODL_Coclustering_dll.h
+++ b/src/Learning/MODL_Coclustering/MODL_Coclustering_dll.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/MODL_Coclustering/resource.h
+++ b/src/Learning/MODL_Coclustering/resource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBAttributeSelectionScorer.cpp
+++ b/src/Learning/SNBPredictor/SNBAttributeSelectionScorer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBAttributeSelectionScorer.h
+++ b/src/Learning/SNBPredictor/SNBAttributeSelectionScorer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBAttributeSelectionWeightCalculator.cpp
+++ b/src/Learning/SNBPredictor/SNBAttributeSelectionWeightCalculator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBAttributeSelectionWeightCalculator.h
+++ b/src/Learning/SNBPredictor/SNBAttributeSelectionWeightCalculator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.cpp
+++ b/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.h
+++ b/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBIndexVector.cpp
+++ b/src/Learning/SNBPredictor/SNBIndexVector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBIndexVector.h
+++ b/src/Learning/SNBPredictor/SNBIndexVector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBPredictorSelectionDataCostCalculator.cpp
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectionDataCostCalculator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBPredictorSelectionDataCostCalculator.h
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectionDataCostCalculator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayes.cpp
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayes.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayes.h
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.cpp
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.h
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesView.cpp
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesView.h
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/genum/GenumCommandLine.cpp
+++ b/src/Learning/genum/GenumCommandLine.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/genum/GenumCommandLine.h
+++ b/src/Learning/genum/GenumCommandLine.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/genum/Version.h
+++ b/src/Learning/genum/Version.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 
@@ -13,4 +13,4 @@
 #define GENUM_VERSION str(1.0)
 
 // Copyright
-#define GENUM_COPYRIGHT_LABEL str((c)2023 Orange.)
+#define GENUM_COPYRIGHT_LABEL str((c)2024 Orange.)

--- a/src/Learning/genum/genum.cpp
+++ b/src/Learning/genum/genum.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/genum/genum.h
+++ b/src/Learning/genum/genum.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/genum/resource.h
+++ b/src/Learning/genum/resource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/genumfp/MHCommandLine.cpp
+++ b/src/Learning/genumfp/MHCommandLine.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/genumfp/MHCommandLine.h
+++ b/src/Learning/genumfp/MHCommandLine.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/genumfp/Version.h
+++ b/src/Learning/genumfp/Version.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 
@@ -13,4 +13,4 @@
 #define GENUMFP_VERSION str(1.0)
 
 // Copyright
-#define GENUMFP_COPYRIGHT_LABEL str((c)2023 Orange.)
+#define GENUMFP_COPYRIGHT_LABEL str((c)2024 Orange.)

--- a/src/Learning/genumfp/genumfp.cpp
+++ b/src/Learning/genumfp/genumfp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/genumfp/genumfp.h
+++ b/src/Learning/genumfp/genumfp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/genumfp/resource.h
+++ b/src/Learning/genumfp/resource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample1/SampleOneLearningProblem.cpp
+++ b/src/Learning/samples/sample1/SampleOneLearningProblem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample1/SampleOneLearningProblem.h
+++ b/src/Learning/samples/sample1/SampleOneLearningProblem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample1/SampleOneLearningProblemView.cpp
+++ b/src/Learning/samples/sample1/SampleOneLearningProblemView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample1/SampleOneLearningProblemView.h
+++ b/src/Learning/samples/sample1/SampleOneLearningProblemView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample1/SampleOneLearningProject.cpp
+++ b/src/Learning/samples/sample1/SampleOneLearningProject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample1/SampleOneLearningProject.h
+++ b/src/Learning/samples/sample1/SampleOneLearningProject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample1/test.cpp
+++ b/src/Learning/samples/sample1/test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample1/test.h
+++ b/src/Learning/samples/sample1/test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMDRMajority.cpp
+++ b/src/Learning/samples/sample2/CMDRMajority.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMDRMajority.h
+++ b/src/Learning/samples/sample2/CMDRMajority.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMLearningProblem.cpp
+++ b/src/Learning/samples/sample2/CMLearningProblem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMLearningProblem.h
+++ b/src/Learning/samples/sample2/CMLearningProblem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMLearningProblemView.cpp
+++ b/src/Learning/samples/sample2/CMLearningProblemView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMLearningProblemView.h
+++ b/src/Learning/samples/sample2/CMLearningProblemView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMLearningProject.cpp
+++ b/src/Learning/samples/sample2/CMLearningProject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMLearningProject.h
+++ b/src/Learning/samples/sample2/CMLearningProject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMMajorityClassifier.cpp
+++ b/src/Learning/samples/sample2/CMMajorityClassifier.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMMajorityClassifier.h
+++ b/src/Learning/samples/sample2/CMMajorityClassifier.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMModelingSpec.cpp
+++ b/src/Learning/samples/sample2/CMModelingSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMModelingSpec.h
+++ b/src/Learning/samples/sample2/CMModelingSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMModelingSpecView.cpp
+++ b/src/Learning/samples/sample2/CMModelingSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/CMModelingSpecView.h
+++ b/src/Learning/samples/sample2/CMModelingSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/ClassifieurMajoritaire.cpp
+++ b/src/Learning/samples/sample2/ClassifieurMajoritaire.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample2/ClassifieurMajoritaire.h
+++ b/src/Learning/samples/sample2/ClassifieurMajoritaire.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYAnalysisResults.cpp
+++ b/src/Learning/samples/sample3/MYAnalysisResults.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYAnalysisResults.h
+++ b/src/Learning/samples/sample3/MYAnalysisResults.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYAnalysisResultsView.cpp
+++ b/src/Learning/samples/sample3/MYAnalysisResultsView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYAnalysisResultsView.h
+++ b/src/Learning/samples/sample3/MYAnalysisResultsView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYLearningProblem.cpp
+++ b/src/Learning/samples/sample3/MYLearningProblem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYLearningProblem.h
+++ b/src/Learning/samples/sample3/MYLearningProblem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYLearningProblemView.cpp
+++ b/src/Learning/samples/sample3/MYLearningProblemView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYLearningProblemView.h
+++ b/src/Learning/samples/sample3/MYLearningProblemView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYLearningProject.cpp
+++ b/src/Learning/samples/sample3/MYLearningProject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYLearningProject.h
+++ b/src/Learning/samples/sample3/MYLearningProject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYMain.cpp
+++ b/src/Learning/samples/sample3/MYMain.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYMain.h
+++ b/src/Learning/samples/sample3/MYMain.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYModelingSpec.cpp
+++ b/src/Learning/samples/sample3/MYModelingSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYModelingSpec.h
+++ b/src/Learning/samples/sample3/MYModelingSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYModelingSpecView.cpp
+++ b/src/Learning/samples/sample3/MYModelingSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Learning/samples/sample3/MYModelingSpecView.h
+++ b/src/Learning/samples/sample3/MYModelingSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIAction.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIAction.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIBooleanElement.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIBooleanElement.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUICard.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUICard.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUICharElement.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUICharElement.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIComboBoxAutoComplete.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIComboBoxAutoComplete.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIComboBoxImageRenderer.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIComboBoxImageRenderer.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIData.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIData.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIDialog.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIDialog.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIDoubleElement.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIDoubleElement.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIElement.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIElement.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIFileDirectoryChooser.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIFileDirectoryChooser.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIIntElement.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIIntElement.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIList.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIList.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIManager.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIManager.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIMessage.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIMessage.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIObject.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIObject.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIStringElement.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIStringElement.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUITable.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUITable.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUITableModel.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUITableModel.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUITaskProgression.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUITaskProgression.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIUnit.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIUnit.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/extensions/GUICardTabbedPanes.java
+++ b/src/Norm/NormGUI/src/normGUI/extensions/GUICardTabbedPanes.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/booleanWidgets/GUIBooleanElementCheckBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/booleanWidgets/GUIBooleanElementCheckBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/booleanWidgets/GUIBooleanElementComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/booleanWidgets/GUIBooleanElementComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/booleanWidgets/GUIBooleanElementRadioButton.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/booleanWidgets/GUIBooleanElementRadioButton.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/charWidgets/GUICharElementComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/charWidgets/GUICharElementComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/charWidgets/GUICharElementEditableComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/charWidgets/GUICharElementEditableComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/charWidgets/GUICharElementRadioButton.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/charWidgets/GUICharElementRadioButton.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/doubleWidgets/GUIDoubleElementComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/doubleWidgets/GUIDoubleElementComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/doubleWidgets/GUIDoubleElementEditableComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/doubleWidgets/GUIDoubleElementEditableComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/doubleWidgets/GUIDoubleElementRadioButton.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/doubleWidgets/GUIDoubleElementRadioButton.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/doubleWidgets/GUIDoubleElementSpinner.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/doubleWidgets/GUIDoubleElementSpinner.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementEditableComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementEditableComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementRadioButton.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementRadioButton.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementSlider.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementSlider.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementSpinner.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementSpinner.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementDirectoryChooser.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementDirectoryChooser.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementEditableComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementEditableComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementFileChooser.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementFileChooser.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementFileDirectoryChooser.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementFileDirectoryChooser.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementFormattedLabel.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementFormattedLabel.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementHelpedComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementHelpedComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementImageComboBox.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementImageComboBox.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementPassword.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementPassword.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementRadioButton.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementRadioButton.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementSelectableLabel.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementSelectableLabel.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementTextArea.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementTextArea.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementUriLabel.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/stringWidgets/GUIStringElementUriLabel.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/ALString.cpp
+++ b/src/Norm/base/ALString.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/ALString.h
+++ b/src/Norm/base/ALString.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/BufferedFile.cpp
+++ b/src/Norm/base/BufferedFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/BufferedFile.h
+++ b/src/Norm/base/BufferedFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/CharVector.cpp
+++ b/src/Norm/base/CharVector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/CharVector.h
+++ b/src/Norm/base/CharVector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/CommandLine.cpp
+++ b/src/Norm/base/CommandLine.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/CommandLine.h
+++ b/src/Norm/base/CommandLine.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Ermgt.cpp
+++ b/src/Norm/base/Ermgt.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Ermgt.h
+++ b/src/Norm/base/Ermgt.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/FileCache.cpp
+++ b/src/Norm/base/FileCache.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/FileCache.h
+++ b/src/Norm/base/FileCache.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/FileService.cpp
+++ b/src/Norm/base/FileService.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/FileService.h
+++ b/src/Norm/base/FileService.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/HugeBuffer.cpp
+++ b/src/Norm/base/HugeBuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/HugeBuffer.h
+++ b/src/Norm/base/HugeBuffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/InputBufferedFile.cpp
+++ b/src/Norm/base/InputBufferedFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/InputBufferedFile.h
+++ b/src/Norm/base/InputBufferedFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Longint.cpp
+++ b/src/Norm/base/Longint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Longint.h
+++ b/src/Norm/base/Longint.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/MemVector.cpp
+++ b/src/Norm/base/MemVector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/MemVector.h
+++ b/src/Norm/base/MemVector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/MemoryBufferedFile.cpp
+++ b/src/Norm/base/MemoryBufferedFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/MemoryBufferedFile.h
+++ b/src/Norm/base/MemoryBufferedFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/MemoryManager.cpp
+++ b/src/Norm/base/MemoryManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/MemoryManager.h
+++ b/src/Norm/base/MemoryManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/MemoryStatsManager.cpp
+++ b/src/Norm/base/MemoryStatsManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/MemoryStatsManager.h
+++ b/src/Norm/base/MemoryStatsManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Obarray.cpp
+++ b/src/Norm/base/Obarray.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Obdic.cpp
+++ b/src/Norm/base/Obdic.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Object.h
+++ b/src/Norm/base/Object.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Oblist.cpp
+++ b/src/Norm/base/Oblist.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/OutputBufferedFile.cpp
+++ b/src/Norm/base/OutputBufferedFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/OutputBufferedFile.h
+++ b/src/Norm/base/OutputBufferedFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/PLRemoteFileService.cpp
+++ b/src/Norm/base/PLRemoteFileService.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/PLRemoteFileService.h
+++ b/src/Norm/base/PLRemoteFileService.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Portability.cpp
+++ b/src/Norm/base/Portability.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Portability.h
+++ b/src/Norm/base/Portability.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Regexp.cpp
+++ b/src/Norm/base/Regexp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Regexp.h
+++ b/src/Norm/base/Regexp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SortedList.cpp
+++ b/src/Norm/base/SortedList.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SortedList.h
+++ b/src/Norm/base/SortedList.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Standard.cpp
+++ b/src/Norm/base/Standard.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Standard.h
+++ b/src/Norm/base/Standard.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemFile.cpp
+++ b/src/Norm/base/SystemFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemFile.h
+++ b/src/Norm/base/SystemFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemFileDriver.cpp
+++ b/src/Norm/base/SystemFileDriver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemFileDriver.h
+++ b/src/Norm/base/SystemFileDriver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemFileDriverANSI.cpp
+++ b/src/Norm/base/SystemFileDriverANSI.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemFileDriverANSI.h
+++ b/src/Norm/base/SystemFileDriverANSI.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemFileDriverCreator.cpp
+++ b/src/Norm/base/SystemFileDriverCreator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemFileDriverCreator.h
+++ b/src/Norm/base/SystemFileDriverCreator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemFileDriverLibrary.cpp
+++ b/src/Norm/base/SystemFileDriverLibrary.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemFileDriverLibrary.h
+++ b/src/Norm/base/SystemFileDriverLibrary.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemResource.cpp
+++ b/src/Norm/base/SystemResource.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/SystemResource.h
+++ b/src/Norm/base/SystemResource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/TaskProgression.cpp
+++ b/src/Norm/base/TaskProgression.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/TaskProgression.h
+++ b/src/Norm/base/TaskProgression.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/TaskProgressionManager.cpp
+++ b/src/Norm/base/TaskProgressionManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/TaskProgressionManager.h
+++ b/src/Norm/base/TaskProgressionManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Timer.cpp
+++ b/src/Norm/base/Timer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Timer.h
+++ b/src/Norm/base/Timer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/UICard.cpp
+++ b/src/Norm/base/UICard.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/UIData.cpp
+++ b/src/Norm/base/UIData.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/UIElements.cpp
+++ b/src/Norm/base/UIElements.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/UIList.cpp
+++ b/src/Norm/base/UIList.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/UIObject.cpp
+++ b/src/Norm/base/UIObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/UIObjectArrayView.cpp
+++ b/src/Norm/base/UIObjectArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/UIObjectView.cpp
+++ b/src/Norm/base/UIObjectView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/UITaskProgression.cpp
+++ b/src/Norm/base/UITaskProgression.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/UIUnit.cpp
+++ b/src/Norm/base/UIUnit.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/UserInterface.h
+++ b/src/Norm/base/UserInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Vector.cpp
+++ b/src/Norm/base/Vector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/Vector.h
+++ b/src/Norm/base/Vector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/jni_md_linux.h
+++ b/src/Norm/base/jni_md_linux.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/jni_md_windows.h
+++ b/src/Norm/base/jni_md_windows.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/base/jni_wrapper.h
+++ b/src/Norm/base/jni_wrapper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/BaseTest.cpp
+++ b/src/Norm/basetest/BaseTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/BaseTest.h
+++ b/src/Norm/basetest/BaseTest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/DiversTests.cpp
+++ b/src/Norm/basetest/DiversTests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/DiversTests.h
+++ b/src/Norm/basetest/DiversTests.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITest.cpp
+++ b/src/Norm/basetest/UITest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITest.h
+++ b/src/Norm/basetest/UITest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestActionSubObject.cpp
+++ b/src/Norm/basetest/UITestActionSubObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestActionSubObject.h
+++ b/src/Norm/basetest/UITestActionSubObject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestActionSubObjectView.cpp
+++ b/src/Norm/basetest/UITestActionSubObjectView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestActionSubObjectView.h
+++ b/src/Norm/basetest/UITestActionSubObjectView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestClassSpec.cpp
+++ b/src/Norm/basetest/UITestClassSpec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestClassSpec.h
+++ b/src/Norm/basetest/UITestClassSpec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestClassSpecArrayView.cpp
+++ b/src/Norm/basetest/UITestClassSpecArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestClassSpecArrayView.h
+++ b/src/Norm/basetest/UITestClassSpecArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestClassSpecView.cpp
+++ b/src/Norm/basetest/UITestClassSpecView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestClassSpecView.h
+++ b/src/Norm/basetest/UITestClassSpecView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestObject.cpp
+++ b/src/Norm/basetest/UITestObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestObject.h
+++ b/src/Norm/basetest/UITestObject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestObjectView.cpp
+++ b/src/Norm/basetest/UITestObjectView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestObjectView.h
+++ b/src/Norm/basetest/UITestObjectView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestSubObject.cpp
+++ b/src/Norm/basetest/UITestSubObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestSubObject.h
+++ b/src/Norm/basetest/UITestSubObject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestSubObjectView.cpp
+++ b/src/Norm/basetest/UITestSubObjectView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/UITestSubObjectView.h
+++ b/src/Norm/basetest/UITestSubObjectView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/main.cpp
+++ b/src/Norm/basetest/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/basetest/main.h
+++ b/src/Norm/basetest/main.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/Attribute.cpp
+++ b/src/Norm/genere/Attribute.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/Attribute.h
+++ b/src/Norm/genere/Attribute.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/AttributeTable.cpp
+++ b/src/Norm/genere/AttributeTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/AttributeTable.h
+++ b/src/Norm/genere/AttributeTable.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/Genere.h
+++ b/src/Norm/genere/Genere.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/GenereAttArrayViewC.cpp
+++ b/src/Norm/genere/GenereAttArrayViewC.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/GenereAttC.cpp
+++ b/src/Norm/genere/GenereAttC.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/GenereAttH.cpp
+++ b/src/Norm/genere/GenereAttH.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/GenereAttViewC.cpp
+++ b/src/Norm/genere/GenereAttViewC.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/GenereAttViewH.cpp
+++ b/src/Norm/genere/GenereAttViewH.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/ManagedObject.cpp
+++ b/src/Norm/genere/ManagedObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/ManagedObject.h
+++ b/src/Norm/genere/ManagedObject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/ManagedObjectTable.cpp
+++ b/src/Norm/genere/ManagedObjectTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/ManagedObjectTable.h
+++ b/src/Norm/genere/ManagedObjectTable.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/QueryServices.cpp
+++ b/src/Norm/genere/QueryServices.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/QueryServices.h
+++ b/src/Norm/genere/QueryServices.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/QueryServicesView.cpp
+++ b/src/Norm/genere/QueryServicesView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/QueryServicesView.h
+++ b/src/Norm/genere/QueryServicesView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/Section.cpp
+++ b/src/Norm/genere/Section.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/Section.h
+++ b/src/Norm/genere/Section.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/SectionTable.cpp
+++ b/src/Norm/genere/SectionTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/SectionTable.h
+++ b/src/Norm/genere/SectionTable.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/TableGenerator.cpp
+++ b/src/Norm/genere/TableGenerator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/TableGenerator.h
+++ b/src/Norm/genere/TableGenerator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/TableServices.cpp
+++ b/src/Norm/genere/TableServices.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/TableServices.h
+++ b/src/Norm/genere/TableServices.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/genere.cpp
+++ b/src/Norm/genere/genere.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/genere/genereattarrayviewH.cpp
+++ b/src/Norm/genere/genereattarrayviewH.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/generetest/Sample.cpp
+++ b/src/Norm/generetest/Sample.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/generetest/Sample.h
+++ b/src/Norm/generetest/Sample.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/generetest/SampleArrayView.cpp
+++ b/src/Norm/generetest/SampleArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/generetest/SampleArrayView.h
+++ b/src/Norm/generetest/SampleArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/generetest/SampleView.cpp
+++ b/src/Norm/generetest/SampleView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/generetest/SampleView.h
+++ b/src/Norm/generetest/SampleView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/generetest/generetest.cpp
+++ b/src/Norm/generetest/generetest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/khiopsdriver_file_null/khiopsdriver_file_null.cpp
+++ b/src/Norm/khiopsdriver_file_null/khiopsdriver_file_null.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/khiopsdriver_file_null/khiopsdriver_file_null.h
+++ b/src/Norm/khiopsdriver_file_null/khiopsdriver_file_null.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample1/main.cpp
+++ b/src/Norm/samples/sample1/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample1/main.h
+++ b/src/Norm/samples/sample1/main.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample2/PRWorker.cpp
+++ b/src/Norm/samples/sample2/PRWorker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample2/PRWorker.h
+++ b/src/Norm/samples/sample2/PRWorker.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample2/PRWorkerView.cpp
+++ b/src/Norm/samples/sample2/PRWorkerView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample2/PRWorkerView.h
+++ b/src/Norm/samples/sample2/PRWorkerView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample2/main.cpp
+++ b/src/Norm/samples/sample2/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample2/main.h
+++ b/src/Norm/samples/sample2/main.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRAddress.cpp
+++ b/src/Norm/samples/sample3/PRAddress.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRAddress.h
+++ b/src/Norm/samples/sample3/PRAddress.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRAddressView.cpp
+++ b/src/Norm/samples/sample3/PRAddressView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRAddressView.h
+++ b/src/Norm/samples/sample3/PRAddressView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRChild.cpp
+++ b/src/Norm/samples/sample3/PRChild.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRChild.h
+++ b/src/Norm/samples/sample3/PRChild.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRChildArrayView.cpp
+++ b/src/Norm/samples/sample3/PRChildArrayView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRChildArrayView.h
+++ b/src/Norm/samples/sample3/PRChildArrayView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRChildView.cpp
+++ b/src/Norm/samples/sample3/PRChildView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRChildView.h
+++ b/src/Norm/samples/sample3/PRChildView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRWorker.cpp
+++ b/src/Norm/samples/sample3/PRWorker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRWorker.h
+++ b/src/Norm/samples/sample3/PRWorker.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRWorkerView.cpp
+++ b/src/Norm/samples/sample3/PRWorkerView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/PRWorkerView.h
+++ b/src/Norm/samples/sample3/PRWorkerView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/main.cpp
+++ b/src/Norm/samples/sample3/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Norm/samples/sample3/main.h
+++ b/src/Norm/samples/sample3/main.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPIFileServerSlave.cpp
+++ b/src/Parallel/PLMPI/PLMPIFileServerSlave.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPIFileServerSlave.h
+++ b/src/Parallel/PLMPI/PLMPIFileServerSlave.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPIMaster.cpp
+++ b/src/Parallel/PLMPI/PLMPIMaster.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPIMaster.h
+++ b/src/Parallel/PLMPI/PLMPIMaster.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPIMasterSlaveTags.h
+++ b/src/Parallel/PLMPI/PLMPIMasterSlaveTags.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPIMessageManager.cpp
+++ b/src/Parallel/PLMPI/PLMPIMessageManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPIMessageManager.h
+++ b/src/Parallel/PLMPI/PLMPIMessageManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPIMsgContext.cpp
+++ b/src/Parallel/PLMPI/PLMPIMsgContext.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPIMsgContext.h
+++ b/src/Parallel/PLMPI/PLMPIMsgContext.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPISlave.cpp
+++ b/src/Parallel/PLMPI/PLMPISlave.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPISlave.h
+++ b/src/Parallel/PLMPI/PLMPISlave.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPISlaveLauncher.cpp
+++ b/src/Parallel/PLMPI/PLMPISlaveLauncher.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPISlaveLauncher.h
+++ b/src/Parallel/PLMPI/PLMPISlaveLauncher.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPISlaveProgressionManager.cpp
+++ b/src/Parallel/PLMPI/PLMPISlaveProgressionManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPISlaveProgressionManager.h
+++ b/src/Parallel/PLMPI/PLMPISlaveProgressionManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPISystemFileDriverRemote.cpp
+++ b/src/Parallel/PLMPI/PLMPISystemFileDriverRemote.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPISystemFileDriverRemote.h
+++ b/src/Parallel/PLMPI/PLMPISystemFileDriverRemote.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPITaskDriver.cpp
+++ b/src/Parallel/PLMPI/PLMPITaskDriver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPITaskDriver.h
+++ b/src/Parallel/PLMPI/PLMPITaskDriver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPITracer.cpp
+++ b/src/Parallel/PLMPI/PLMPITracer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPITracer.h
+++ b/src/Parallel/PLMPI/PLMPITracer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLMPI/PLMPImpi_wrapper.h
+++ b/src/Parallel/PLMPI/PLMPImpi_wrapper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLErrorWithIndex.cpp
+++ b/src/Parallel/PLParallelTask/PLErrorWithIndex.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLErrorWithIndex.h
+++ b/src/Parallel/PLParallelTask/PLErrorWithIndex.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.h
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLIncrementalStats.cpp
+++ b/src/Parallel/PLParallelTask/PLIncrementalStats.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLIncrementalStats.h
+++ b/src/Parallel/PLParallelTask/PLIncrementalStats.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLParallelTask.cpp
+++ b/src/Parallel/PLParallelTask/PLParallelTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLParallelTask.h
+++ b/src/Parallel/PLParallelTask/PLParallelTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLSerializer.cpp
+++ b/src/Parallel/PLParallelTask/PLSerializer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLSerializer.h
+++ b/src/Parallel/PLParallelTask/PLSerializer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLSharedObject.cpp
+++ b/src/Parallel/PLParallelTask/PLSharedObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLSharedObject.h
+++ b/src/Parallel/PLParallelTask/PLSharedObject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLSharedVariable.cpp
+++ b/src/Parallel/PLParallelTask/PLSharedVariable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLSharedVariable.h
+++ b/src/Parallel/PLParallelTask/PLSharedVariable.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLSharedVector.cpp
+++ b/src/Parallel/PLParallelTask/PLSharedVector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLSharedVector.h
+++ b/src/Parallel/PLParallelTask/PLSharedVector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_HostResource.cpp
+++ b/src/Parallel/PLParallelTask/PLShared_HostResource.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_HostResource.h
+++ b/src/Parallel/PLParallelTask/PLShared_HostResource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_ObjectArray.cpp
+++ b/src/Parallel/PLParallelTask/PLShared_ObjectArray.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_ObjectDictionary.cpp
+++ b/src/Parallel/PLParallelTask/PLShared_ObjectDictionary.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_ObjectList.cpp
+++ b/src/Parallel/PLParallelTask/PLShared_ObjectList.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_ResourceRequirement.cpp
+++ b/src/Parallel/PLParallelTask/PLShared_ResourceRequirement.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_ResourceRequirement.h
+++ b/src/Parallel/PLParallelTask/PLShared_ResourceRequirement.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_SampleObject.cpp
+++ b/src/Parallel/PLParallelTask/PLShared_SampleObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_SampleObject.h
+++ b/src/Parallel/PLParallelTask/PLShared_SampleObject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_TaskResourceGrant.cpp
+++ b/src/Parallel/PLParallelTask/PLShared_TaskResourceGrant.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLShared_TaskResourceGrant.h
+++ b/src/Parallel/PLParallelTask/PLShared_TaskResourceGrant.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLSlaveState.cpp
+++ b/src/Parallel/PLParallelTask/PLSlaveState.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLSlaveState.h
+++ b/src/Parallel/PLParallelTask/PLSlaveState.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLTaskDriver.cpp
+++ b/src/Parallel/PLParallelTask/PLTaskDriver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLTaskDriver.h
+++ b/src/Parallel/PLParallelTask/PLTaskDriver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLTracer.cpp
+++ b/src/Parallel/PLParallelTask/PLTracer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/PLTracer.h
+++ b/src/Parallel/PLParallelTask/PLTracer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/RMParallelResourceDriver.cpp
+++ b/src/Parallel/PLParallelTask/RMParallelResourceDriver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/RMParallelResourceDriver.h
+++ b/src/Parallel/PLParallelTask/RMParallelResourceDriver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/RMParallelResourceManager.cpp
+++ b/src/Parallel/PLParallelTask/RMParallelResourceManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/RMParallelResourceManager.h
+++ b/src/Parallel/PLParallelTask/RMParallelResourceManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/RMTaskResourceGrant.cpp
+++ b/src/Parallel/PLParallelTask/RMTaskResourceGrant.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/RMTaskResourceGrant.h
+++ b/src/Parallel/PLParallelTask/RMTaskResourceGrant.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/RMTaskResourceRequirement.cpp
+++ b/src/Parallel/PLParallelTask/RMTaskResourceRequirement.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLParallelTask/RMTaskResourceRequirement.h
+++ b/src/Parallel/PLParallelTask/RMTaskResourceRequirement.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEFileSearchTask.cpp
+++ b/src/Parallel/PLSamples/PEFileSearchTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEFileSearchTask.h
+++ b/src/Parallel/PLSamples/PEFileSearchTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEHelloWorldTask.cpp
+++ b/src/Parallel/PLSamples/PEHelloWorldTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEHelloWorldTask.h
+++ b/src/Parallel/PLSamples/PEHelloWorldTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEIOParallelTestTask.cpp
+++ b/src/Parallel/PLSamples/PEIOParallelTestTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEIOParallelTestTask.h
+++ b/src/Parallel/PLSamples/PEIOParallelTestTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PELullaby.cpp
+++ b/src/Parallel/PLSamples/PELullaby.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PELullabyTask.h
+++ b/src/Parallel/PLSamples/PELullabyTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEPi.cpp
+++ b/src/Parallel/PLSamples/PEPi.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEPi.h
+++ b/src/Parallel/PLSamples/PEPi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEPiTask.cpp
+++ b/src/Parallel/PLSamples/PEPiTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEPiTask.h
+++ b/src/Parallel/PLSamples/PEPiTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEPiView.cpp
+++ b/src/Parallel/PLSamples/PEPiView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEPiView.h
+++ b/src/Parallel/PLSamples/PEPiView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEProgressionTask.cpp
+++ b/src/Parallel/PLSamples/PEProgressionTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEProgressionTask.h
+++ b/src/Parallel/PLSamples/PEProgressionTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEProtocolTestTask.cpp
+++ b/src/Parallel/PLSamples/PEProtocolTestTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEProtocolTestTask.h
+++ b/src/Parallel/PLSamples/PEProtocolTestTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PESerializerLongTestTask.cpp
+++ b/src/Parallel/PLSamples/PESerializerLongTestTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PESerializerLongTestTask.h
+++ b/src/Parallel/PLSamples/PESerializerLongTestTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PESerializerTestTask.cpp
+++ b/src/Parallel/PLSamples/PESerializerTestTask.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PESerializerTestTask.h
+++ b/src/Parallel/PLSamples/PESerializerTestTask.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEShared_SampleObject.cpp
+++ b/src/Parallel/PLSamples/PEShared_SampleObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLSamples/PEShared_SampleObject.h
+++ b/src/Parallel/PLSamples/PEShared_SampleObject.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLTest/PLTest.cpp
+++ b/src/Parallel/PLTest/PLTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/PLTest/PLTest.h
+++ b/src/Parallel/PLTest/PLTest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/RMResourceManager/RMResourceConstraints.cpp
+++ b/src/Parallel/RMResourceManager/RMResourceConstraints.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/RMResourceManager/RMResourceConstraints.h
+++ b/src/Parallel/RMResourceManager/RMResourceConstraints.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/RMResourceManager/RMResourceManager.cpp
+++ b/src/Parallel/RMResourceManager/RMResourceManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/RMResourceManager/RMResourceManager.h
+++ b/src/Parallel/RMResourceManager/RMResourceManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/RMResourceManager/RMResourceSystem.cpp
+++ b/src/Parallel/RMResourceManager/RMResourceSystem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/RMResourceManager/RMResourceSystem.h
+++ b/src/Parallel/RMResourceManager/RMResourceSystem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/RMResourceManager/RMStandardResourceDriver.cpp
+++ b/src/Parallel/RMResourceManager/RMStandardResourceDriver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/src/Parallel/RMResourceManager/RMStandardResourceDriver.h
+++ b/src/Parallel/RMResourceManager/RMStandardResourceDriver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/KNITest/KNITest.cpp
+++ b/test/KNITest/KNITest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/KNITest/KNITest.h
+++ b/test/KNITest/KNITest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/Learning/KWClass_test.cpp
+++ b/test/Learning/KWClass_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/Norm/InputBufferedFile_test.cpp
+++ b/test/Norm/InputBufferedFile_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/Parallel-mpi/PEProtocolTest.cpp
+++ b/test/Parallel-mpi/PEProtocolTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/Parallel-mpi/main.cpp
+++ b/test/Parallel-mpi/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/Parallel/PLSerializer_test.cpp
+++ b/test/Parallel/PLSerializer_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/Utils/MpiEnvironment.h
+++ b/test/Utils/MpiEnvironment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/Utils/ParallelTest.h
+++ b/test/Utils/ParallelTest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/Utils/TestServices.cpp
+++ b/test/Utils/TestServices.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 

--- a/test/Utils/TestServices.h
+++ b/test/Utils/TestServices.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Orange. All rights reserved.
+// Copyright (c) 2024 Orange. All rights reserved.
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 


### PR DESCRIPTION
This has to be done every begining of year

Most of the job should be done using git command
- pre-commit run --all-files

Search 2023 in source files to find potential remaining cases (ex: licence, README.txt, histogram tool...)