### PR TITLE
KWDatabaseTask fewer interruption checks

### DIFF
--- a/src/Learning/KWDataUtils/KWDatabaseTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTask.cpp
@@ -970,6 +970,13 @@ boolean KWDatabaseTask::SlaveProcessExploitDatabase()
 				// corrects)
 				if (GetTaskIndex() == 0)
 					sourceDatabase->DisplayReadTaskProgressionLabel(lRecordNumber, lObjectNumber);
+
+				// Arret si interruption utilisateur
+				if (TaskProgression::IsInterruptionRequested())
+				{
+					bOk = false;
+					break;
+				}
 			}
 
 			// Lecture (la gestion de l'avancement se fait dans la methode Read)
@@ -986,13 +993,6 @@ boolean KWDatabaseTask::SlaveProcessExploitDatabase()
 				delete kwoObject;
 				if (not bOk)
 					break;
-			}
-			// Arret si interruption utilisateur (deja detectee avant et ayant donc rendu un objet NULL)
-			else if (TaskProgression::IsInterruptionRequested())
-			{
-				assert(kwoObject == NULL);
-				bOk = false;
-				break;
 			}
 
 			// Arret si erreur de lecture


### PR DESCRIPTION
The interruption check method TaskProgression::IsInterruptionRequested was called at every Read() call for the input database. Now they are made less often by pairing it with a call to
PeriodicTest::IsTestAllowed.