### PR TITLE
141 investigate the impact of pairing taskprogressionisinterruptrequested with periodictestinterruptionistestallowed

### DIFF
--- a/src/Learning/DTForest/DTGrouperMODLOptimization.cpp
+++ b/src/Learning/DTForest/DTGrouperMODLOptimization.cpp
@@ -1341,7 +1341,6 @@ void DTGrouperMODL::FastPostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequ
 	double dBestDeltaCost;
 	double dBestInDeltaCost;
 	int nBestInGroup;
-	PeriodicTest periodicTestOptimize;
 
 	require(kwftSource != NULL);
 	require(kwftTarget != NULL);
@@ -1388,7 +1387,7 @@ void DTGrouperMODL::FastPostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequ
 		nStepNumber++;
 
 		// Test si arret de tache demandee
-		if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+		if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 			break;
 
 		// Perturbation aleatoire des index de modalites et de groupes
@@ -1420,7 +1419,7 @@ void DTGrouperMODL::FastPostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequ
 				nInGroup = ivGroupIndexes.GetAt((nStart + n2) % nGroupNumber);
 
 				// Test si arret de tache demandee
-				if (periodicTestOptimize.IsTestAllowed(0) and
+				if (TaskProgression::IsRefreshNecessary() and
 				    TaskProgression::IsInterruptionRequested())
 					break;
 
@@ -1454,7 +1453,7 @@ void DTGrouperMODL::FastPostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequ
 			}
 
 			// Test si arret de tache demandee
-			if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+			if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 				break;
 
 			// On effectue si necessaire le meilleur transfert de groupe
@@ -1529,7 +1528,6 @@ void DTGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 	double dBestDeltaCost;
 	double dBestInDeltaCost;
 	int nBestInGroup;
-	PeriodicTest periodicTestOptimize;
 	POSITION position;
 	KWFrequencyVector* frequencyVector;
 	int nGarbageModalityNumber;
@@ -1603,7 +1601,7 @@ void DTGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 		nStepNumber++;
 
 		// Test si arret de tache demandee
-		if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+		if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 			break;
 
 		// Perturbation aleatoire des index de modalites et de groupes
@@ -1641,7 +1639,7 @@ void DTGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 				nInGroup = ivGroupIndexes.GetAt((nStart + n2) % nGroupNumber);
 
 				// Test si arret de tache demandee
-				if (periodicTestOptimize.IsTestAllowed(0) and
+				if (TaskProgression::IsRefreshNecessary() and
 				    TaskProgression::IsInterruptionRequested())
 					break;
 
@@ -1806,7 +1804,7 @@ void DTGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 			}
 
 			// Test si arret de tache demandee
-			if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+			if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 				break;
 
 			// On effectue si necessaire le meilleur transfert de groupe

--- a/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.cpp
+++ b/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.cpp
@@ -297,7 +297,6 @@ boolean KDTextTokenSampleCollectionTask::SequentialCollectTokenSamples(const KWD
 boolean KDTextTokenSampleCollectionTask::AnalyseDatabase(KWDatabase* database, ObjectArray* oaTextTokenizers)
 {
 	boolean bOk = true;
-	PeriodicTest periodicTestInterruption;
 	KWObject* kwoObject;
 	longint lObjectNumber;
 	longint lRecordNumber;
@@ -356,7 +355,7 @@ boolean KDTextTokenSampleCollectionTask::AnalyseDatabase(KWDatabase* database, O
 			}
 
 			// Suivi de la tache
-			if (periodicTestInterruption.IsTestAllowed(lRecordNumber))
+			if (TaskProgression::IsRefreshNecessary())
 				TaskProgression::DisplayProgression((int)(100 * database->GetReadPercentage()));
 		}
 		Global::DesactivateErrorFlowControl();

--- a/src/Learning/KWData/KWDataTableDriverTextFile.cpp
+++ b/src/Learning/KWData/KWDataTableDriverTextFile.cpp
@@ -318,7 +318,7 @@ KWObject* KWDataTableDriverTextFile::Read()
 	require(not inputBuffer->IsBufferEnd());
 
 	// On retourne NULL, sans message, si interruption utilisateur
-	if (periodicTestInterruption.IsTestAllowed(lRecordIndex))
+	if (TaskProgression::IsRefreshNecessary())
 	{
 		if (TaskProgression::IsInterruptionRequested())
 			return NULL;

--- a/src/Learning/KWData/KWDataTableDriverTextFile.h
+++ b/src/Learning/KWData/KWDataTableDriverTextFile.h
@@ -162,9 +162,6 @@ protected:
 	// coherente des flags internes de gestion du fichier
 	virtual void ResetDatabaseFile();
 
-	// Memorisation de l'etat de suivi des taches
-	PeriodicTest periodicTestInterruption;
-
 	// Utilisation d'une ligne d'en-tete
 	boolean bHeaderLineUsed;
 

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -364,7 +364,7 @@ KWClass* KWDatabase::ComputeClass()
 				}
 
 				// Suivi de la tache
-				if (periodicTestDisplay.IsTestAllowed(lRecordNumber))
+				if (TaskProgression::IsRefreshNecessary())
 				{
 					TaskProgression::DisplayProgression((int)(100 * GetReadPercentage()));
 					if (TaskProgression::IsInterruptionRequested())
@@ -774,7 +774,7 @@ boolean KWDatabase::ReadAll()
 			}
 
 			// Suivi de la tache
-			if (periodicTestInterruption.IsTestAllowed(lRecordNumber))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				TaskProgression::DisplayProgression((int)(100 * GetReadPercentage()));
 				DisplayReadTaskProgressionLabel(lRecordNumber, lObjectNumber);
@@ -850,7 +850,7 @@ void KWDatabase::DeleteAll()
 			delete oaAllObjects.GetAt(nObject);
 
 			// Suivi de la tache (sans test d'interruption: il faut detruire tous les objets)
-			if (periodicTestDisplay.IsTestAllowed(nObject))
+			if (TaskProgression::IsRefreshNecessary())
 				TaskProgression::DisplayProgression((int)(nObject * 100.0 / oaAllObjects.GetSize()));
 			if (bDisplay)
 			{
@@ -917,14 +917,12 @@ boolean KWDatabase::WriteAll(KWDatabase* sourceObjects)
 			}
 
 			// Suivi de la tache
-			if (periodicTestDisplay.IsTestAllowed(lObjectNumber))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				TaskProgression::DisplayProgression(
 				    (int)(nObject * 100.0 / sourceObjects->GetObjects()->GetSize()));
 				if (TaskProgression::IsInterruptionRequested())
-				{
 					break;
-				}
 			}
 		}
 		Global::DesactivateErrorFlowControl();

--- a/src/Learning/KWData/KWDatabase.h
+++ b/src/Learning/KWData/KWDatabase.h
@@ -574,10 +574,6 @@ protected:
 	Continuous cSelectionContinuous;
 	IntVector ivMarkedInstances;
 
-	// Memorisation de l'etat de suivi des taches
-	PeriodicTest periodicTestInterruption;
-	PeriodicTest periodicTestDisplay;
-
 	// Formats par defaut des types complexes, pour gerer les conversions vers les chaines de caracteres
 	KWDateFormat dateDefaultConverter;
 	KWTimeFormat timeDefaultConverter;

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -1670,7 +1670,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 						break;
 
 					// Suivi de la tache
