### PR TITLE
Add release to package build CICD

### DIFF
--- a/.github/workflows/build-linux-pack-containers.yml
+++ b/.github/workflows/build-linux-pack-containers.yml
@@ -1,9 +1,9 @@
 ---
-name: Build Linux containers for packaging
+name: Dev Linux Images
 on:
   workflow_dispatch:
 jobs:
-  build-packaging-container:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -11,6 +11,7 @@ jobs:
         os:
           - debian10
           - debian11
+          - debian12
           - rocky8
           - rocky9
           - ubuntu18.04

--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [debian10, ubuntu22.04, ubuntu20.04]
+        os: [debian10, debian11, debian12, ubuntu22.04, ubuntu20.04]
     container:
       image: ghcr.io/khiopsml/khiops/khiopsdev-${{ matrix.os }}:latest
     steps:
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['debian:10', 'ubuntu:22.04', 'ubuntu:20.04']
+        os: ['debian:10', 'debian:11', 'debian:12', 'ubuntu:22.04', 'ubuntu:20.04']
     container:
       image: ${{ matrix.os }}
     steps:
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [debian10, ubuntu22.04, ubuntu20.04]
+        os: [debian10, debian11, debian12, ubuntu22.04, ubuntu20.04]
     container:
       image: ghcr.io/khiopsml/khiops/khiopsdev-${{ matrix.os }}:latest
     steps:

--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
     paths: ['**CMakeLists.txt', '**.cmake']
+# Cancel any ongoing run of this workflow on the same PR or ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-deb-package:
     runs-on: ubuntu-latest

--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -1,15 +1,20 @@
 ---
-name: Create Debian package
+name: DEB Packages
 on:
   workflow_dispatch:
   pull_request:
-    paths: ['**CMakeLists.txt', '**.cmake']
+    paths:
+      - '**CMakeLists.txt'
+      - '**.cmake'
+      - .github/workflows/pack-debian.yml
+  push:
+    tags: [v*]
 # Cancel any ongoing run of this workflow on the same PR or ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
-  build-deb-package:
+  build:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -22,7 +27,7 @@ jobs:
       image: ghcr.io/khiopsml/khiops/khiopsdev-${{ matrix.os }}:latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set environment variables
         run: |
           source /etc/os-release
@@ -46,17 +51,21 @@ jobs:
             mv -v $filename ${filename%_*}-${VERSION_CODENAME}.${filename##*_}
           done
       - name: Upload the packages as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ID }}-${{ env.VERSION_CODENAME }}
