### PR TITLE
204 fatal error in debug mode for learningtesttestkhiopsmissingvaluesmissingvaluesdatagrid

### DIFF
--- a/src/Learning/KWDataPreparation/KWLearningReport.cpp
+++ b/src/Learning/KWDataPreparation/KWLearningReport.cpp
@@ -575,6 +575,29 @@ longint KWDataPreparationStats::GetUsedMemory() const
 	return lUsedMemory;
 }
 
+const ALString KWDataPreparationStats::GetClassLabel() const
+{
+	if (GetAttributeNumber() > 1)
+		return "Variables";
+	else
+		return "Variable";
+}
+
+const ALString KWDataPreparationStats::GetObjectLabel() const
+{
+	ALString sLabel;
+	int i;
+
+	// Calcul d'un nom par concatenation des noms des attributs
+	for (i = 0; i < GetAttributeNumber(); i++)
+	{
+		if (i > 0)
+			sLabel += "`";
+		sLabel += GetAttributeNameAt(i);
+	}
+	return sLabel;
+}
+
 double KWDataPreparationStats::GetSortValue() const
 {
 	require(IsStatsComputed());

--- a/src/Learning/KWDataPreparation/KWLearningReport.h
+++ b/src/Learning/KWDataPreparation/KWLearningReport.h
@@ -213,6 +213,10 @@ public:
 	// Memoire utilisee
 	longint GetUsedMemory() const override;
 
+	// Libelles
+	const ALString GetClassLabel() const override;
+	const ALString GetObjectLabel() const override;
+
 	/////////////////////////////////////////////////
 	///// Implementation
 protected:

--- a/src/Learning/KWModeling/KWPredictor.h
+++ b/src/Learning/KWModeling/KWPredictor.h
@@ -219,7 +219,7 @@ protected:
 	// Dictionnaire des KWDataPreparationStats du ClassStats selectionnes
 	NumericKeyDictionary nkdSelectedDataPreparationStats;
 
-	// Dictionnaire des KWDataPreparationStats du selectionnes recursivement
+	// Dictionnaire des KWDataPreparationStats du ClassStats selectionnes recursivement
 	NumericKeyDictionary nkdRecursivelySelectedDataPreparationStats;
 
 	// Resultats d'apprentissage, a creer et alimenter par la methode InternalTrain

--- a/src/Learning/KWModeling/KWPredictorDataGrid.cpp
+++ b/src/Learning/KWModeling/KWPredictorDataGrid.cpp
@@ -297,6 +297,47 @@ boolean KWPredictorDataGrid::InternalTrain()
 	return false;
 }
 
+void KWPredictorDataGrid::CollectSelectedPreparationStats(ObjectArray* oaUsedDataPreparationStats)
+{
+	KWAttributeSubsetStats* attributeSubsetStats;
+	ObjectArray oaDataGridUsedDataPreparationStats;
+	KWDataPreparationStats* dataPreparationStats;
+	int nAttribute;
+	ALString sAttributeName;
+
+	require(nkdSelectedDataPreparationStats.GetCount() == 0);
+	require(nkdRecursivelySelectedDataPreparationStats.GetCount() == 0);
+	require(oaUsedDataPreparationStats != NULL);
+	require(GetClassStats() != NULL);
+	require(GetClass() != NULL);
+	require(GetClass() == GetClassStats()->GetClass());
+
+	// On recherche l'unique preparation d'attribut dans le cas d'une grille, si elle est disponible
+	assert(oaUsedDataPreparationStats->GetSize() <= 1);
+	if (oaUsedDataPreparationStats->GetSize() == 1)
+	{
+		dataPreparationStats = cast(KWDataPreparationStats*, oaUsedDataPreparationStats->GetAt(0));
+		check(dataPreparationStats);
+		attributeSubsetStats = cast(KWAttributeSubsetStats*, dataPreparationStats);
+
+		// Collecte des preparation d'attribut effectivement utulises par la grille apprise
+		for (nAttribute = 0;
+		     nAttribute < attributeSubsetStats->GetPreparedDataGridStats()->GetSourceAttributeNumber();
+		     nAttribute++)
+		{
+			sAttributeName = attributeSubsetStats->GetPreparedDataGridStats()
+					     ->GetAttributeAt(nAttribute)
+					     ->GetAttributeName();
+			dataPreparationStats =
+			    cast(KWDataPreparationStats*, GetClassStats()->LookupAttributeStats(sAttributeName));
+			oaDataGridUsedDataPreparationStats.Add(dataPreparationStats);
+		}
+
+		// Appel de la methode ancetre en se basant les attributs de la grille
+		KWPredictorNaiveBayes::CollectSelectedPreparationStats(&oaDataGridUsedDataPreparationStats);
+	}
+}
+
 void KWPredictorDataGrid::InternalTrainUnsupervisedDG(KWDataPreparationClass* dataPreparationClass,
 						      ObjectArray* oaDataPreparationUsedAttributes)
 {

--- a/src/Learning/KWModeling/KWPredictorDataGrid.h
+++ b/src/Learning/KWModeling/KWPredictorDataGrid.h
@@ -79,6 +79,11 @@ protected:
 	// Redefinition de la methode d'apprentissage
 	boolean InternalTrain() override;
 
+	// Redefinition de la collecte des KWDataPreparationStats selectionnes recursivement ou non par le predicteur
+	// On exploite ici les attributs effectivement utilises par la grille, et non ceux potentiellement utilises
+	// par l'objet temporaire KWAttributeSubsetStats issu de l'apprentissage, qui est detruit apres le traitement
+	void CollectSelectedPreparationStats(ObjectArray* oaUsedDataPreparationStats) override;
+
 	// Apprentissage non supervise
 	void InternalTrainUnsupervisedDG(KWDataPreparationClass* dataPreparationClass,
 					 ObjectArray* oaDataPreparationUsedAttributes);

--- a/test/LearningTestTool/py/kht_help.py
+++ b/test/LearningTestTool/py/kht_help.py
@@ -2,6 +2,7 @@ import os
 import argparse
 
 import _kht_constants as kht
+import _kht_utils as utils
 
 
 def help_commands():


### PR DESCRIPTION
Suite au lancement de tout LearningTest en mode debug (pour les temps < 5 s), seul le test LearningTest\TestKhiops\MissingValues\MissingValuesDataGrid a planté en fatal error

Correction dans KWDataGridPredictor