### PR TITLE
Improve stability of coclustering IV results

### DIFF
--- a/src/Learning/KWDataPreparation/KWDataGrid.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGrid.cpp
@@ -4738,8 +4738,9 @@ int KWDGValueCompareTypicality(const void* elem1, const void* elem2)
 	return value1->CompareTypicality(value2);
 }
 
-int KWSortableObjectComparePartValue(const void* elem1, const void* elem2)
+int KWSortableObjectCompareValue(const void* elem1, const void* elem2)
 {
+	int nCompare;
 	KWDGValue* value1;
 	KWDGValue* value2;
 
@@ -4750,7 +4751,14 @@ int KWSortableObjectComparePartValue(const void* elem1, const void* elem2)
 	value1 = cast(KWDGValue*, cast(KWSortableObject*, *(Object**)elem1)->GetSortValue());
 	value2 = cast(KWDGValue*, cast(KWSortableObject*, *(Object**)elem2)->GetSortValue());
 
-	return value1->CompareValue(value2);
+	// Comparaison sur la valeur
+	nCompare = value1->CompareValue(value2);
+
+	// Comparaison sur l'index si egal
+	if (nCompare == 0)
+		nCompare = cast(KWSortableObject*, *(Object**)elem1)->GetIndex() -
+			   cast(KWSortableObject*, *(Object**)elem2)->GetIndex();
+	return nCompare;
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/Learning/KWDataPreparation/KWDataGrid.h
+++ b/src/Learning/KWDataPreparation/KWDataGrid.h
@@ -1070,7 +1070,7 @@ protected:
 
 //////////////////////////////////////////////////////////////////////////////
 // Classe KWDGValue
-// Classe virtuelle pour mutualiser la gestion des valeur de type Symbol ou VarPart
+// Classe virtuelle pour mutualiser la gestion des valeurs de type Symbol ou VarPart
 class KWDGValue : public Object
 {
 public:
@@ -1147,8 +1147,9 @@ int KWDGValueCompareFrequency(const void* elem1, const void* elem2);
 // Comparaison de deux typicalite
 int KWDGValueCompareTypicality(const void* elem1, const void* elem2);
 
-// Comparaison de deux objets KWSortableObject contenant des KWDGValue, par valeur
-int KWSortableObjectComparePartValue(const void* elem1, const void* elem2);
+// Comparaison de deux objets KWSortableObject contenant des KWDGValue, par valeur puis par index
+// Permet un comparaison generique pour des valeurs de type Symbol ou VarPart
+int KWSortableObjectCompareValue(const void* elem1, const void* elem2);
 
 //////////////////////////////////////////////////////////////////////////////
 // Classe KWDGSymbolValueSet

--- a/src/Learning/MODL/MODL.cpp
+++ b/src/Learning/MODL/MODL.cpp
@@ -15,7 +15,7 @@ void SetWindowsDebugDir(const ALString& sDatasetFamily, const ALString& sDataset
 	// A parametrer pour chaque utilisateur
 	// Devra etre fait plus proprement quand tout l'equipe sera sur git, par exemple via une variable
 	// d'environnement et quelques commentaires clairs
-	sUserRootPath = "D:/Users/miib6422/Documents/boullema/LearningTest/TestKhiops/";
+	sUserRootPath = "D:/Users/miib6422/Documents/boullema/LearningTest.V10.5.0-a1/LearningTest/TestKhiops/";
 
 	// Pour permettre de continuer a utiliser LearningTest, on ne fait rien s'il y a deja un fichier test.prm
 	// dans le repertoire courante
@@ -37,8 +37,7 @@ int main(int argc, char** argv)
 
 	// Choix du repertoire de lancement pour le debugage sous Windows (a commenter apres fin du debug)
 	// SetWindowsDebugDir("Standard", "IrisLight");
-	// SetWindowsDebugDir("Standard", "Iris2D");
-	SetWindowsDebugDir("BugsMultiTables", "BugUnsortedRootTable");
+	// SetWindowsDebugDir("Standard", "IrisU2D");
 
 	// Parametrage des logs memoires depuis les variables d'environnement, pris en compte dans KWLearningProject
 	//   KhiopsMemStatsLogFileName, KhiopsMemStatsLogFrequency, KhiopsMemStatsLogToCollect

--- a/src/Learning/MODL_Coclustering/MODL_Coclustering.cpp
+++ b/src/Learning/MODL_Coclustering/MODL_Coclustering.cpp
@@ -15,7 +15,7 @@ void SetWindowsDebugDir(const ALString& sDatasetFamily, const ALString& sDataset
 	// A parametrer pour chaque utilisateur
 	// Devra etre fait plus proprement quand tout l'equipe sera sur git, par exemple via une variable
 	// d'environnement et quelques commentaires clairs
-	sUserRootPath = "D:/Users/miib6422/Documents/boullema/LearningTest/TestCoclustering/";
+	sUserRootPath = "D:/Users/miib6422/Documents/boullema/LearningTest.V10.5.0-a1/LearningTest/TestCoclustering/";
 
 	// Pour permettre de continuer a utiliser LearningTest, on ne fait rien s'il y a deja un fichier test.prm
 	// dans le repertoire courante


### PR DESCRIPTION
La stabilite des resultats d'analyse bivariee et plus generalement de coclustering
 a ete mise en place recemment pour les tests massifs de la version 10.2 via LearningTest.
Lors du merge de dev-v11, cette stabilisation a ete reportee. Il s'agit de l'extension de cette stabilisation au cas du coclustering IV

Methodes principales impactees:
- KWDatagrid, KWSortableObjectComparePartValue -> KWSortableObjectCompareValue
  - methode prenant en compte la claxsse virtuelle KWDGValue pour les valeurs de type Symbol ou VarPartK
  - prise en compte de l'index aleatoire en criter de tri secondaire
- KWDataGridManager::SortAttributePartsByTargetGroups
  - generalisation de la perturbation aleatoire au cas IV
  - implementation generique unique

Tests sur tout LearningTest