+          # We add a `deb-` prefix so we can later recover all artifacts with the pattern `deb-*`
+          # Note: The more natural pattern `*-deb` or `*` does not work
+          name: deb-${{ env.ID }}-${{ env.VERSION_CODENAME }}
           path: build/linux-gcc-release/packages/*.deb
+          if-no-files-found: error
   # Test packages on a brand new runner to check:
   # - the installation process (including dependencies installation)
   # - that executable works (run with -v)
   # - that it executes a small test
-  test-deb-package:
-    needs: build-deb-package
+  test:
+    needs: build
     runs-on: ubuntu-latest
+    continue-on-error: true
     defaults:
       run:
         shell: bash
@@ -68,16 +77,16 @@ jobs:
       image: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set environment variables
         run: |
           source /etc/os-release
           echo "ID=$ID" >> "$GITHUB_ENV"
           echo "VERSION_CODENAME=$VERSION_CODENAME" >> "$GITHUB_ENV"
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ID }}-${{ env.VERSION_CODENAME }}
+          name: deb-${{ env.ID }}-${{ env.VERSION_CODENAME }}
           path: artifacts
       - name: Install Khiops core
         run: |
@@ -99,9 +108,10 @@ jobs:
           khiops_coclustering -v
       - name: Test Khiops installation
         uses: ./.github/actions/test-khiops-install
-  test-kni-deb:
-    needs: build-deb-package
+  test-kni:
+    needs: build
     runs-on: ubuntu-latest
+    continue-on-error: true
     defaults:
       run:
         shell: bash
@@ -114,13 +124,13 @@ jobs:
     steps:
       - name: Put OS info on the environment
         run: |
-          source /etc/os-release 
+          source /etc/os-release
           echo "ID=$ID" >> "$GITHUB_ENV"
           echo "VERSION_CODENAME=$VERSION_CODENAME" >> "$GITHUB_ENV"
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ID }}-${{ env.VERSION_CODENAME }}
+          name: deb-${{ env.ID }}-${{ env.VERSION_CODENAME }}
           path: artifacts
       - name: Install KNI Package
         run: |
@@ -128,8 +138,42 @@ jobs:
           dpkg -i ./artifacts/kni* || true
           apt-get -f install -y
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           sparse-checkout: .github
       - name: Test KNI package
         uses: ./.github/actions/test-kni
+  # Release is only executed on tags
+  release:
+    if: github.ref_type == 'tag'
+    # We release even if the tests fail (we delete from the release whatever fails manually)
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # See the upload-artifact step in the build job for the explanation of this pattern
+          pattern: deb-*
+          merge-multiple: true
+      - name: Rename packages with tag version
+        run: |
+          SOURCE_VERSION=$(./scripts/khiops-version)
+          for PKG_FILE in *.deb
+          do
+            NEW_PKG_FILE=$(echo $PKG_FILE | sed "s/_${SOURCE_VERSION}-/_${{ github.ref_name }}-/")
+            mv $PKG_FILE $NEW_PKG_FILE
+          done
+      - name: Upload packages to the release
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          allowUpdates: true
+          artifacts: '*.deb'
+          draft: false
+          makeLatest: false
+          prerelease: true
+          updateOnlyUnreleased: true

--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -1,5 +1,5 @@
 ---
-name: Build NSIS Windows installer
+name: Windows Installer
 on:
   workflow_dispatch:
   pull_request:
@@ -7,6 +7,7 @@ on:
       - '**CMakeLists.txt'
       - packaging/windows/nsis/*.nsh
       - packaging/windows/nsis/*.nsi
+      - .github/workflows/pack-nsis.yml
   push:
     tags: [v*]
 # Cancel any ongoing run of this workflow on the same PR or ref
@@ -15,10 +16,9 @@ concurrency:
     }}
   cancel-in-progress: true
 jobs:
-  build-nsis-installer:
+  build:
     outputs:
-      khiops-package-version: ${{ steps.get-version.outputs.khiops-package-version }}
-    name: Build NSIS Windows installer
+      khiops-version: ${{ steps.get-version.outputs.khiops-version }}
     runs-on: windows-latest
     steps:
       - name: Obtain checkout ref
@@ -35,7 +35,7 @@ jobs:
           echo "CHECKOUT_REF=$CHECKOUT_REF" >> $GITHUB_ENV
           echo "Checkout ref: $CHECKOUT_REF"
       - name: Checkout sources
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.CHECKOUT_REF }}
       - name: Put the package version on the environment and output
@@ -43,13 +43,13 @@ jobs:
         shell: bash
         run: |
           # Build the versions
-          KHIOPS_PACKAGE_VERSION="$(./scripts/khiops-package-version ${{ env.CHECKOUT_REF }})"
-          KHIOPS_PACKAGE_REDUCED_VERSION="$(echo $KHIOPS_PACKAGE_VERSION | cut -d'-' -f1)"
-          echo "KHIOPS_PACKAGE_VERSION=$KHIOPS_PACKAGE_VERSION" >> "$GITHUB_ENV"
-          echo "KHIOPS_PACKAGE_REDUCED_VERSION=$KHIOPS_PACKAGE_REDUCED_VERSION" >> "$GITHUB_ENV"
-          echo "khiops-package-version=$KHIOPS_PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          KHIOPS_VERSION="$(./scripts/khiops-version)"
+          KHIOPS_REDUCED_VERSION="$(echo $KHIOPS_VERSION | cut -d'-' -f1)"
+          echo "KHIOPS_VERSION=$KHIOPS_VERSION" >> "$GITHUB_ENV"
+          echo "KHIOPS_REDUCED_VERSION=$KHIOPS_REDUCED_VERSION" >> "$GITHUB_ENV"
+          echo "khiops-version=$KHIOPS_VERSION" >> "$GITHUB_OUTPUT"
       - name: Download Windows install assets
-        uses: robinraju/release-downloader@v1.8
+        uses: robinraju/release-downloader@v1.9
         with:
           repository: khiopsml/khiops-win-install-assets
           latest: true
@@ -59,7 +59,7 @@ jobs:
           assets_tar_gz=$(ls khiops-win-install-assets*.tar.gz)
           tar -zxvf "$assets_tar_gz"
           cat assets/assets-info.env >> "$GITHUB_ENV"
-      - name: Build Khiops binaries
+      - name: Build the Khiops Binaries
         uses: ./.github/actions/build-khiops
         with:
           preset-name: windows-msvc-release
@@ -70,8 +70,8 @@ jobs:
         run: |-
           cd ./packaging/windows/nsis
           makensis `
-            /DKHIOPS_VERSION=${{ env.KHIOPS_PACKAGE_VERSION }} `
-            /DKHIOPS_REDUCED_VERSION=${{ env.KHIOPS_PACKAGE_REDUCED_VERSION }} `
+            /DKHIOPS_VERSION=${{ env.KHIOPS_VERSION }} `
+            /DKHIOPS_REDUCED_VERSION=${{ env.KHIOPS_REDUCED_VERSION }} `
             /DKHIOPS_WINDOWS_BUILD_DIR=..\..\..\build\windows-msvc-release `
             /DJRE_INSTALLER_PATH=..\..\..\assets\${{ env.JRE_FILENAME }} `
             /DJRE_VERSION=${{ env.JRE_VERSION }} `
@@ -82,20 +82,19 @@ jobs:
             /DKHIOPS_SAMPLES_DIR=..\..\..\assets\samples `
             /DKHIOPS_DOC_DIR=..\..\..\assets\doc `
             khiops.nsi
-      - name: Upload installer as an artifact
-        uses: actions/upload-artifact@v3.1.2
+      - name: Upload the Installer Artifact
+        uses: actions/upload-artifact@v4
         with:
-          name: khiops-installer
-          path: ./packaging/windows/nsis/khiops-${{ env.KHIOPS_PACKAGE_VERSION }}-setup.exe
-  test-nsis-installer:
-    name: Test NSIS Windows installer
-    needs: build-nsis-installer
+          name: khiops-setup
+          path: ./packaging/windows/nsis/khiops-${{ env.KHIOPS_VERSION }}-setup.exe
+  test:
+    needs: build
     runs-on: windows-2019
     steps:
       - name: Download NSIS installer artifact
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
-          name: khiops-installer
+          name: khiops-setup
       - name: Install Khiops
         shell: pwsh
         run: |
@@ -103,7 +102,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $ProgressPreference = 'SilentlyContinue'
           Start-Process `
-            -FilePath .\khiops-${{ needs.build-nsis-installer.outputs.khiops-package-version }}-setup.exe `
+            -FilePath .\khiops-${{ needs.build.outputs.khiops-version }}-setup.exe `
             -ArgumentList '/S' `
             -Wait
           # Add Khiops and MPI to the path
@@ -112,6 +111,34 @@ jobs:
           echo ${Env:GITHUB_ENV}
           type ${Env:GITHUB_ENV}
       - name: Checkout the khiops sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Test the installation
         uses: ./.github/actions/test-khiops-install
+  # Release is only executed on tags
+  release:
+    if: github.ref_type == 'tag'
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download NSIS installer artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: khiops-setup
+      - name: Rename packages with tag version
+        run: |
+          SOURCE_VERSION="${{ needs.build.outputs.khiops-version }}"
+          PKG_FILE=$(ls *-setup.exe)
+          NEW_PKG_FILE=$(echo $PKG_FILE | sed "s/-${SOURCE_VERSION}-/-${{ github.ref_name }}-/")
+          mv $PKG_FILE $NEW_PKG_FILE
+      - name: Upload NSIS installer to the release
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          allowUpdates: true
+          artifacts: khiops-*-setup.exe
+          body: '**For testing purposes only**'
+          draft: false
+          makeLatest: false
+          prerelease: true
+          updateOnlyUnreleased: true

--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -9,6 +9,11 @@ on:
       - packaging/windows/nsis/*.nsi
   push:
     tags: [v*]
+# Cancel any ongoing run of this workflow on the same PR or ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
+    }}
+  cancel-in-progress: true
 jobs:
   build-nsis-installer:
     outputs:

--- a/.github/workflows/pack-rpm.yml
+++ b/.github/workflows/pack-rpm.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   pull_request:
     paths: ['**CMakeLists.txt', '**.cmake']
+# Cancel any ongoing run of this workflow on the same PR or ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
+    }}
+  cancel-in-progress: true
 jobs:
   build-rpm-package:
     runs-on: ubuntu-latest

--- a/.github/workflows/pack-rpm.yml
+++ b/.github/workflows/pack-rpm.yml
@@ -1,16 +1,18 @@
 ---
-name: Create RPM package
+name: RPM Packages
 on:
   workflow_dispatch:
   pull_request:
-    paths: ['**CMakeLists.txt', '**.cmake']
+    paths: ['**CMakeLists.txt', '**.cmake', .github/workflows/pack-rpm.yml]
+  push:
+    tags: [v*]
 # Cancel any ongoing run of this workflow on the same PR or ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
     }}
   cancel-in-progress: true
 jobs:
-  build-rpm-package:
+  build:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -23,8 +25,8 @@ jobs:
       image: ghcr.io/khiopsml/khiops/khiopsdev-${{ matrix.os }}:latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
-      - name: set environment variables
+        uses: actions/checkout@v4
+      - name: Put OS info on the environment
         run: |
           source /etc/os-release
           echo "ID=$ID" >> "$GITHUB_ENV"
@@ -53,18 +55,21 @@ jobs:
             mv -v $filename ${filename%.${ARCH}*}.${{ env.VERSION_CODENAME }}.${ARCH}.rpm
           done
       - name: Upload the packages as artifacts
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ID }}-${{ env.VERSION_CODENAME }}
+          # We add a `rpm-` prefix so we can later recover all artifacts with the pattern `rpm-*`
+          # Note: The more natural pattern `*-rpm` or `*` does not work
+          name: rpm-${{ env.ID }}-${{ env.VERSION_CODENAME }}
           path: build/linux-gcc-release/packages/*.rpm
           if-no-files-found: error
   # Test packages on a brand new runner to check:
   # - the installation process (including dependencies installation)
   # - that executable works (run with -v)
   # - that it executes a small test
-  test-rpm-package:
-    needs: build-rpm-package
+  test:
+    needs: build
     runs-on: ubuntu-latest
+    continue-on-error: true
     defaults:
       run:
         shell: bash
@@ -76,7 +81,7 @@ jobs:
       image: rockylinux:${{ matrix.rocky_version }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set environment variables
         run: |
           source /etc/os-release
@@ -84,9 +89,9 @@ jobs:
           VERSION=$(echo $PLATFORM_ID | cut -d":" -f2)
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ID }}-${{ env.VERSION }}
+          name: rpm-${{ env.ID }}-${{ env.VERSION }}
           path: artifacts
       - run: yum update -y
       - name: Install Khiops core
@@ -97,9 +102,10 @@ jobs:
           yum install -y ./artifacts/khiops-*
       - name: Test Khiops installation
         uses: ./.github/actions/test-khiops-install
-  test-kni-rpm:
-    needs: build-rpm-package
+  test-kni:
+    needs: build
     runs-on: ubuntu-latest
+    continue-on-error: true
     defaults:
       run:
         shell: bash
@@ -117,17 +123,52 @@ jobs:
           VERSION=$(echo $PLATFORM_ID | cut -d":" -f2)
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ID }}-${{ env.VERSION }}
+          name: rpm-${{ env.ID }}-${{ env.VERSION }}
           path: artifacts
-      - name: Install KNI package
+      - name: Install KNI Package
         run: |
           yum update -y
           yum install -y ./artifacts/kni*
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           sparse-checkout: .github
-      - name: Test KNI package installation
+      - name: Test KNI package
         uses: ./.github/actions/test-kni
+  # Release is only executed on tags
+  release:
+    if: github.ref_type == 'tag'
+    # We release even if the tests fail (we delete from the release whatever fails manually)
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # See the upload-artifact step in the build job for the explanation of this pattern
+          pattern: rpm-*
+          merge-multiple: true
+      - name: Rename packages with tag version
+        run: |
+          SOURCE_VERSION=$(./scripts/khiops-version)
+          for PKG_FILE in *.rpm
+          do
+            NEW_PKG_FILE=$(echo $PKG_FILE | sed "s/-${SOURCE_VERSION}-/-${{ github.ref_name }}-/")
+            mv $PKG_FILE $NEW_PKG_FILE
+          done
+      - name: Upload packages to the release
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          allowUpdates: true
+          artifacts: '*.rpm'
+          body: '**For testing purposes only**'
+          draft: false
+          makeLatest: false
+          prerelease: true
+          updateOnlyUnreleased: true

--- a/.github/workflows/run-standard-tests.yml
+++ b/.github/workflows/run-standard-tests.yml
@@ -19,6 +19,11 @@ on:
       - src/**.lex
       - src/**.yac
       - test/LearningTest/**
+# Cancel any ongoing run of this workflow on the same PR or ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
+    }}
+  cancel-in-progress: true
 env:
   KhiopsBatchMode: true
 jobs:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -14,6 +14,11 @@ on:
       - src/**.yac
       - test/**.h
       - test/**.cpp
+# Cancel any ongoing run of this workflow on the same PR or ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
+    }}
+  cancel-in-progress: true
 jobs:
   run-unit-tests:
     defaults:

--- a/packaging/dockerfiles/Dockerfile.debian12
+++ b/packaging/dockerfiles/Dockerfile.debian12
@@ -1,0 +1,24 @@
+FROM debian:12
+LABEL maintainer="khiops.team@orange.com"
+LABEL description="Container with the dependencies to build and package Khiops"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN true \
+  && apt-get -y update \
+  && apt-get -y --no-install-recommends install \
+    build-essential \
+    cmake \
+    coreutils \
+    debhelper \
+    default-jdk \
+    devscripts \
+    fakeroot \
+    libmpich-dev \
+    nano \
+    ninja-build \
+    wget \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get -y remove wget \
+  && apt-get clean \
+  && true


### PR DESCRIPTION
commit 530ec9e7cfbe9865743e94b3b3fd0258e3c60bb3 (HEAD -> 159-make-cicd-package-builders-upload-to-a-release, tag: v10.2.0-rc1, origin/159-make-cicd-package-builders-upload-to-a-release)
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Wed Feb 21 09:53:57 2024 +0100

    Add debian 11 and 12 to build

commit a92a8ef74fb24a8e5982dc31268d9ec6e0f0a283
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Mon Feb 19 17:26:44 2024 +0100

    Add release job to packaging CICD workflows

    We add a release job that is only executed when the workflow executed on
    a tag (either by pushing or by manual execution). The workflow creates
    the release as a pre-release so it does not disturb the current stable
    one in the github page. The workflow may be executed many times as long
    as the release stays in the "pre-release" state.

    In the release step, we rename the package file names so their version
    match the tag. For now, the maintainers must check the coherence of the
    "source version" (that in KWKhiopsVersion.cpp) when creating a release.

    The release step depends only ond the build step and the tests steps
    are now allowed to fail. It is to maintainers to clean any defectiva
    package from a final release.

    Other opportunistic changes in this commit:
    - Update to version 4 of actions checkout, upload-artifact and
      download-artifact. This is to avoid deprecation warnings and in the
      case of dowload-artifact it even necessary as we use the new "pattern"
      option.
    - Simplify names of workflows and jobs so they are better seen in the
      "checks" box and tab of a PR. The verbose steps names are kept.  This
      is to achieve a good compromise between legibility in the GitHub webUI
      and auto-documentation.

commit e7003a57e476b73b86b08e54a4a6778a640cadf3
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Tue Feb 20 08:37:29 2024 +0100

    Add concurrency rule to workflows that compile

    This allows to cancel any ongoing run of the workflow if it is in the
    same PR or git reference. This is to enable faster development cycles in
    the CI by not having to cancel runs manually.