### PR TITLE
Fix package renaming in CI

### DIFF
--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -65,7 +65,6 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
-    continue-on-error: true
     defaults:
       run:
         shell: bash
@@ -94,6 +93,7 @@ jobs:
           dpkg -i ./artifacts/khiops-core* || true
           apt-get -f install -y
       - name: Check Khiops core installation
+        continue-on-error: ${{ matrix.os == 'debian:11' }}
         run: |
           khiops-env --env
           khiops -v
@@ -103,10 +103,12 @@ jobs:
           dpkg -i ./khiops_* || true
           apt-get -f install -y
       - name: Check Khiops installation
+        continue-on-error: ${{ matrix.os == 'debian:11' }}
         run: |
           khiops -v
           khiops_coclustering -v
       - name: Test Khiops installation
+        continue-on-error: ${{ matrix.os == 'debian:11' || matrix.os == 'debian:12' }}
         uses: ./.github/actions/test-khiops-install
   test-kni:
     needs: build

--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -166,7 +166,10 @@ jobs:
           for PKG_FILE in *.deb
           do
             NEW_PKG_FILE=$(echo $PKG_FILE | sed "s/_${SOURCE_VERSION}-/_${{ github.ref_name }}-/")
-            mv $PKG_FILE $NEW_PKG_FILE
+            if [[ "$PKG_FILE" != "$NEW_PKG_FILE" ]]
+            then
+              mv $PKG_FILE $NEW_PKG_FILE
+            fi
           done
       - name: Upload packages to the release
         uses: ncipollo/release-action@v1.14.0

--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -158,10 +158,16 @@ jobs:
           name: KNI
       - name: Rename packages with tag version
         run: |
+          # Build the package file names
           SOURCE_VERSION="${{ needs.build.outputs.khiops-version }}"
           PKG_FILE=$(ls *-setup.exe)
           NEW_PKG_FILE=$(echo $PKG_FILE | sed "s/-${SOURCE_VERSION}-/-${{ github.ref_name }}-/")
-          mv $PKG_FILE $NEW_PKG_FILE
+
+          # Rename to the tag version only if it is not coherent with the source version
+          if [[ "$PKG_FILE" != "$NEW_PKG_FILE" ]]
+          then
+            mv $PKG_FILE $NEW_PKG_FILE
+          fi
       - name: Upload NSIS installer and KNI to the release
         uses: ncipollo/release-action@v1.14.0
         with:

--- a/.github/workflows/pack-rpm.yml
+++ b/.github/workflows/pack-rpm.yml
@@ -156,11 +156,15 @@ jobs:
           merge-multiple: true
       - name: Rename packages with tag version
         run: |
+          # Renames the packge only if the source version differs from the tag
           SOURCE_VERSION=$(./scripts/khiops-version)
           for PKG_FILE in *.rpm
           do
             NEW_PKG_FILE=$(echo $PKG_FILE | sed "s/-${SOURCE_VERSION}-/-${{ github.ref_name }}-/")
-            mv $PKG_FILE $NEW_PKG_FILE
+            if [[ "$PKG_FILE" != "$NEW_PKG_FILE" ]]
+            then
+              mv $PKG_FILE $NEW_PKG_FILE
+            fi
           done
       - name: Upload packages to the release
         uses: ncipollo/release-action@v1.14.0


### PR DESCRIPTION
commit 11c4c6cd5415a1ad7f59b84eb2ea1c83e3c25737 (HEAD -> fix-renaming-nsis, origin/fix-renaming-nsis)
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Tue Mar 5 19:04:55 2024 +0100

    Allow CI failure for unsupported Debian versions

    We use `continue-on-error` for certain steps of the testing packages for
    Debian 11 and 12. This way the CI is green even though in these OS the
    packages fail on basic tests.

commit bfa6aa362d684472a48290c431f87aa99b287fc2 (tag: 10.2.1)
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Mon Mar 25 10:25:32 2024 +0100

    Fix package renaming in CI

    The release part of the packaging workflows contain a renaming step to
    make sure it coincides with the tag. This patch makes sure that this is
    only made when the source version is different from the tag.