-					if (bIsInTask and periodicTestInterruption.IsTestAllowed(lRecordNumber))
+					if (bIsInTask and TaskProgression::IsRefreshNecessary())
 					{
 						TaskProgression::DisplayLabel(sMessage + ": " +
 									      LongintToReadableString(lObjectNumber) +
@@ -1753,7 +1753,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 
 					// Suivi de la tache
 					lRecordNumber++;
-					if (bIsInTask and periodicTestInterruption.IsTestAllowed(lRecordNumber))
+					if (bIsInTask and TaskProgression::IsRefreshNecessary())
 					{
 						if (TaskProgression::IsInterruptionRequested())
 						{

--- a/src/Learning/KWDataPreparation/KWAttributeSubsetStats.cpp
+++ b/src/Learning/KWDataPreparation/KWAttributeSubsetStats.cpp
@@ -690,7 +690,7 @@ boolean KWAttributeSubsetStats::CreateAttributeIntervals(const KWTupleTable* tup
 			tuple = attributeTupleTable.GetAt(nTuple);
 
 			// Progression
-			if (periodicTestDisplay.IsTestAllowed(nTuple))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				// CH IV Begin
 				// Cas d'un attribut de grille, qui n'est pas un attribut interne d'un attribut VarPart
@@ -786,7 +786,7 @@ boolean KWAttributeSubsetStats::CreateAttributeValueSets(const KWTupleTable* tup
 		       attributeTupleTable.GetAt(nTuple - 1)->GetSymbolAt(0).CompareValue(tuple->GetSymbolAt(0)) < 0);
 
 		// Progression
-		if (periodicTestDisplay.IsTestAllowed(nTuple))
+		if (TaskProgression::IsRefreshNecessary())
 		{
 			// CH IV Begin
 			// Cas d'un attribut de grille, qui n'est pas un attribut interne d'un attribut VarPart
@@ -965,7 +965,7 @@ boolean KWAttributeSubsetStats::CreateDataGridCells(const KWTupleTable* tupleTab
 		tuple = tupleTable->GetAt(nTuple);
 
 		// Progression
-		if (periodicTestDisplay.IsTestAllowed(nTuple))
+		if (TaskProgression::IsRefreshNecessary())
 		{
 			TaskProgression::DisplayProgression((int)(50 + nTuple * 50.0 / tupleTable->GetSize()));
 			if (TaskProgression::IsInterruptionRequested())

--- a/src/Learning/KWDataPreparation/KWAttributeSubsetStats.h
+++ b/src/Learning/KWDataPreparation/KWAttributeSubsetStats.h
@@ -171,13 +171,11 @@ protected:
 	// Parametre avance. Par defaut: 0 signifie qu'il n'y a pas de contrainte
 	int nMaxCellNumberConstraint;
 
-	// Gestion des tests pour le suivi des taches
-	PeriodicTest periodicTestDisplay;
-	friend class PLShared_AttributeSubsetStats;
-
 	// Pre-granularisation des attributs numeriques cible (regression) et des attributs numeriques explicatifs en
 	// analyse non supervisee (co-clustering)
 	static boolean bPregranularizedNumericalAttributes;
+
+	friend class PLShared_AttributeSubsetStats;
 };
 
 ///////////////////////////////////////////////////////

--- a/src/Learning/KWDataPreparation/KWDataPreparationUnivariateTask.cpp
+++ b/src/Learning/KWDataPreparation/KWDataPreparationUnivariateTask.cpp
@@ -1111,7 +1111,6 @@ boolean KWDataPreparationUnivariateTask::SplitSlice(KWDataTableSlice* slice, int
 	int nSubSliceBlockIndex;
 	int nSliceDenseSymbolAttributeIndex;
 	int nSubSliceDenseAttributeIndex;
-	PeriodicTest periodicTestInterruption;
 	KWObject* kwoObject;
 	longint lRecordNumber;
 	ALString sSliceBaseName;
@@ -1239,7 +1238,7 @@ boolean KWDataPreparationUnivariateTask::SplitSlice(KWDataTableSlice* slice, int
 					}
 
 					// Suivi de la tache
-					if (periodicTestInterruption.IsTestAllowed(lRecordNumber))
+					if (TaskProgression::IsRefreshNecessary())
 						TaskProgression::DisplayProgression(
 						    (int)(100 * slice->GetReadPercentage()));
 				}

--- a/src/Learning/KWDataPreparation/KWDiscretizerMODL.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizerMODL.cpp
@@ -1547,7 +1547,6 @@ void KWDiscretizerMODL::IntervalListPostOptimization(const KWFrequencyTable* kwf
 	int nIntervalNumber;
 	int nSurnumerousIntervalNumber;
 	int nStepNumber;
-	PeriodicTest periodicTestOptimize;
 
 	require(kwftSource != NULL);
 	require(headInterval != NULL);
@@ -1590,7 +1589,7 @@ void KWDiscretizerMODL::IntervalListPostOptimization(const KWFrequencyTable* kwf
 		nStepNumber++;
 
 		// Test si arret de tache demandee
-		if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+		if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 			break;
 
 		// Calcul du nombre d'inetrvalles surnumeraires pour la prise en compte de
@@ -1763,7 +1762,6 @@ void KWDiscretizerMODL::IntervalListBoundaryPostOptimization(const KWFrequencyTa
 	double dBestDeltaCost;
 	int nIntervalNumber;
 	int nStepNumber;
-	PeriodicTest periodicTestOptimize;
 
 	require(kwftSource != NULL);
 	require(headInterval != NULL);
@@ -1801,7 +1799,7 @@ void KWDiscretizerMODL::IntervalListBoundaryPostOptimization(const KWFrequencyTa
 		nStepNumber++;
 
 		// Test si arret de tache demandee
-		if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+		if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 			break;
 
 		// Recherche du meilleur MergeSplit et de son cout

--- a/src/Learning/KWDataPreparation/KWGrouperMODLOptimization.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperMODLOptimization.cpp
@@ -1342,7 +1342,6 @@ void KWGrouperMODL::FastPostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequ
 	double dBestDeltaCost;
 	double dBestInDeltaCost;
 	int nBestInGroup;
-	PeriodicTest periodicTestOptimize;
 
 	require(kwftSource != NULL);
 	require(kwftTarget != NULL);
@@ -1388,7 +1387,7 @@ void KWGrouperMODL::FastPostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequ
 		nStepNumber++;
 
 		// Test si arret de tache demandee
-		if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+		if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 			break;
 
 		// Perturbation aleatoire des index de modalites et de groupes
@@ -1420,7 +1419,7 @@ void KWGrouperMODL::FastPostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequ
 				nInGroup = ivGroupIndexes.GetAt((nStart + n2) % nGroupNumber);
 
 				// Test si arret de tache demandee
-				if (periodicTestOptimize.IsTestAllowed(0) and
+				if (TaskProgression::IsRefreshNecessary() and
 				    TaskProgression::IsInterruptionRequested())
 					break;
 
@@ -1454,7 +1453,7 @@ void KWGrouperMODL::FastPostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequ
 			}
 
 			// Test si arret de tache demandee
-			if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+			if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 				break;
 
 			// On effectue si necessaire le meilleur transfert de groupe
@@ -1528,7 +1527,6 @@ void KWGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 	double dBestDeltaCost;
 	double dBestInDeltaCost;
 	int nBestInGroup;
-	PeriodicTest periodicTestOptimize;
 	POSITION position;
 	KWFrequencyVector* frequencyVector;
 	int nGarbageModalityNumber;
@@ -1602,7 +1600,7 @@ void KWGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 		nStepNumber++;
 
 		// Test si arret de tache demandee
-		if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+		if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 			break;
 
 		// Perturbation aleatoire des index de modalites et de groupes
@@ -1640,7 +1638,7 @@ void KWGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 				nInGroup = ivGroupIndexes.GetAt((nStart + n2) % nGroupNumber);
 
 				// Test si arret de tache demandee
-				if (periodicTestOptimize.IsTestAllowed(0) and
+				if (TaskProgression::IsRefreshNecessary() and
 				    TaskProgression::IsInterruptionRequested())
 					break;
 
@@ -1805,7 +1803,7 @@ void KWGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 			}
 
 			// Test si arret de tache demandee
-			if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+			if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 				break;
 
 			// On effectue si necessaire le meilleur transfert de groupe
@@ -1913,7 +1911,6 @@ void KWGrouperMODL::EMPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSource
 	double dBestDeltaCost;
 	double dBestInDeltaCost;
 	int nBestInGroup;
-	PeriodicTest periodicTestOptimize;
 	POSITION position;
 	KWFrequencyTable kwftImproved;
 	SortedList improvedFrequencyList(KWFrequencyVectorModalityNumberCompare);
@@ -1993,7 +1990,7 @@ void KWGrouperMODL::EMPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSource
 		nStepNumber++;
 
 		// Test si arret de tache demandee
-		if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+		if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 			break;
 
 		// Parcours de toutes les modalites
@@ -2026,7 +2023,7 @@ void KWGrouperMODL::EMPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSource
 			for (nInGroup = 0; nInGroup < nGroupNumber; nInGroup++)
 			{
 				// Test si arret de tache demandee
-				if (periodicTestOptimize.IsTestAllowed(0) and
+				if (TaskProgression::IsRefreshNecessary() and
 				    TaskProgression::IsInterruptionRequested())
 					break;
 
@@ -2179,7 +2176,7 @@ void KWGrouperMODL::EMPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSource
 			}
 
 			// Test si arret de tache demandee
-			if (periodicTestOptimize.IsTestAllowed(0) and TaskProgression::IsInterruptionRequested())
+			if (TaskProgression::IsRefreshNecessary() and TaskProgression::IsInterruptionRequested())
 				break;
 
 			// On memorise le meilleur transfert de la modalite courante vers un nouveau groupe s'il existe

--- a/src/Learning/KWDataUtils/KWDataTableSliceSet.cpp
+++ b/src/Learning/KWDataUtils/KWDataTableSliceSet.cpp
@@ -1285,7 +1285,6 @@ boolean KWDataTableSliceSet::Close()
 boolean KWDataTableSliceSet::ReadAllObjectsWithClass(const KWClass* kwcInputClass, ObjectArray* oaReadObjects)
 {
 	boolean bOk = true;
-	PeriodicTest periodicTestInterruption;
 	KWObject* kwoObject;
 	longint lRecordNumber;
 	ALString sTmp;
@@ -1332,7 +1331,7 @@ boolean KWDataTableSliceSet::ReadAllObjectsWithClass(const KWClass* kwcInputClas
 			}
 
 			// Suivi de la tache
-			if (periodicTestInterruption.IsTestAllowed(lRecordNumber))
+			if (TaskProgression::IsRefreshNecessary())
 				TaskProgression::DisplayProgression((int)(100 * GetReadPercentage()));
 		}
 		Global::DesactivateErrorFlowControl();
@@ -3136,7 +3135,6 @@ boolean KWDataTableSlice::Close()
 boolean KWDataTableSlice::ReadAll()
 {
 	boolean bOk = true;
-	PeriodicTest periodicTestInterruption;
 	KWObject* kwoObject;
 	longint lRecordNumber;
 
@@ -3173,7 +3171,7 @@ boolean KWDataTableSlice::ReadAll()
 			}
 
 			// Suivi de la tache
-			if (periodicTestInterruption.IsTestAllowed(lRecordNumber))
+			if (TaskProgression::IsRefreshNecessary())
 				TaskProgression::DisplayProgression((int)(100 * GetReadPercentage()));
 		}
 		Global::DesactivateErrorFlowControl();
@@ -3916,7 +3914,7 @@ boolean KWDataTableDriverSlice::ReadObject(KWObject* kwoObject)
 	require(kwoObject->GetClass() == GetClass());
 
 	// On retourne NULL, sans message, si interruption utilisateur
-	if (periodicTestInterruption.IsTestAllowed(lRecordIndex))
+	if (TaskProgression::IsRefreshNecessary())
 	{
 		if (TaskProgression::IsInterruptionRequested())
 			return false;

--- a/src/Learning/KWDataUtils/KWDatabaseTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTask.cpp
@@ -758,7 +758,6 @@ boolean KWDatabaseTask::SlaveProcessStartDatabase()
 	ALString sChunkFileName;
 	int nBufferSize;
 	longint lChunkSize;
-	PeriodicTest periodicTestInterruption;
 	ALString sTmp;
 
 	// Initialisation des variables de travail
@@ -929,7 +928,6 @@ boolean KWDatabaseTask::SlaveProcessExploitDatabase()
 	KWObjectKey lastRootObjectKey;
 	KWObject* kwoObject;
 	ALString sChunkFileName;
-	PeriodicTest periodicTestInterruption;
 	PLDataTableDriverTextFile* rootDriver;
 	double dProgression;
 	ALString sTmp;
@@ -959,7 +957,7 @@ boolean KWDatabaseTask::SlaveProcessExploitDatabase()
 		while (not sourceDatabase->IsEnd())
 		{
 			// Suivi de la tache
-			if (periodicTestInterruption.IsTestAllowed(lRecordNumber))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				// Avancement
 				dProgression = rootDriver->GetReadPercentage();

--- a/src/Learning/KWDataUtils/KWFileKeyExtractorTask.cpp
+++ b/src/Learning/KWDataUtils/KWFileKeyExtractorTask.cpp
@@ -523,7 +523,6 @@ boolean KWFileKeyExtractorTask::SlaveProcess()
 	longint lNextLinePos;
 	boolean bLineTooLong;
 	int nCumulatedLineNumber;
-	PeriodicTest periodicTestInterruption;
 	boolean bIsLineOK;
 	ALString sTmp;
 
@@ -616,8 +615,7 @@ boolean KWFileKeyExtractorTask::SlaveProcess()
 			while (bOk and not inputFile.IsBufferEnd())
 			{
 				// Gestion de la progresssion
-				if (periodicTestInterruption.IsTestAllowed(nCumulatedLineNumber +
-									   inputFile.GetCurrentLineIndex()))
+				if (TaskProgression::IsRefreshNecessary())
 				{
 					// Calcul de la progression par rapport a la proportion de la portion du fichier
 					// traitee parce que l'on ne sait pas le nombre total de ligne que l'on va
@@ -694,7 +692,7 @@ boolean KWFileKeyExtractorTask::SlaveProcess()
 		}
 	}
 
-	// On ajoute un test sur l'interruption car pour les petits fichiers IsTestAllowed n'est jamais declenchee dans
+	// On ajoute un test sur l'interruption car pour les petits fichiers IsRefreshNecessary n'est jamais declenchee dans
 	// la boucle precedente et l'interruption n'est pas detectee, il faut neanmoins detruire les fichiers
 	// temporaires
 	if (TaskProgression::IsInterruptionRequested())

--- a/src/Learning/KWDataUtils/KWKeyPositionFinderTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeyPositionFinderTask.cpp
@@ -985,7 +985,6 @@ boolean KWKeyPositionFinderTask::SlaveProcess()
 	KWKey* inputKey;
 	int nInputKeyIndex;
 	longint lLinePosition;
-	PeriodicTest periodicTestInterruption;
 	double dProgression;
 	longint lBeginPos;
 	longint lMaxEndPos;
@@ -1076,8 +1075,7 @@ boolean KWKeyPositionFinderTask::SlaveProcess()
 				lLinePosition = inputFile.GetPositionInFile();
 
 				// Gestion de la progresssion
-				if (periodicTestInterruption.IsTestAllowed(nCumulatedLineNumber +
-									   inputFile.GetCurrentLineIndex()))
+				if (TaskProgression::IsRefreshNecessary())
 				{
 					// Calcul de la progression par rapport a la proportion de la portion du fichier
 					// traitee parce que l'on ne sait pas le nombre total de ligne que l'on va

--- a/src/Learning/KWDataUtils/KWKeyPositionSampleExtractorTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeyPositionSampleExtractorTask.cpp
@@ -575,7 +575,6 @@ boolean KWKeyPositionSampleExtractorTask::SlaveProcess()
 	ObjectArray* oaKeyPositionSample;
 	KWKeyPosition* previousRecordKeyPosition;
 	KWKeyPosition* recordKeyPosition;
-	PeriodicTest periodicTestInterruption;
 	double dProgression;
 	int nCompareKey;
 	longint lBeginPos;
@@ -639,8 +638,7 @@ boolean KWKeyPositionSampleExtractorTask::SlaveProcess()
 		while (bOk and not inputFile.IsBufferEnd())
 		{
 			// Gestion de la progresssion
-			if (periodicTestInterruption.IsTestAllowed(nCumulatedLineNumber +
-								   inputFile.GetCurrentLineIndex()))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				// Calcul de la progression par rapport a la proportion de la portion du fichier traitee
 				// parce que l'on ne sait pas le nombre total de ligne que l'on va traiter

--- a/src/Learning/KWDataUtils/KWKeySampleExtractorTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeySampleExtractorTask.cpp
@@ -701,7 +701,6 @@ boolean KWKeySampleExtractorTask::SlaveProcess()
 {
 	boolean bOk = true;
 	KWKey* recordKey;
-	PeriodicTest periodicTestInterruption;
 	double dProgression;
 	int nCount;
 	longint lBeginPos;
@@ -757,7 +756,7 @@ boolean KWKeySampleExtractorTask::SlaveProcess()
 		{
 			// Gestion de la progesssion
 			nCount++;
-			if (periodicTestInterruption.IsTestAllowed(nCount))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				dProgression = inputFile.GetCurrentLineIndex() * 1.0 / inputFile.GetBufferLineNumber();
 				TaskProgression::DisplayProgression((int)floor(dProgression * 100));

--- a/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.cpp
+++ b/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.cpp
@@ -611,7 +611,6 @@ boolean KWSortedChunkBuilderTask::SlaveProcess()
 	longint lNextLinePos;
 	boolean bLineTooLong;
 	int nCumulatedLineNumber;
-	PeriodicTest periodicTestInterruption;
 	boolean bIsLineOk;
 
 	if (not input_bLastRound)
@@ -681,8 +680,7 @@ boolean KWSortedChunkBuilderTask::SlaveProcess()
 				while (bOk and not inputFile.IsBufferEnd())
 				{
 					// Gestion de la progresssion
-					if (periodicTestInterruption.IsTestAllowed(nCumulatedLineNumber +
-										   inputFile.GetCurrentLineIndex()))
+					if (TaskProgression::IsRefreshNecessary())
 					{
 						// Calcul de la progression par rapport a la proportion de la portion du
 						// fichier traitee parce que l'on ne sait pas le nombre total de ligne

--- a/src/Learning/KWModeling/KWClassifierPostOptimizer.cpp
+++ b/src/Learning/KWModeling/KWClassifierPostOptimizer.cpp
@@ -534,7 +534,6 @@ boolean KWClassifierPostOptimizer::LoadWorkingData(KWPredictor* predictor, KWTra
 	KWLoadIndex liTargetAttributeLoadIndex;
 	KWLoadIndexVector livProbAttributeLoadIndexes;
 	KWLoadIndex liProbAttributeLoadIndex;
-	PeriodicTest periodicTestInterruption;
 
 	require(predictor->GetTrainParameters()->GetClassifierCriterion() != "None");
 	require(trainedClassifier->GetTargetValueNumber() > 1);
@@ -652,7 +651,7 @@ boolean KWClassifierPostOptimizer::LoadWorkingData(KWPredictor* predictor, KWTra
 			}
 
 			// Suivi de la tache
-			if (periodicTestInterruption.IsTestAllowed(lRecordNumber))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				TaskProgression::DisplayProgression(
 				    (int)(100 * evaluationDatabase->GetReadPercentage()));

--- a/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.cpp
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.cpp
@@ -1725,7 +1725,7 @@ boolean CCCoclusteringBuilder::CreateVarPartDataGridCells(const KWTupleTable* tu
 		tuple = tupleTable->GetAt(nTuple);
 
 		// Progression
-		if (periodicTestDisplay.IsTestAllowed(nTuple))
+		if (TaskProgression::IsRefreshNecessary())
 		{
 			TaskProgression::DisplayProgression((int)(50 + nTuple * 50.0 / tupleTable->GetSize()));
 			if (TaskProgression::IsInterruptionRequested())
@@ -2230,7 +2230,6 @@ boolean CCCoclusteringBuilder::FillTupleTableFromDatabase(KWDatabase* database, 
 	longint lRecordNumber;
 	int nObjectFrequency;
 	longint lTotalFrequency;
-	PeriodicTest periodicTestInterruption;
 	ALString sTmp;
 
 	require(not GetVarPartCoclustering());
@@ -2366,7 +2365,7 @@ boolean CCCoclusteringBuilder::FillTupleTableFromDatabase(KWDatabase* database, 
 			}
 
 			// Suivi de la tache
-			if (periodicTestInterruption.IsTestAllowed(lRecordNumber))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				TaskProgression::DisplayProgression((int)(100 * database->GetReadPercentage()));
 				database->DisplayReadTaskProgressionLabel(lRecordNumber, lObjectNumber);
@@ -2434,7 +2433,6 @@ boolean CCCoclusteringBuilder::FillVarPartTupleTableFromDatabase(KWDatabase* dat
 	longint lRecordNumber;
 	int nObjectFrequency;
 	longint lTotalFrequency;
-	PeriodicTest periodicTestInterruption;
 	int nObjectObservationNumber;
 	IntObject* ioObservationNumber;
 	ALString sTmp;
@@ -2623,7 +2621,7 @@ boolean CCCoclusteringBuilder::FillVarPartTupleTableFromDatabase(KWDatabase* dat
 			}
 
 			// Suivi de la tache
-			if (periodicTestInterruption.IsTestAllowed(lRecordNumber))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				TaskProgression::DisplayProgression((int)(100 * database->GetReadPercentage()));
 				database->DisplayReadTaskProgressionLabel(lRecordNumber, lObjectNumber);
@@ -2747,7 +2745,7 @@ boolean CCCoclusteringBuilder::CreateIdentifierAttributeIntervals(const KWTupleT
 			tuple = attributeTupleTable.GetAt(nTuple);
 
 			// Progression
-			if (periodicTestDisplay.IsTestAllowed(nTuple))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				// Cas d'un attribut de grille standard, non interne dans un attribut VarPart
 				if (not dgAttribute->IsInnerAttribute())
@@ -2870,7 +2868,7 @@ boolean CCCoclusteringBuilder::CreateIdentifierAttributeValueSets(const KWTupleT
 		       attributeTupleTable.GetAt(nTuple - 1)->GetSymbolAt(0).CompareValue(tuple->GetSymbolAt(0)) < 0);
 
 		// Progression
-		if (periodicTestDisplay.IsTestAllowed(nTuple))
+		if (TaskProgression::IsRefreshNecessary())
 		{
 			// Cas d'un attribut de grille standard, non interne dans un attribut VarPart
 			// Sinon GetDataGrid() n'est pas defini

--- a/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.cpp
+++ b/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.cpp
@@ -1291,7 +1291,6 @@ boolean SNBDataTableBinarySliceSetBuffer::LoadBlockFromSliceSetAt(int nChunk, in
 	int nAttribute;
 	IntVector* ivAttributeIndexes;
 	Continuous cIndex;
-	PeriodicTest periodicTestInterruption;
 
 	// Chargement des attributs de la slice dans le dictionnaire de recodage
 	LoadRecodedAttributesAtSlice(nSlice, recoderClass, schema, &livLoadedRecodedAttributeIndexes);
@@ -1332,7 +1331,7 @@ boolean SNBDataTableBinarySliceSetBuffer::LoadBlockFromSliceSetAt(int nChunk, in
 		// chunk. Moralement, l'ecriture du fichier devrait etre aussi suivi mais cela entrainarait utiliser des
 		// etats en plus, des calculs plus tordus et une perte de localite de cette partie du code. La lecture
 		// du bloc depuis le fichier binaire est tres rapide et n'a pas besoin de suivi.
-		if (TaskProgression::IsInTask() and periodicTestInterruption.IsTestAllowed(nInstance))
+		if (TaskProgression::IsInTask() and TaskProgression::IsRefreshNecessary())
 		{
 			// Mise-a-jour de la barre d'avancement
 			dProgressPercentSlice = 100.0 * (nInstance + 1) / nChunkInstanceNumber;

--- a/src/Norm/base/TaskProgression.h
+++ b/src/Norm/base/TaskProgression.h
@@ -113,6 +113,11 @@ public:
 	// Cette methode peut etre appelee meme hors des taches (sans effet dans ce cas)
 	static boolean IsInterruptionRequested();
 
+	// Parametrage d'un comportement ou les taches ne sont interruptible ou non (defaut: true)
+	// Dans le cas non interruptible, IsInterruptionRequested renvoie false systematiquement
+	static void SetInterruptible(boolean bValue);
+	static boolean GetInterruptible();
+
 	// Libelle principal
 	static void DisplayMainLabel(const ALString& sValue);
 
@@ -124,6 +129,12 @@ public:
 
 	// Remise a vide des libelles MainLabel, Label et de la progression
 	static void CleanLabels();
+
+	// Test si un rafraichissement est necessaire
+	// A chaque appel, un compteur est incremente, et on ne repond true qu'environ une fois sur 100
+	// Permet de conditionner la fabrication des libelle a afficher et les test d'interruption
+	// dans les boucle de traitement intensifs, pour limiter la charge de traitement d'avancement des taches
+	static boolean IsRefreshNecessary();
 
 	///////////////////////////////////////////////////////////
 	// Parametrage avance de la gestion des taches
@@ -235,6 +246,9 @@ protected:
 	// Date du dernier affichage global
 	static clock_t tLastDisplayTime;
 
+	// Fraicheur de l'affichage, permettant de controler la methode IsRefreshNecessary
+	static longint lDisplayFreshness;
+
 	// Memorisation des derniers affichages effectue par niveau, pour bufferisation
 	static StringVector svLastDisplayedMainLabels;
 	static IntVector ivLastDisplayedProgressions;
@@ -255,6 +269,9 @@ protected:
 	// Index de demande d'interruption
 	static longint lInterruptionRequestIndex;
 
+	// Indique si les taches sont interruptibles
+	static boolean bInterruptible;
+
 	// Gestion du lancement differe du suivi de progression
 	static clock_t tStartRequested;
 	static boolean bIsManagerStarted;
@@ -274,4 +291,20 @@ protected:
 inline boolean TaskProgression::IsInTask()
 {
 	return (nCurrentLevel >= 0);
+}
+
+inline boolean TaskProgression::IsRefreshNecessary()
+{
+	lDisplayFreshness++;
+	return (lDisplayFreshness % 128) == 0;
+}
+
+inline void TaskProgression::SetInterruptible(boolean bValue)
+{
+	bInterruptible = bValue;
+}
+
+inline boolean TaskProgression::GetInterruptible()
+{
+	return bInterruptible;
 }

--- a/src/Norm/base/TaskProgressionManager.cpp
+++ b/src/Norm/base/TaskProgressionManager.cpp
@@ -230,11 +230,6 @@ void FileTaskProgressionManager::SetProgression(int nValue)
 	}
 }
 
-boolean FileTaskProgressionManager::IsInterruptionResponsive() const
-{
-	return true;
-}
-
 void FileTaskProgressionManager::AddCompletedTaskMessage(const ALString& sMessage)
 {
 	StringObject* soMessage;

--- a/src/Norm/base/TaskProgressionManager.h
+++ b/src/Norm/base/TaskProgressionManager.h
@@ -33,10 +33,6 @@ public:
 	virtual void SetMainLabel(const ALString& sValue) = 0;
 	virtual void SetLabel(const ALString& sValue) = 0;
 	virtual void SetProgression(int nValue) = 0;
-
-	// Doit renvoyer true ou false sans aucun calcul pour indiquer si on doit
-	// temporiser ou non le test des interruptions (false pour temporiser).
-	virtual boolean IsInterruptionResponsive() const = 0;
 };
 
 /////////////////////////////////////////////////////////////////////////
@@ -67,7 +63,6 @@ public:
 	void SetMainLabel(const ALString& sValue) override;
 	void SetLabel(const ALString& sValue) override;
 	void SetProgression(int nValue) override;
-	boolean IsInterruptionResponsive() const override;
 
 	/////////////////////////////////////////////////////////////
 	///// Implementation

--- a/src/Norm/base/Timer.h
+++ b/src/Norm/base/Timer.h
@@ -12,7 +12,6 @@
 #endif
 
 class Timer;
-class PeriodicTest;
 
 //////////////////////////////////////////////////////////
 // Classe Timer
@@ -74,27 +73,6 @@ protected:
 	time_t tLastStartTime;
 	time_t tElapsedTime;
 #endif // __C11__
-};
-
-//////////////////////////////////////////////////////////
-// Classe PeriodicTest
-// Utilitaire pour effectuer des test selon une frequence d'evenement et de temps controlee
-class PeriodicTest : public Object
-{
-public:
-	// Constructeur
-	PeriodicTest();
-	~PeriodicTest();
-
-	// Indique si on peut effectuer un test, pour un nombre d'evenement donne
-	// Les tests sont effectues au plus selon une periodicite en nombre d'evenements et en secondes
-	boolean IsTestAllowed(longint lEventNumber) const;
-
-	////////////////////////////////////////////////////////
-	///// Implementation
-protected:
-	// Timer pour gerer la periodicite
-	mutable Timer timer;
 };
 
 //////////////////////////////////
@@ -213,29 +191,3 @@ inline double Timer::GetElapsedTime() const
 		return ((double)tElapsedTime) / 1e6;
 }
 #endif // __C11__
-
-/////////////////////////////////////////
-// Implementation inline de PeriodicTest
-
-inline PeriodicTest::PeriodicTest()
-{
-	timer.Start();
-}
-
-inline PeriodicTest::~PeriodicTest()
-{
-	timer.Stop();
-}
-
-inline boolean PeriodicTest::IsTestAllowed(longint lEventNumber) const
-{
-	if (lEventNumber % 128 == 0 and timer.GetElapsedTime() > 0.25)
-	{
-		// On reinitialise le timer
-		timer.Reset();
-		timer.Start();
-		return true;
-	}
-	else
-		return false;
-}

--- a/src/Norm/base/UIObject.cpp
+++ b/src/Norm/base/UIObject.cpp
@@ -348,6 +348,11 @@ boolean UIObject::SetUIMode(int nValue)
 	boolean bOk = true;
 	require(nValue == Textual or nValue == Graphic);
 
+	// On parametre la gestion des taches comme interruptible par l'utilisateur uniquement en mode Graphic
+	// Cela permet d'optimiser les temps de traitement en mode batch en evitant l'overhead
+	// de gestion des interruptions utilisateurs
+	TaskProgression::SetInterruptible(nValue == Graphic);
+
 	// En mode Graphic, on verifie qu'on peut instancier une JVM correctement
 	// Sinon on force le mode Textual et on renvoie false
 	if (nValue == Graphic)

--- a/src/Norm/base/UITaskProgression.cpp
+++ b/src/Norm/base/UITaskProgression.cpp
@@ -285,11 +285,6 @@ void UITaskProgression::SetProgression(int nValue)
 	}
 }
 
-boolean UITaskProgression::IsInterruptionResponsive() const
-{
-	return false;
-}
-
 jobject UITaskProgression::GetGuiTaskProgressionManager()
 {
 	JNIEnv* env;

--- a/src/Norm/base/UserInterface.h
+++ b/src/Norm/base/UserInterface.h
@@ -206,6 +206,7 @@ public:
 
 	// Si on echoue a passer en mode Graphic (probleme java), on passe
 	// inconditionnellement en Textual et on renvoie false
+	// Les taches sont interruptible par l'utilisateur uniquement en mode Graphic
 	static boolean SetUIMode(int nValue);
 	static int GetUIMode();
 
@@ -500,7 +501,6 @@ public:
 	void SetMainLabel(const ALString& sValue) override;
 	void SetLabel(const ALString& sValue) override;
 	void SetProgression(int nValue) override;
-	boolean IsInterruptionResponsive() const override;
 
 	// Acces au gestion de suivi global
 	static UITaskProgression* GetManager();

--- a/src/Parallel/PLMPI/PLMPIMaster.cpp
+++ b/src/Parallel/PLMPI/PLMPIMaster.cpp
@@ -7,15 +7,25 @@
 PLMPIMaster::PLMPIMaster(PLParallelTask* t)
 {
 	ALString sTmp;
-	bInterruptionRequested = false;
-	bIsMaxErrorReached = 0;
-	bIsMaxWarningReached = 0;
-	bIsMaxMessageReached = 0;
 	nWorkingSlaves = 0;
 	task = t;
+	bNewMessage = false;
 	bSpawnedDone = false;
+	bStopOrderDone = false;
+	bInterruptionRequested = false;
+	bSlaveError = false;
+	bMasterError = false;
+	bIsMaxErrorReached = false;
+	bIsMaxWarningReached = false;
+	bIsMaxMessageReached = false;
+	dGlobalProgression = 0;
+	nOldProgression = 0;
+	bIsProcessing = false;
+	nInitialisationCount = 0;
+	nFinalisationCount = 0;
 	nFirstSlaveInitializeMessageRank = -1;
 	nFirstSlaveFinalizeMessageRank = -1;
+	sBufferDischarge[0] = '\0';
 }
 
 PLMPIMaster::~PLMPIMaster()
@@ -223,7 +233,7 @@ boolean PLMPIMaster::Run()
 		slave->SetRank(context.GetRank());
 		slave->SetHostName(sHostName);
 		slave->SetProgression(0);
-		slave->SetTaskPercent(1 / task->nWorkingProcessNumber); // Pour l'initialisation
+		slave->SetTaskPercent(1.0 / task->nWorkingProcessNumber); // Pour l'initialisation
 		GetTask()->oaSlaves.Add(slave);
 
 		// Ajout de l'esclave dans le dictionaire hsostName / liste des esclaves

--- a/src/Parallel/PLMPI/PLMPIMessageManager.cpp
+++ b/src/Parallel/PLMPI/PLMPIMessageManager.cpp
@@ -17,12 +17,12 @@ int MessageWithTaskIndexCompare(const void* elem1, const void* elem2)
 	message2 = cast(MessageWithTaskIndex*, *(Object**)elem2);
 
 	// Comparaison sur le TaskIndex puis sur le numero de ligne, puis sur l'ordre de reception
-	lIndexComp = message1->GetTaskIndex() - message2->GetTaskIndex();
+	lIndexComp = (longint)message1->GetTaskIndex() - message2->GetTaskIndex();
 	if (lIndexComp == 0)
 	{
 		lIndexComp = message1->GetMessage()->GetIndex() - message2->GetMessage()->GetIndex();
 		if (lIndexComp == 0)
-			lIndexComp = message1->GetAddIndex() - message2->GetAddIndex();
+			lIndexComp = (longint)message1->GetAddIndex() - message2->GetAddIndex();
 	}
 	return (int)((lIndexComp > 0) - (lIndexComp < 0)); // 1 si > 0; -1 si >0; 0 sinon
 }

--- a/src/Parallel/PLMPI/PLMPISlaveProgressionManager.cpp
+++ b/src/Parallel/PLMPI/PLMPISlaveProgressionManager.cpp
@@ -16,6 +16,8 @@ PLMPISlaveProgressionManager::PLMPISlaveProgressionManager(void)
 	nOldProgression = 0;
 	sendRequest = MPI_REQUEST_NULL;
 	ivMaxErrorReached = NULL;
+	nSlaveState = State::VOID;
+	sBuffer[0] = '\0';
 }
 
 PLMPISlaveProgressionManager::~PLMPISlaveProgressionManager(void)

--- a/src/Parallel/PLMPI/PLMPISlaveProgressionManager.cpp
+++ b/src/Parallel/PLMPI/PLMPISlaveProgressionManager.cpp
@@ -69,11 +69,6 @@ void PLMPISlaveProgressionManager::SetProgression(int nValue)
 	}
 }
 
-boolean PLMPISlaveProgressionManager::IsInterruptionResponsive() const
-{
-	return true;
-}
-
 void PLMPISlaveProgressionManager::SetSlaveState(State nState)
 {
 	nSlaveState = nState;

--- a/src/Parallel/PLMPI/PLMPISlaveProgressionManager.h
+++ b/src/Parallel/PLMPI/PLMPISlaveProgressionManager.h
@@ -31,7 +31,6 @@ public:
 	void SetMainLabel(const ALString& sValue) override;
 	void SetLabel(const ALString& sValue) override;
 	void SetProgression(int nValue) override;
-	boolean IsInterruptionResponsive() const override;
 
 	// Etat de l'esclave (VOID,PROCESS,FINALIZE)
 	void SetSlaveState(State nState);

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
@@ -170,7 +170,7 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 		nInputPreferredSize = SystemFile::nMinPreferredBufferSize;
 	nOutputPreferredSize = PLRemoteFileService::GetPreferredBufferSize(sOutputFileName);
 
-	if (lRemainingMemory >= nInputPreferredSize + nOutputPreferredSize)
+	if (lRemainingMemory >= (longint)nInputPreferredSize + nOutputPreferredSize)
 	{
 		nOutputBufferSize = nOutputPreferredSize;
 		lInputBufferSize = lRemainingMemory - nOutputBufferSize;
@@ -180,8 +180,8 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 			lInputBufferSize = (lInputBufferSize / nInputPreferredSize) * nInputPreferredSize;
 
 		// On n'utilise pas plus de 8 preferred size
-		if (lInputBufferSize > 8 * nOutputPreferredSize)
-			lInputBufferSize = 8 * nOutputPreferredSize;
+		if (lInputBufferSize > 8 * (longint)nOutputPreferredSize)
+			lInputBufferSize = 8 * (longint)nOutputPreferredSize;
 	}
 	else
 	{

--- a/src/Parallel/PLParallelTask/PLParallelTask.cpp
+++ b/src/Parallel/PLParallelTask/PLParallelTask.cpp
@@ -2129,7 +2129,7 @@ int PLParallelTask::InternalComputeStairBufferSize(int nBufferSizeMin, int nBuff
 
 	// Fin de traitement : quand il n'y a du travail que pour la moitie des esclaves
 	lFileSizeRemaining = lFileSize - lFileProcessed;
-	if (lFileSizeRemaining < (nProcessNumber / 2) * nComputedBufferSizeMax)
+	if (lFileSizeRemaining < (nProcessNumber / 2) * (longint)nComputedBufferSizeMax)
 	{
 		bStop = true;
 	}

--- a/src/Parallel/PLParallelTask/PLSharedVector.cpp
+++ b/src/Parallel/PLParallelTask/PLSharedVector.cpp
@@ -233,10 +233,10 @@ void PLShared_LongintVector::Test()
 
 	// Initialisation d'une variable partagee en entree
 	for (i = 0; i < 5; i++)
-		ivInitialValue.Add(i + 1);
+		ivInitialValue.Add((longint)i + 1);
 	shared_valueIn.GetLongintVector()->CopyFrom(&ivInitialValue);
 	for (i = 0; i < 5; i++)
-		shared_valueIn.Add(101 + i);
+		shared_valueIn.Add(101 + (longint)i);
 
 	// Serialisation
 	serializer.OpenForWrite(NULL);

--- a/src/Parallel/PLParallelTask/RMParallelResourceManager.cpp
+++ b/src/Parallel/PLParallelTask/RMParallelResourceManager.cpp
@@ -2357,7 +2357,7 @@ boolean PLSolution::FitMinimalRequirements(int nRT, longint& lMissingResource, b
 					if (hostClassSolution->GetHostCountPerProcNumber()->GetAt(nProcNumber) != 0)
 					{
 						// Resources necessaires sur ce host
-						lUsedResource = lMasterSum + (nProcNumber - 1) * lSlaveMin;
+						lUsedResource = lMasterSum + ((longint)nProcNumber - 1) * lSlaveMin;
 
 						// Ressources disponibles sur le host
 						lLocalMissingResource = lUsedResource - lAvailableResource;

--- a/src/Parallel/PLSamples/PEFileSearchTask.cpp
+++ b/src/Parallel/PLSamples/PEFileSearchTask.cpp
@@ -20,6 +20,7 @@ PEFileSearchTask::PEFileSearchTask()
 	// Variables du maitre
 	lInputFileSize = 0;
 	lFoundLineNumber = 0;
+	lFilePos = 0;
 }
 
 PEFileSearchTask::~PEFileSearchTask() {}

--- a/src/Parallel/PLSamples/PEFileSearchTask.cpp
+++ b/src/Parallel/PLSamples/PEFileSearchTask.cpp
@@ -178,7 +178,6 @@ boolean PEFileSearchTask::SlaveProcess()
 	boolean bIsOpen;
 	boolean bTrace = false;
 	longint lLinePosition;
-	PeriodicTest periodicTestInterruption;
 	longint lBeginPos;
 	longint lMaxEndPos;
 	longint lNextLinePos;
@@ -257,8 +256,7 @@ boolean PEFileSearchTask::SlaveProcess()
 			lLinePosition = inputBuffer.GetPositionInFile();
 
 			// Gestion de la progresssion
-			if (periodicTestInterruption.IsTestAllowed(nCumulatedLineNumber +
-								   inputBuffer.GetCurrentLineIndex()))
+			if (TaskProgression::IsRefreshNecessary())
 			{
 				// Calcul de la progression par rapport a la proportion de la portion du fichier traitee
 				// parce que l'on ne sait pas le nombre total de ligne que l'on va traiter

--- a/src/Parallel/PLSamples/PEIOParallelTestTask.cpp
+++ b/src/Parallel/PLSamples/PEIOParallelTestTask.cpp
@@ -15,6 +15,7 @@ PEIOParallelTestTask::PEIOParallelTestTask()
 	lTotalFieldNumber = 0;
 	lTotalLineNumber = 0;
 	lTotalFileSizes = 0;
+	nFileIndex = 0;
 }
 
 PEIOParallelTestTask::~PEIOParallelTestTask() {}

--- a/src/Parallel/PLSamples/PELullaby.cpp
+++ b/src/Parallel/PLSamples/PELullaby.cpp
@@ -4,7 +4,11 @@
 
 #include "PELullabyTask.h"
 
-PELullabyTask::PELullabyTask() {}
+PELullabyTask::PELullabyTask()
+{
+	nMyTaskIndex = 0;
+	nStepSize = 0;
+}
 
 PELullabyTask::~PELullabyTask() {}
 

--- a/src/Parallel/PLSamples/PEProgressionTask.cpp
+++ b/src/Parallel/PLSamples/PEProgressionTask.cpp
@@ -8,6 +8,7 @@ PEProgressionTask::PEProgressionTask()
 {
 	nMethodToTest = 0;
 	bBoostMode = false;
+	nIterationNumber = 0;
 	DeclareTaskInput(&input_nIterationNumber);
 }
 PEProgressionTask::~PEProgressionTask() {}
@@ -74,7 +75,7 @@ boolean PEProgressionTask::Test(int nMethod, boolean bValue)
 boolean PEProgressionTask::Test()
 {
 	int nMethod;
-	int bOk;
+	boolean bOk;
 	bOk = true;
 	for (nMethod = MASTER_INITIALIZE; nMethod < END; nMethod++)
 	{

--- a/src/Parallel/PLSamples/PESerializerLongTestTask.cpp
+++ b/src/Parallel/PLSamples/PESerializerLongTestTask.cpp
@@ -8,6 +8,7 @@ PESerializerLongTestTask::PESerializerLongTestTask()
 {
 	DeclareTaskInput(&input_sString);
 	DeclareTaskInput(&input_nStringLength);
+	nMaxStringSize = 0;
 }
 
 PESerializerLongTestTask::~PESerializerLongTestTask() {}

--- a/src/Parallel/PLSamples/PESerializerTestTask.cpp
+++ b/src/Parallel/PLSamples/PESerializerTestTask.cpp
@@ -18,6 +18,8 @@ PESerializerTestTask::PESerializerTestTask()
 	DeclareSharedParameter(&shared_nLargeCharVectorSize);
 	DeclareSharedParameter(&shared_nLargeStringSize);
 
+	nLargeCharVectorSize = 0;
+	nLargeStringSize = 0;
 	sSimpleStringToSerialize = "A simple string";
 	sSimpleCharVectorToSerialize = "A simple CharVector !!";
 }

--- a/test/LearningTestTool/py/_kht_results_management.py
+++ b/test/LearningTestTool/py/_kht_results_management.py
@@ -112,7 +112,7 @@ def get_context_computing_type(log_file=None, show=False):
     Base sur la variable process_number
     Une trace est ecrite dans un fichier de log et affichees sur la console si besoin
     """
-    if process_number is None:
+    if process_number is None or process_number == 1:
         computing_type = "sequential"
     else:
         computing_type = "parallel"

--- a/test/LearningTestTool/py/kht_export.py
+++ b/test/LearningTestTool/py/kht_export.py
@@ -146,9 +146,7 @@ def export_learning_test_tree(
                         # Creation du repertoire de suite uniquement si necessaire
                         if not target_suite_dir_created:
                             utils.make_dir(target_suite_dir)
-                            target_suite_dir_created = os.path.isdir(
-                                target_suite_dir
-                            )
+                            target_suite_dir_created = os.path.isdir(target_suite_dir)
                         # Cas d'un repertoire
                         if os.path.isdir(source_test_dir):
                             # Copie du repertoire de test

--- a/test/LearningTestTool/py/kht_export.py
+++ b/test/LearningTestTool/py/kht_export.py
@@ -137,28 +137,20 @@ def export_learning_test_tree(
                 # Parcours des repertoires de test de la suite
                 for test_dir_name in test_dir_names:
                     source_test_dir = os.path.join(source_suite_dir, test_dir_name)
-                    # Gestion des fichiers de la suite (ex: readme), a conserver
-                    if os.path.isfile(source_test_dir):
-                        if export_test_dirs:
-                            source_file_name = source_test_dir
-                            target_file_name = os.path.join(
-                                target_suite_dir, test_dir_name
+                    # Export du contenu de la suite si necessaire
+                    if export_test_dirs:
+                        # Creation du repertoire de l'outil uniquement si necessaire
+                        if not target_tool_dir_created:
+                            utils.make_dir(target_tool_dir)
+                            target_tool_dir_created = os.path.isdir(target_tool_dir)
+                        # Creation du repertoire de suite uniquement si necessaire
+                        if not target_suite_dir_created:
+                            utils.make_dir(target_suite_dir)
+                            target_suite_dir_created = os.path.isdir(
+                                target_suite_dir
                             )
-                            utils.copy_file(source_file_name, target_file_name)
-                    # Gestion des repertoires de la suite: a exporter ou analyser
-                    if os.path.isdir(source_test_dir):
-                        # Export du repertoire de test si necessaire
-                        if export_test_dirs:
-                            # Creation du repertoire de l'outil uniquement si necessaire
-                            if not target_tool_dir_created:
-                                utils.make_dir(target_tool_dir)
-                                target_tool_dir_created = os.path.isdir(target_tool_dir)
-                            # Creation du repertoire de suite uniquement si necessaire
-                            if not target_suite_dir_created:
-                                utils.make_dir(target_suite_dir)
-                                target_suite_dir_created = os.path.isdir(
-                                    target_suite_dir
-                                )
+                        # Cas d'un repertoire
+                        if os.path.isdir(source_test_dir):
                             # Copie du repertoire de test
                             target_test_dir = os.path.join(
                                 target_suite_dir, test_dir_name
@@ -169,6 +161,15 @@ def export_learning_test_tree(
                                 target_test_dir,
                                 ignore_list=forbidden_names,
                             )
+                        # Cas d'un fichier de la suite (ex: readme), a conserver
+                        if os.path.isfile(source_test_dir):
+                            source_file_name = source_test_dir
+                            target_file_name = os.path.join(
+                                target_suite_dir, test_dir_name
+                            )
+                            utils.copy_file(source_file_name, target_file_name)
+                    # Gestion des repertoires de la suite a analyser
+                    if os.path.isdir(source_test_dir):
                         # Analyse du scenario pour detecter les jeux de donnees utilises
                         test_prm_path = os.path.join(source_test_dir, kht.TEST_PRM)
                         if os.path.isfile(test_prm_path):


### PR DESCRIPTION
Essentiellement, dans le commit principal (nettemenent plus détaillé dans les notes de commit)
- TaskProgressionManager::IsInterruptionResponsive
  - on considère desormais que le test d'interruption n'est jamais "responsive", et on protège toujours par une timer
- TaskProgression::IsRefreshNecessary
  - nouvelle méthode permettant de bufferiser la fabrication des messages pour DisplayTaskProgesssion et le test d'interruption utilisateur
  - utilise un modulo et les timers deja existant dans TaskProgression
  - remplace l'utilisation de PeriodicTest::IsTestAllowed
- PeriodicTest: suppression de la classe et de tous ses usages
- TaskProgression::Set|GetInterruptible
  - si GetInterruptible vaut false, la méthode TaskProgression::IsInterruptionRequested renvoie systematiquement false
    sauf si une interruption a été forcée par programme par la methode ForceInterruptionRequested (utilisee dans les CrashTests)
  - paramétrage
    - quand on lance les outils en mode batch (cf. UIObject::SetUIMode)

Plus deux petits commits indépendant:
- corrections mineures dans les scripts de LearningTest
- corrections mineures pour des warning de compilation dans la librairie Parallel (à valider par Bruno)

Devrait permettre de clore également l'issue https://github.com/KhiopsML/khiops/issues/140
