### PR TITLE
Fix wrong errno in remote fread

### DIFF
--- a/src/Parallel/PLMPI/PLMPISystemFileDriverRemote.h
+++ b/src/Parallel/PLMPI/PLMPISystemFileDriverRemote.h
@@ -45,6 +45,9 @@ public:
 	boolean ReserveExtraSize(longint lSize, void* stream) override;
 
 	// TODO ?? boolean CopyFileToLocal(const char* sSourceFilePathName, const char* sDestFilePathName);
+private:
+	// errno local, on n'utilise pas errno car il est modifie par MPI (MPI_REcv notamment)
+	int nLocalErrno;
 };
 
 // Handle sur un fichier distant


### PR DESCRIPTION
In the class `PLMPISystemFileDriverRemote`, we use a new class attribute `nLocalErrno` to store errno code. We can not relies on the global errno for file access because `MPI_Recv` modifies errno (sets it to 11, Resource Temporarily Unavailable) even if all is OK.