### PR TITLE
Fix the unflushed output of LearningTest scripts

### DIFF
--- a/test/LearningTestTool/py/_kht_utils.py
+++ b/test/LearningTestTool/py/_kht_utils.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import sys
 import shutil
 import stat
 import argparse
@@ -564,3 +565,34 @@ def sub_dirs(source_dir):
         except (IOError, os.error):
             pass
     return result_sub_dirs
+
+
+def set_flushed_outputs():
+    """Flush systematique des sorties standard et d'erreur"""
+    sys.stdout = Unbuffered(sys.stdout)
+    sys.stderr = Unbuffered(sys.stderr)
+
+
+class Unbuffered:
+    """Pour ouvrir un fichier avec un flush systematique
+    usage: par exemple, appeler sys.stdout = Unbuffered(sys.stdout) pour que toutes les sorties standard
+     soit immediatement affichees dans le shell, sans bufferisation
+    """
+
+    def __init__(self, stream):
+        self.stream = stream
+
+    def write(self, data):
+        # on encode en utf-8 en ignorant les erreurs pour eviter un erreur lors de l'encodage automatique
+        self.stream.write(data.encode("utf-8", "ignore").decode("utf-8"))
+        self.stream.flush()
+
+    def writelines(self, datas):
+        # on encode en utf-8 en ignorant les erreurs pour eviter un erreur lors de l'encodage automatique
+        self.stream.writelines(
+            [data.encode("utf-8", "ignore").decode("utf-8") for data in datas]
+        )
+        self.stream.flush()
+
+    def __getattr__(self, attr):
+        return getattr(self.stream, attr)

--- a/test/LearningTestTool/py/kht_apply.py
+++ b/test/LearningTestTool/py/kht_apply.py
@@ -279,4 +279,5 @@ def main():
 
 
 if __name__ == "__main__":
+    utils.set_flushed_outputs()
     main()

--- a/test/LearningTestTool/py/kht_collect_results.py
+++ b/test/LearningTestTool/py/kht_collect_results.py
@@ -296,4 +296,5 @@ def main():
 
 
 if __name__ == "__main__":
+    utils.set_flushed_outputs()
     main()

--- a/test/LearningTestTool/py/kht_env.py
+++ b/test/LearningTestTool/py/kht_env.py
@@ -63,4 +63,5 @@ def main():
 
 
 if __name__ == "__main__":
+    utils.set_flushed_outputs()
     main()

--- a/test/LearningTestTool/py/kht_export.py
+++ b/test/LearningTestTool/py/kht_export.py
@@ -440,4 +440,5 @@ def main():
 
 
 if __name__ == "__main__":
+    utils.set_flushed_outputs()
     main()

--- a/test/LearningTestTool/py/kht_help.py
+++ b/test/LearningTestTool/py/kht_help.py
@@ -49,4 +49,5 @@ def main():
 
 
 if __name__ == "__main__":
+    utils.set_flushed_outputs()
     main()

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -908,4 +908,5 @@ def main():
 
 
 if __name__ == "__main__":
+    utils.set_flushed_outputs()
     main()


### PR DESCRIPTION
Probleme:
Quand on lance des scripts LearningTest qui durent longtemps (par exemple les tests en debug), on a l'impression qu'il ne se passe rien. Cela provient du fait que la sortie standard est bufferisee et que les affichages de l'avancement ne sont effectues que rarement par buffer. Ce fonctionnement est tres perturbant pour l'utilisateur des scripts

La solution à ce probleme etait dejà en place dans la version precedente des scripts, mais avait ete enlevee son utilite n'etait pas documentee. Elle vient d'etre remise en place:
- fonction set_flushed_outputs dans _kht_utils
- appel en debut de main dans toutes les commandes de LearningTest