### PR TITLE
196 assertion violated in kwprobabilitytabletest

### DIFF
--- a/src/Learning/DTForest/DTDecisionTreeCreationTask.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTask.cpp
@@ -2206,7 +2206,6 @@ KWLearningSpec* DTDecisionTreeCreationTask::InitializeRegressionLearningSpec(con
 	// on transforme la cible continue en cible categorielle, en effectuant au prealable une dicretisation equalFreq
 	// sur la cible continue
 
-	boolean bOk = true;
 	DTBaseLoader bl;
 	KWLearningSpec* newLearningSpec = NULL;
 	KWClass* newClass = NULL;
@@ -2222,8 +2221,7 @@ KWLearningSpec* DTDecisionTreeCreationTask::InitializeRegressionLearningSpec(con
 	newTarget->SetName(learningSpec->GetTargetAttributeName() + "_categorical");
 	newTarget->SetType(KWType::Symbol);
 	newClass->InsertAttribute(newTarget);
-	bOk = KWClassDomain::GetCurrentDomain()->InsertClass(newClass);
-	assert(bOk);
+	KWClassDomain::GetCurrentDomain()->InsertClass(newClass);
 	newClass->Compile();
 	KWClassDomain::GetCurrentDomain()->Compile();
 	assert(newClass->Check());

--- a/src/Learning/DTForest/DTDecisionTreeCreationTaskSequential.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTaskSequential.cpp
@@ -1525,8 +1525,7 @@ DTDecisionTreeCreationTaskSequential::InitializeEqualFreqDiscretization(KWTupleT
 	newTarget->SetName(learningSpec->GetTargetAttributeName() + "_categorical");
 	newTarget->SetType(KWType::Symbol);
 	newClass->InsertAttribute(newTarget);
-	bOk = KWClassDomain::GetCurrentDomain()->InsertClass(newClass);
-	assert(bOk);
+	KWClassDomain::GetCurrentDomain()->InsertClass(newClass);
 	newClass->Compile();
 	KWClassDomain::GetCurrentDomain()->Compile();
 	assert(newClass->Check());

--- a/src/Learning/KWData/KWCYac.cpp
+++ b/src/Learning/KWData/KWCYac.cpp
@@ -557,10 +557,10 @@ static const yytype_int8 yytranslate[] = {
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] = {
     0,    134,  134,  138,  145,  149,  153,  157,  161,  165,  169,  173,  177,  181,  185,  189,  193,  197,  201,
-    207,  220,  221,  224,  227,  237,  245,  288,  367,  386,  397,  442,  491,  583,  590,  598,  604,  614,  627,
-    647,  669,  688,  705,  713,  848,  860,  867,  879,  886,  891,  898,  903,  910,  914,  918,  922,  926,  930,
-    934,  938,  942,  946,  950,  958,  963,  969,  973,  977,  982,  991,  996,  1002, 1022, 1038, 1216, 1220, 1227,
-    1240, 1251, 1265, 1274, 1283, 1293, 1303, 1314, 1323, 1330, 1331, 1335, 1340, 1346, 1347, 1351, 1356, 1368, 1370};
+    207,  220,  221,  224,  227,  237,  245,  286,  365,  384,  395,  438,  485,  577,  584,  592,  598,  608,  621,
+    641,  663,  682,  699,  707,  842,  854,  861,  873,  880,  885,  892,  897,  904,  908,  912,  916,  920,  924,
+    928,  932,  936,  940,  944,  952,  957,  963,  967,  971,  976,  985,  990,  996,  1016, 1032, 1210, 1214, 1221,
+    1234, 1245, 1259, 1268, 1277, 1287, 1297, 1308, 1317, 1324, 1325, 1329, 1334, 1340, 1341, 1345, 1350, 1362, 1364};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -1581,7 +1581,6 @@ yyreduce:
 		KWClass* kwcClass = (yyvsp[-1].kwcValue);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
 		assert(kwcLoadCurrentClass == (yyvsp[-1].kwcValue));
-		boolean bOk;
 
 		/* Si attribut non valide: on ne fait rien */
 		if (attribute == NULL)
@@ -1616,17 +1615,16 @@ yyreduce:
 		/* Si OK, d'insertion */
 		else
 		{
-			bOk = kwcClass->InsertAttribute(attribute);
-			assert(bOk);
+			kwcClass->InsertAttribute(attribute);
 		}
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1660 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1658 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 26: /* kwclassBegin: kwclassBegin '{' comments oaAttributeArrayDeclaration '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 289 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 287 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-9].kwcValue);
 		KWAttributeBlock* attributeBlock;
@@ -1712,11 +1710,11 @@ yyreduce:
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1743 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1741 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 27: /* kwclassBegin: kwclassBegin '{' comments '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 368 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 366 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-8].kwcValue);
 
@@ -1735,11 +1733,11 @@ yyreduce:
 			delete (yyvsp[0].sValue);
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1766 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1764 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 28: /* kwclassBegin: kwclassBegin error  */
-#line 387 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 385 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* ERRORMGT */
 		/* Attention: cette regle qui permet une gestion des erreurs amelioree */
@@ -1747,16 +1745,15 @@ yyreduce:
 		kwcLoadCurrentClass = NULL;
 		YYABORT;
 	}
-#line 1778 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1776 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 29: /* oaAttributeArrayDeclaration: oaAttributeArrayDeclaration kwattributeDeclaration  */
-#line 398 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 396 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes = (yyvsp[-1].oaAttributes);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
 		KWClass* kwcClass = kwcLoadCurrentClass;
-		boolean bOk;
 		check(oaAttributes);
 
 		/* Si attribut non valide: on ne fait rien */
@@ -1793,23 +1790,21 @@ yyreduce:
 		/* Si OK, d'insertion */
 		else
 		{
-			bOk = kwcClass->InsertAttribute(attribute);
+			kwcClass->InsertAttribute(attribute);
 			oaAttributes->Add(attribute);
-			assert(bOk);
 		}
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1827 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1823 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 30: /* oaAttributeArrayDeclaration: kwattributeDeclaration  */
-#line 443 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 439 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes;
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
 		KWClass* kwcClass = kwcLoadCurrentClass;
-		boolean bOk;
 
 		/* Creation d'un tableau */
 		oaAttributes = new ObjectArray;
@@ -1848,18 +1843,17 @@ yyreduce:
 		/* Si OK, d'insertion */
 		else
 		{
-			bOk = kwcClass->InsertAttribute(attribute);
+			kwcClass->InsertAttribute(attribute);
 			oaAttributes->Add(attribute);
-			assert(bOk);
 		}
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1878 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1872 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 31: /* kwclassHeader: comments rootDeclaration CLASS IDENTIFIER keyFields metaData '{'  */
-#line 492 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 486 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass;
 		KWClass* kwcReferencedClass;
@@ -1949,41 +1943,41 @@ yyreduce:
 		kwcLoadCurrentClass = kwcClass;
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1971 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1965 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 32: /* keyFields: '(' keyFieldList ')' comments  */
-#line 584 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 578 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore les comemntaires */
 		if ((yyvsp[0].sValue) != NULL)
 			delete (yyvsp[0].sValue);
 		(yyval.svValue) = (yyvsp[-2].svValue);
 	}
-#line 1982 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1976 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 33: /* keyFields: comments  */
-#line 591 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 585 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore les comemntaires */
 		if ((yyvsp[0].sValue) != NULL)
 			delete (yyvsp[0].sValue);
 		(yyval.svValue) = NULL; /* pas de champ cle */
 	}
-#line 1993 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1987 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 34: /* keyFields: %empty  */
-#line 598 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 592 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.svValue) = NULL; /* pas de champ cle */
 	}
-#line 2001 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1995 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 35: /* keyFieldList: keyFieldList ',' IDENTIFIER  */
-#line 605 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 599 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svKeyFields;
 
@@ -1993,11 +1987,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svKeyFields;
 	}
-#line 2015 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2009 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 36: /* keyFieldList: IDENTIFIER  */
-#line 615 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 609 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svKeyFields;
 
@@ -2007,11 +2001,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svKeyFields;
 	}
-#line 2029 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2023 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 37: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' STRINGLITTERAL '>'  */
-#line 628 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 622 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2031,11 +2025,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2053 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2047 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 38: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' CONTINUOUSLITTERAL '>'  */
-#line 648 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 642 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2057,11 +2051,11 @@ yyreduce:
 		delete (yyvsp[-3].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2079 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2073 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 39: /* metaData: metaData '<' SIMPLEIDENTIFIER '>'  */
-#line 670 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 664 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2080,11 +2074,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2102 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2096 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 40: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' IDENTIFIER '>'  */
-#line 689 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 683 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2101,19 +2095,19 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2122 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2116 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 41: /* metaData: %empty  */
-#line 705 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 699 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwmdMetaData) = NULL; /* pas de paires cle valeurs */
 	}
-#line 2130 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2124 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 42: /* kwattributeDeclaration: usedDeclaration typeDeclaration refIdentifier IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 721 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 715 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWAttribute* attribute;
 		KWDerivationRule* rule;
@@ -2256,11 +2250,11 @@ yyreduce:
 
 		(yyval.kwaValue) = attribute;
 	}
-#line 2257 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2251 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 43: /* applicationids: applicationids APPLICATIONID  */
-#line 849 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 843 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ne garde que la premiere ligne de chaque identification d'application */
 		if ((yyvsp[-1].sValue) == NULL)
@@ -2271,19 +2265,19 @@ yyreduce:
 			(yyval.sValue) = (yyvsp[-1].sValue);
 		}
 	}
-#line 2272 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2266 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 44: /* applicationids: %empty  */
-#line 860 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 854 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL; /* pas d'identification d'application */
 	}
-#line 2280 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2274 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 45: /* comments: comments LABEL  */
-#line 868 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 862 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ne garde que la premiere ligne de chaque commentaire */
 		if ((yyvsp[-1].sValue) == NULL)
@@ -2294,180 +2288,180 @@ yyreduce:
 			(yyval.sValue) = (yyvsp[-1].sValue);
 		}
 	}
-#line 2295 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2289 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 46: /* comments: %empty  */
-#line 879 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 873 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL; /* pas de commentaire */
 	}
-#line 2303 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2297 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 47: /* rootDeclaration: ROOT  */
-#line 887 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 881 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = true;
 	}
-#line 2311 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2305 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 48: /* rootDeclaration: %empty  */
-#line 891 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 885 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = false; /* valeur par defaut */
 	}
-#line 2319 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2313 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 49: /* usedDeclaration: UNUSED  */
-#line 899 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 893 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = false;
 	}
-#line 2327 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2321 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 50: /* usedDeclaration: %empty  */
-#line 903 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 897 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = true; /* valeur par defaut */
 	}
-#line 2335 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2329 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 51: /* typeDeclaration: CONTINUOUSTYPE  */
-#line 911 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 905 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Continuous;
 	}
-#line 2343 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2337 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 52: /* typeDeclaration: SYMBOLTYPE  */
-#line 915 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 909 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Symbol;
 	}
-#line 2351 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2345 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 53: /* typeDeclaration: DATETYPE  */
-#line 919 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 913 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Date;
 	}
-#line 2359 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2353 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 54: /* typeDeclaration: TIMETYPE  */
-#line 923 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 917 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Time;
 	}
-#line 2367 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2361 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 55: /* typeDeclaration: TIMESTAMPTYPE  */
-#line 927 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 921 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Timestamp;
 	}
-#line 2375 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2369 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 56: /* typeDeclaration: TIMESTAMPTZTYPE  */
-#line 931 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 925 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::TimestampTZ;
 	}
-#line 2383 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2377 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 57: /* typeDeclaration: TEXTTYPE  */
-#line 935 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 929 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Text;
 	}
-#line 2391 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2385 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 58: /* typeDeclaration: TEXTLISTTYPE  */
-#line 939 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 933 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::TextList;
 	}
-#line 2399 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2393 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 59: /* typeDeclaration: OBJECTTYPE  */
-#line 943 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 937 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Object;
 	}
-#line 2407 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2401 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 60: /* typeDeclaration: OBJECTARRAYTYPE  */
-#line 947 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 941 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::ObjectArray;
 	}
-#line 2415 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2409 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 61: /* typeDeclaration: STRUCTURETYPE  */
-#line 951 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 945 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Structure;
 	}
-#line 2423 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2417 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 62: /* refIdentifier: '(' IDENTIFIER ')'  */
-#line 959 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 953 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[-1].sValue);
 	}
-#line 2431 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2425 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 63: /* refIdentifier: %empty  */
-#line 963 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 957 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL;
 	}
-#line 2439 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2433 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 64: /* usedDerivationRule: '=' derivationRule  */
-#line 970 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 964 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2447 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2441 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 65: /* usedDerivationRule: referenceRule  */
-#line 974 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 968 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2455 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2449 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 66: /* usedDerivationRule: '=' derivationRule ')'  */
-#line 978 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 972 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ')'");
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2464 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2458 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 67: /* usedDerivationRule: '(' IDENTIFIER ')'  */
-#line 983 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 977 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ALString sTmp;
 		yyerror(sTmp + "Invalid syntax (" + *(yyvsp[-1].sValue) + ")");
@@ -2475,27 +2469,27 @@ yyreduce:
 			delete (yyvsp[-1].sValue);
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2476 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2470 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 68: /* usedDerivationRule: %empty  */
-#line 991 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 985 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2484 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2478 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 69: /* referenceRule: referenceRuleBody ']'  */
-#line 997 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 991 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2492 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2486 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 70: /* referenceRuleBody: '[' derivationRuleOperand  */
-#line 1003 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 997 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule;
 		KWDerivationRuleOperand* operand;
@@ -2515,11 +2509,11 @@ yyreduce:
 		/* On retourner la regle */
 		(yyval.kwdrValue) = rule;
 	}
-#line 2516 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2510 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 71: /* referenceRuleBody: referenceRuleBody ',' derivationRuleOperand  */
-#line 1023 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1017 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand;
@@ -2533,11 +2527,11 @@ yyreduce:
 		/* On retourner la regle */
 		(yyval.kwdrValue) = rule;
 	}
-#line 2534 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2528 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 72: /* derivationRule: derivationRuleBody closeparenthesis  */
-#line 1039 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1033 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* ruleBody = (yyvsp[-1].kwdrValue);
 		KWDerivationRule* rule;
@@ -2719,27 +2713,27 @@ yyreduce:
 
 		(yyval.kwdrValue) = rule;
 	}
-#line 2713 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2707 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 73: /* derivationRuleBody: derivationRuleBegin  */
-#line 1217 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1211 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2721 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2715 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 74: /* derivationRuleBody: derivationRuleHeader  */
-#line 1221 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1215 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2729 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2723 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 75: /* derivationRuleHeader: IDENTIFIER openparenthesis  */
-#line 1228 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1222 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule;
 
@@ -2749,11 +2743,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2743 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2737 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 76: /* derivationRuleBegin: derivationRuleHeader derivationRuleOperand  */
-#line 1241 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1235 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-1].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2764,11 +2758,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2758 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2752 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 77: /* derivationRuleBegin: derivationRuleBegin ',' derivationRuleOperand  */
-#line 1252 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1246 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2779,11 +2773,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2773 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2767 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 78: /* derivationRuleOperand: IDENTIFIER  */
-#line 1266 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1260 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2792,11 +2786,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2786 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2780 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 79: /* derivationRuleOperand: CONTINUOUSLITTERAL  */
-#line 1275 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1269 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2805,11 +2799,11 @@ yyreduce:
 		operand->SetContinuousConstant((yyvsp[0].cValue));
 		(yyval.kwdroValue) = operand;
 	}
-#line 2799 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2793 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 80: /* derivationRuleOperand: bigstring  */
-#line 1284 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1278 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2819,11 +2813,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2813 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2807 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 81: /* derivationRuleOperand: derivationRule  */
-#line 1294 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1288 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2833,22 +2827,22 @@ yyreduce:
 			operand->SetType(operand->GetDerivationRule()->GetType());
 		(yyval.kwdroValue) = operand;
 	}
-#line 2827 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2821 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 82: /* derivationRuleOperand: '.' derivationRuleOperand  */
-#line 1304 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1298 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = (yyvsp[0].kwdroValue);
 		operand->SetScopeLevel(operand->GetScopeLevel() + 1);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2838 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2832 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 83: /* bigstring: bigstring '+' STRINGLITTERAL  */
-#line 1315 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1309 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* Concatenation des deux chaines */
 		(yyval.sValue) = new ALString(*(yyvsp[-2].sValue) + *(yyvsp[0].sValue));
@@ -2857,59 +2851,59 @@ yyreduce:
 		delete (yyvsp[-2].sValue);
 		delete (yyvsp[0].sValue);
 	}
-#line 2851 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2845 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 84: /* bigstring: STRINGLITTERAL  */
-#line 1324 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1318 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 2859 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2853 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 86: /* semicolon: ';' ';'  */
-#line 1332 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1326 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous ';'");
 	}
-#line 2867 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2861 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 87: /* semicolon: ';' ';' ';'  */
-#line 1336 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1330 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ';'");
 	}
-#line 2875 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2869 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 88: /* semicolon: %empty  */
-#line 1340 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1334 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Missing ';'");
 	}
-#line 2883 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2877 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 90: /* openparenthesis: '(' '('  */
-#line 1348 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1342 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous '('");
 	}
-#line 2891 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2885 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 91: /* openparenthesis: '(' '(' '('  */
-#line 1352 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1346 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many '('");
 	}
-#line 2899 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2893 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 92: /* openparenthesis: %empty  */
-#line 1356 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1350 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* ERRORMGT */
 		/* Attention: supprimer cette instruction en cas d'evolution du parser */
@@ -2918,11 +2912,11 @@ yyreduce:
 		/* sa consoeur 3 shift/reduce conflicts et 12 reduce conflicts     */
 		yyerror("Missing '('");
 	}
-#line 2912 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2906 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 94: /* closeparenthesis: %empty  */
-#line 1370 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1364 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* ERRORMGT */
 		/* Attention: supprimer cette instruction en cas d'evolution du parser */
@@ -2931,10 +2925,10 @@ yyreduce:
 		/* sa consoeur 3 shift/reduce conflicts et 12 reduce conflicts     */
 		yyerror("Missing ')'");
 	}
-#line 2925 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2919 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-#line 2929 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2923 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 	default:
 		break;
@@ -3113,7 +3107,7 @@ yyreturnlab:
 	return yyresult;
 }
 
-#line 1381 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1375 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 #include "KWCLex.inc"
 

--- a/src/Learning/KWData/KWCYac.yac
+++ b/src/Learning/KWData/KWCYac.yac
@@ -247,7 +247,6 @@ kwclassBegin: kwclassHeader comments
 		  KWClass* kwcClass=$1;
 		  KWAttribute* attribute=$2;
 		  assert(kwcLoadCurrentClass == $1);
-		  boolean bOk;
 
 		  /* Si attribut non valide: on ne fait rien */
 		  if (attribute == NULL)
@@ -279,8 +278,7 @@ kwclassBegin: kwclassHeader comments
 		  /* Si OK, d'insertion */
 		  else
 		  {
-		    bOk = kwcClass->InsertAttribute(attribute);
-			assert(bOk);
+		    kwcClass->InsertAttribute(attribute);
 		  }
 
 		  $$ = kwcClass;       
@@ -399,7 +397,6 @@ oaAttributeArrayDeclaration :
 		  ObjectArray* oaAttributes = $1;
 		  KWAttribute* attribute=$2;
 		  KWClass* kwcClass=kwcLoadCurrentClass;
-		  boolean bOk;
 		  check(oaAttributes);
 
 		  /* Si attribut non valide: on ne fait rien */
@@ -432,9 +429,8 @@ oaAttributeArrayDeclaration :
 		  /* Si OK, d'insertion */
 		  else
 		  {
-		    bOk = kwcClass->InsertAttribute(attribute);
+		    kwcClass->InsertAttribute(attribute);
 		    oaAttributes->Add(attribute);
-			assert(bOk);
 		  }
 
 		  $$ = oaAttributes;       
@@ -444,7 +440,6 @@ oaAttributeArrayDeclaration :
 		  ObjectArray* oaAttributes;
 		  KWAttribute* attribute=$1;
 		  KWClass* kwcClass=kwcLoadCurrentClass;
-		  boolean bOk;
 
 		  /* Creation d'un tableau */
 		  oaAttributes = new ObjectArray;
@@ -479,9 +474,8 @@ oaAttributeArrayDeclaration :
 		  /* Si OK, d'insertion */
 		  else
 		  {
-		    bOk = kwcClass->InsertAttribute(attribute);
+		    kwcClass->InsertAttribute(attribute);
 		    oaAttributes->Add(attribute);
-			assert(bOk);
 		  }
 
 		  $$ = oaAttributes;       

--- a/src/Learning/KWData/KWClass.cpp
+++ b/src/Learning/KWData/KWClass.cpp
@@ -50,34 +50,28 @@ void KWClass::SetKeyAttributeNameAt(int nIndex, const ALString& sValue)
 	nFreshness++;
 }
 
-boolean KWClass::InsertAttribute(KWAttribute* attribute)
+void KWClass::InsertAttribute(KWAttribute* attribute)
 {
 	require(attribute != NULL);
 	require(CheckName(attribute->GetName(), attribute));
 	require(attribute->parentClass == NULL);
+	require(LookupAttribute(attribute->GetName()) == NULL);
+	require(LookupAttributeBlock(attribute->GetName()) == NULL);
 
-	// Test d'existence d'un attribut ou d'un bloc de meme nom
-	if (odAttributes.Lookup(attribute->GetName()) != NULL or odAttributeBlocks.Lookup(attribute->GetName()) != NULL)
-		return false;
-	// Insertion de l'attribut dans le dictionnaire et en fin de liste
-	else
-	{
-		// Ajout dans le dictionnaire des attributs
-		odAttributes.SetAt(attribute->GetName(), attribute);
-		attribute->parentClass = this;
+	// Ajout dans le dictionnaire des attributs
+	odAttributes.SetAt(attribute->GetName(), attribute);
+	attribute->parentClass = this;
 
-		// Ajout dans la liste
-		attribute->listPosition = olAttributes.AddTail(attribute);
+	// Ajout dans la liste
+	attribute->listPosition = olAttributes.AddTail(attribute);
 
-		// Fraicheur
-		nFreshness++;
+	// Fraicheur
+	nFreshness++;
 
-		assert(odAttributes.GetCount() == olAttributes.GetCount());
-		return true;
-	}
+	assert(odAttributes.GetCount() == olAttributes.GetCount());
 }
 
-boolean KWClass::InsertAttributeBefore(KWAttribute* attribute, KWAttribute* attributeRef)
+void KWClass::InsertAttributeBefore(KWAttribute* attribute, KWAttribute* attributeRef)
 {
 	require(attributeRef != NULL);
 	require(attributeRef == cast(KWAttribute*, odAttributes.Lookup(attributeRef->GetName())));
@@ -87,29 +81,23 @@ boolean KWClass::InsertAttributeBefore(KWAttribute* attribute, KWAttribute* attr
 	require(attribute != NULL);
 	require(CheckName(attribute->GetName(), this));
 	require(attribute->parentClass == NULL);
+	require(LookupAttribute(attribute->GetName()) == NULL);
+	require(LookupAttributeBlock(attribute->GetName()) == NULL);
 
-	// Test d'existence d'un attribut ou d'un bloc de meme nom
-	if (odAttributes.Lookup(attribute->GetName()) != NULL or odAttributeBlocks.Lookup(attribute->GetName()) != NULL)
-		return false;
-	// Insertion de l'attribut dans le dictionnaire et dans la liste
-	else
-	{
-		// Ajout dans le dictionnaire
-		odAttributes.SetAt(attribute->GetName(), attribute);
-		attribute->parentClass = this;
+	// Ajout dans le dictionnaire
+	odAttributes.SetAt(attribute->GetName(), attribute);
+	attribute->parentClass = this;
 
-		// Ajout dans la liste
-		attribute->listPosition = olAttributes.InsertBefore(attributeRef->listPosition, attribute);
+	// Ajout dans la liste
+	attribute->listPosition = olAttributes.InsertBefore(attributeRef->listPosition, attribute);
 
-		// Fraicheur
-		nFreshness++;
+	// Fraicheur
+	nFreshness++;
 
-		assert(odAttributes.GetCount() == olAttributes.GetCount());
-		return true;
-	}
+	assert(odAttributes.GetCount() == olAttributes.GetCount());
 }
 
-boolean KWClass::InsertAttributeAfter(KWAttribute* attribute, KWAttribute* attributeRef)
+void KWClass::InsertAttributeAfter(KWAttribute* attribute, KWAttribute* attributeRef)
 {
 	require(attributeRef != NULL);
 	require(attributeRef == cast(KWAttribute*, odAttributes.Lookup(attributeRef->GetName())));
@@ -118,29 +106,23 @@ boolean KWClass::InsertAttributeAfter(KWAttribute* attribute, KWAttribute* attri
 	require(attribute != NULL);
 	require(CheckName(attribute->GetName(), attribute));
 	require(attribute->parentClass == NULL);
+	require(LookupAttribute(attribute->GetName()) == NULL);
+	require(LookupAttributeBlock(attribute->GetName()) == NULL);
 
-	// Test d'existence d'un attribut ou d'un bloc de meme nom
-	if (odAttributes.Lookup(attribute->GetName()) != NULL or odAttributeBlocks.Lookup(attribute->GetName()) != NULL)
-		return false;
-	// Insertion de l'attribut dans le dictionnaire et dans la liste
-	else
-	{
-		// Ajout dans le dictionnaire
-		odAttributes.SetAt(attribute->GetName(), attribute);
-		attribute->parentClass = this;
+	// Ajout dans le dictionnaire
+	odAttributes.SetAt(attribute->GetName(), attribute);
+	attribute->parentClass = this;
 
-		// Ajout dans la liste
-		attribute->listPosition = olAttributes.InsertAfter(attributeRef->listPosition, attribute);
+	// Ajout dans la liste
+	attribute->listPosition = olAttributes.InsertAfter(attributeRef->listPosition, attribute);
 
-		// Fraicheur
-		nFreshness++;
+	// Fraicheur
+	nFreshness++;
 
-		assert(odAttributes.GetCount() == olAttributes.GetCount());
-		return true;
-	}
+	assert(odAttributes.GetCount() == olAttributes.GetCount());
 }
 
-boolean KWClass::RenameAttribute(KWAttribute* refAttribute, const ALString& sNewName)
+void KWClass::RenameAttribute(KWAttribute* refAttribute, const ALString& sNewName)
 {
 	KWAttribute* attribute;
 	KWDerivationRule* currentDerivationRule;
@@ -148,42 +130,36 @@ boolean KWClass::RenameAttribute(KWAttribute* refAttribute, const ALString& sNew
 	require(refAttribute != NULL);
 	require(refAttribute == cast(KWAttribute*, odAttributes.Lookup(refAttribute->GetName())));
 	require(refAttribute->parentClass == this);
+	require(LookupAttribute(sNewName) == NULL);
 	require(CheckName(sNewName, refAttribute));
 
-	// Test d'existence d'un attribut ou d'un bloc de meme nom
-	if (odAttributes.Lookup(sNewName) != NULL or odAttributeBlocks.Lookup(sNewName) != NULL)
-		return false;
 	// Renommage par manipulation dans le dictionnaire
-	else
+	// Propagation du renommage a toutes les regles de derivation
+	// des classes du domaine referencant l'attribut
+	attribute = GetHeadAttribute();
+	currentDerivationRule = NULL;
+	while (attribute != NULL)
 	{
-		// Propagation du renommage a toutes les regles de derivation
-		// des classes du domaine referencant l'attribut
-		attribute = GetHeadAttribute();
-		currentDerivationRule = NULL;
-		while (attribute != NULL)
+		// Detection de changement de regle de derivation (notamment pour les blocs)
+		if (attribute->GetAnyDerivationRule() != currentDerivationRule)
 		{
-			// Detection de changement de regle de derivation (notamment pour les blocs)
-			if (attribute->GetAnyDerivationRule() != currentDerivationRule)
-			{
-				currentDerivationRule = attribute->GetAnyDerivationRule();
+			currentDerivationRule = attribute->GetAnyDerivationRule();
 
-				// Renommage dans les regles de derivation (et au plus une seule fois par bloc)
-				if (currentDerivationRule != NULL)
-					currentDerivationRule->RenameAttribute(this, refAttribute, sNewName);
-			}
-
-			// Attribut suivant
-			GetNextAttribute(attribute);
+			// Renommage dans les regles de derivation (et au plus une seule fois par bloc)
+			if (currentDerivationRule != NULL)
+				currentDerivationRule->RenameAttribute(this, refAttribute, sNewName);
 		}
 
-		// Renommage de l'attribut dans la classe
-		odAttributes.RemoveKey(refAttribute->GetName());
-		refAttribute->usName.SetValue(sNewName);
-		odAttributes.SetAt(refAttribute->GetName(), refAttribute);
-		assert(odAttributes.GetCount() == olAttributes.GetCount());
-		nFreshness++;
-		return true;
+		// Attribut suivant
+		GetNextAttribute(attribute);
 	}
+
+	// Renommage de l'attribut dans la classe
+	odAttributes.RemoveKey(refAttribute->GetName());
+	refAttribute->usName.SetValue(sNewName);
+	odAttributes.SetAt(refAttribute->GetName(), refAttribute);
+	assert(odAttributes.GetCount() == olAttributes.GetCount());
+	nFreshness++;
 }
 
 void KWClass::UnsafeRenameAttribute(KWAttribute* refAttribute, const ALString& sNewName)
@@ -820,7 +796,7 @@ KWAttributeBlock* KWClass::CreateAttributeBlock(const ALString& sBlockName, KWAt
 	return attributeBlock;
 }
 
-boolean KWClass::InsertAttributeInBlock(KWAttribute* attribute, KWAttributeBlock* attributeBlockRef)
+void KWClass::InsertAttributeInBlock(KWAttribute* attribute, KWAttributeBlock* attributeBlockRef)
 {
 	require(attribute != NULL);
 	require(CheckName(attribute->GetName(), attribute));
@@ -833,31 +809,24 @@ boolean KWClass::InsertAttributeInBlock(KWAttribute* attribute, KWAttributeBlock
 		attributeBlockRef->GetFirstAttribute());
 	require(LookupAttribute(attributeBlockRef->GetLastAttribute()->GetName()) ==
 		attributeBlockRef->GetLastAttribute());
+	require(LookupAttribute(attribute->GetName()) == NULL);
+	require(LookupAttributeBlock(attribute->GetName()) == NULL);
 
-	// Test d'existence d'un attribut ou d'un bloc de meme nom
-	if (odAttributes.Lookup(attribute->GetName()) != NULL or odAttributeBlocks.Lookup(attribute->GetName()) != NULL)
-		return false;
-	// Insertion de l'attribut dans le dictionnaire et en fin de liste
-	else
-	{
-		// Ajout dans le dictionnaire des attributs
-		odAttributes.SetAt(attribute->GetName(), attribute);
-		attribute->parentClass = this;
+	// Ajout dans le dictionnaire des attributs
+	odAttributes.SetAt(attribute->GetName(), attribute);
+	attribute->parentClass = this;
 
-		// Ajout dans la liste, apres le dernier attribut du bloc
-		attribute->listPosition =
-		    olAttributes.InsertAfter(attributeBlockRef->lastAttribute->listPosition, attribute);
+	// Ajout dans la liste, apres le dernier attribut du bloc
+	attribute->listPosition = olAttributes.InsertAfter(attributeBlockRef->lastAttribute->listPosition, attribute);
 
-		// Mise a jour des informations sur le block
-		attribute->attributeBlock = attributeBlockRef;
-		attributeBlockRef->lastAttribute = attribute;
+	// Mise a jour des informations sur le block
+	attribute->attributeBlock = attributeBlockRef;
+	attributeBlockRef->lastAttribute = attribute;
 
-		// Fraicheur
-		nFreshness++;
+	// Fraicheur
+	nFreshness++;
 
-		assert(odAttributes.GetCount() == olAttributes.GetCount());
-		return true;
-	}
+	assert(odAttributes.GetCount() == olAttributes.GetCount());
 }
 
 KWAttributeBlock* KWClass::LookupAttributeBlock(const ALString& sBlockName) const

--- a/src/Learning/KWData/KWClass.cpp
+++ b/src/Learning/KWData/KWClass.cpp
@@ -2314,7 +2314,7 @@ KWClass* KWClass::CreateClass(const ALString& sClassName, int nKeySize, int nSym
 	for (i = 0; i < nTextListNumber; i++)
 	{
 		attribute = new KWAttribute;
-		attribute->SetName(sPrefix + KWType::ToString(KWType::Text) + IntToString(i + 1));
+		attribute->SetName(sPrefix + KWType::ToString(KWType::TextList) + IntToString(i + 1));
 		attribute->SetLabel("Label of " + attribute->GetName());
 		attribute->SetType(KWType::TextList);
 		kwcClass->InsertAttribute(attribute);

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -122,23 +122,22 @@ public:
 	KWAttribute* LookupAttribute(const ALString& sAttributeName) const;
 
 	// Ajout d'un attribut en fin de liste, et par rapport a un autre attribut
-	// Renvoie true si OK, false sinon (attribut ou bloc existant)
-	boolean InsertAttribute(KWAttribute* attribute);
+	// Le nom de l'attribut ne doit pas deja exister
+	void InsertAttribute(KWAttribute* attribute);
 
 	// Insertion avant ou apres un attribut existant
 	// Erreur de programmation si attribut de reference inexistant,
 	// ou au milieu d'un bloc (on peut etre au debut d'un bloc pour
 	// le InsertBefore ou a la fin d'un bloc pour le InsertAfter)
-	// Renvoie true si OK, false sinon (attribut ou bloc existant)
-	boolean InsertAttributeBefore(KWAttribute* attribute, KWAttribute* attributeRef);
-	boolean InsertAttributeAfter(KWAttribute* attribute, KWAttribute* attributeRef);
+	// Le nom de l'attribut ne doit pas deja exister
+	void InsertAttributeBefore(KWAttribute* attribute, KWAttribute* attributeRef);
+	void InsertAttributeAfter(KWAttribute* attribute, KWAttribute* attributeRef);
 
 	// Renommage d'un attribut
-	// Retourne true si OK. Sans effet si le nom cible existe deja
-	// parmi les attribut ou les blocs.
+	// Le nom cible ne doit pas exister parmi les attribut ou les blocs.
 	// Propagation a toutes les references a cet attribut dans les regles
 	// de derivations des attributs de la classe
-	boolean RenameAttribute(KWAttribute* refAttribute, const ALString& sNewName);
+	void RenameAttribute(KWAttribute* refAttribute, const ALString& sNewName);
 
 	// Renommage d'un attribut sans se soucier des utilisation dans les regles
 	// Le nom doit etre inexistant dans la classe
@@ -248,8 +247,8 @@ public:
 					       KWAttribute* lastAttribute);
 
 	// Ajout d'un attribut en fin d'un bloc existant
-	// Renvoie true si OK, false sinon (attribut ou bloc existant)
-	boolean InsertAttributeInBlock(KWAttribute* attribute, KWAttributeBlock* attributeBlockRef);
+	// Le nom de l'attribut ne doit pas deja exister
+	void InsertAttributeInBlock(KWAttribute* attribute, KWAttributeBlock* attributeBlockRef);
 
 	// Recherche d'un bloc par son nom
 	// Retourne NUL si bloc inexistant

--- a/src/Learning/KWData/KWClassDomain.h
+++ b/src/Learning/KWData/KWClassDomain.h
@@ -72,24 +72,24 @@ public:
 	// Recherche (retourne NULL si echec)
 	KWClass* LookupClass(const ALString& sClassName) const;
 
-	// Insertion (echec si classe de meme nom existante)
-	boolean InsertClass(KWClass* newObject);
+	// Insertion d'une nouvelle classe
+	void InsertClass(KWClass* newObject);
 
 	// Insertion avec nouveau non (ce nom ne doit pas deja exister)
 	// Apres insertion, la classe a changee de nom
 	void InsertClassWithNewName(KWClass* newObject, const ALString& sNewName);
 
 	// Supression
-	boolean RemoveClass(const ALString& sClassName);
+	void RemoveClass(const ALString& sClassName);
 
 	// Supression et destruction
-	boolean DeleteClass(const ALString& sClassName);
+	void DeleteClass(const ALString& sClassName);
 
 	// Renommage d'une classe ou d'un attribut
-	// Retourne true si OK. Sans effet si le nom cible existe deja.
+	// Le nom cible ne doit pas exister
 	// Propagation a toutes les utilisations dans les regles de derivation
-	boolean RenameClass(KWClass* refClass, const ALString& sNewClassName);
-	boolean RenameAttribute(KWAttribute* refAttribute, const ALString& sNewAttributeName);
+	void RenameClass(KWClass* refClass, const ALString& sNewClassName);
+	void RenameAttribute(KWAttribute* refAttribute, const ALString& sNewAttributeName);
 
 	// Acces massifs
 	int GetClassNumber() const;
@@ -180,17 +180,17 @@ public:
 	static KWClassDomain* LookupDomain(const ALString& sName);
 
 	// Insertion
-	static boolean InsertDomain(KWClassDomain* newObject);
+	static void InsertDomain(KWClassDomain* newObject);
 
 	// Supression
-	static boolean RemoveDomain(const ALString& sName);
+	static void RemoveDomain(const ALString& sName);
 
 	// Supression et destruction
-	static boolean DeleteDomain(const ALString& sName);
+	static void DeleteDomain(const ALString& sName);
 
 	// Renommage du domaine
 	// Retourne true si OK. Sans effet si le nom cible existe deja.
-	static boolean RenameDomain(KWClassDomain* domain, const ALString& sNewName);
+	static void RenameDomain(KWClassDomain* domain, const ALString& sNewName);
 
 	// Acces massifs
 	static int GetDomainNumber();

--- a/src/Learning/KWData/KWDataTableDriverTextFile.cpp
+++ b/src/Learning/KWData/KWDataTableDriverTextFile.cpp
@@ -102,7 +102,6 @@ boolean KWDataTableDriverTextFile::BuildDataTableClass(KWClass* kwcDataTableClas
 	ALString sField;
 	KWAttribute* attribute;
 	ALString sAttributeName;
-	boolean bAttributeOk;
 	ALString sTmp;
 
 	require(inputBuffer == NULL);
@@ -165,8 +164,7 @@ boolean KWDataTableDriverTextFile::BuildDataTableClass(KWClass* kwcDataTableClas
 				attribute = new KWAttribute;
 				attribute->SetType(KWType::Symbol);
 				attribute->SetName(sAttributeName);
-				bAttributeOk = kwcDataTableClass->InsertAttribute(attribute);
-				assert(bAttributeOk);
+				kwcDataTableClass->InsertAttribute(attribute);
 			}
 
 			// Message si beaucoup de champs

--- a/src/Learning/KWDataPreparation/KWDataGridStats.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridStats.cpp
@@ -2764,6 +2764,8 @@ KWDGSAttributeDiscretization* KWDGSAttributeDiscretization::CreateTestAttribute(
 	attribute->SetAttributeName("Att");
 
 	// Creation des bornes des intervalles
+	attribute->SetInitialValueNumber(nPartNumber);
+	attribute->SetGranularizedValueNumber(nPartNumber);
 	attribute->SetPartNumber(nPartNumber);
 	for (nBound = 0; nBound < attribute->GetIntervalBoundNumber(); nBound++)
 		attribute->SetIntervalBoundAt(nBound, (Continuous)(1.0 + nBound));
@@ -3294,6 +3296,8 @@ KWDGSAttributeGrouping* KWDGSAttributeGrouping::CreateTestAttribute(int nPartNum
 	attribute->SetValueAt(attribute->GetKeptValueNumber() - 1, Symbol::GetStarValue());
 
 	// Creation des groupes
+	attribute->GetKeptValueNumber();
+	attribute->SetGranularizedValueNumber(nPartNumber);
 	attribute->SetPartNumber(nPartNumber);
 	for (nGroup = 0; nGroup < attribute->GetGroupNumber(); nGroup++)
 		attribute->SetGroupFirstValueIndexAt(nGroup, nGroup * nGroupSize);
@@ -3498,6 +3502,8 @@ KWDGSAttributeContinuousValues* KWDGSAttributeContinuousValues::CreateTestAttrib
 	attribute->SetAttributeName("Att");
 
 	// Creation des valeurs
+	attribute->SetInitialValueNumber(nPartNumber);
+	attribute->SetGranularizedValueNumber(nPartNumber);
 	attribute->SetPartNumber(nPartNumber);
 	for (nValue = 0; nValue < attribute->GetValueNumber(); nValue++)
 		attribute->SetValueAt(nValue, (Continuous)(1.0 + nValue));
@@ -3712,6 +3718,8 @@ KWDGSAttributeSymbolValues* KWDGSAttributeSymbolValues::CreateTestAttribute(int 
 	attribute->SetAttributeName("Att");
 
 	// Creation des valeurs
+	attribute->SetInitialValueNumber(nPartNumber);
+	attribute->SetGranularizedValueNumber(nPartNumber);
 	attribute->SetPartNumber(nPartNumber);
 	for (nValue = 0; nValue < attribute->GetValueNumber(); nValue++)
 		attribute->SetValueAt(nValue, Symbol(sValuePrefix + IntToString(nValue + 1)));

--- a/test/UnitTests/Learning/Learning_test.cpp
+++ b/test/UnitTests/Learning/Learning_test.cpp
@@ -2,6 +2,7 @@
 // This software is distributed under the BSD 3-Clause-clear License, the text of which is available
 // at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
 
+#include "Standard.h"
 #include "KWClass.h"
 #include "KWClassDomain.h"
 #include "KWProbabilityTable.h"
@@ -19,6 +20,6 @@ KHIOPS_TEST(KWData, KWClassDomain, KWClassDomain::Test);
 
 // Librairie KWDataPreparation
 KHIOPS_TEST(KWDataPreparation, KWQuantileIntervalBuilder, KWQuantileIntervalBuilder::Test);
-// BUG il y a une assertion KHIOPS_TEST(KWDataPreparation, KWProbabilityTable, KWProbabilityTable::Test);
+KHIOPS_TEST(KWDataPreparation, KWProbabilityTable, KWProbabilityTable::Test);
 
 } // namespace

--- a/test/UnitTests/Learning/results.ref/KWData_KWClass.txt
+++ b/test/UnitTests/Learning/results.ref/KWData_KWClass.txt
@@ -33,6 +33,7 @@ Root	Dictionary	TestClass	(Key1)
 	Timestamp	SAttTimestamp1		;	// Label of SAttTimestamp1
 	TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
 	Text	SAttText1		;	// Label of SAttText1
+	TextList	SAttTextList1		;	// Label of SAttTextList1
 	Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
 	Entity(AttributeClass)	SAttEntity2		;	// Label of SAttEntity2
 	Table(AttributeClass)	SAttTable1		;	// Label of SAttTable1
@@ -52,6 +53,7 @@ Dictionary TestClass : List iteration
 		Timestamp	SAttTimestamp1		;	// Label of SAttTimestamp1
 		TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
 		Text	SAttText1		;	// Label of SAttText1
+		TextList	SAttTextList1		;	// Label of SAttTextList1
 		Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
 		Entity(AttributeClass)	SAttEntity2		;	// Label of SAttEntity2
 		Table(AttributeClass)	SAttTable1		;	// Label of SAttTable1
@@ -61,6 +63,7 @@ Dictionary TestClass : Inverse list iteration
 		Table(AttributeClass)	SAttTable1		;	// Label of SAttTable1
 		Entity(AttributeClass)	SAttEntity2		;	// Label of SAttEntity2
 		Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
+		TextList	SAttTextList1		;	// Label of SAttTextList1
 		Text	SAttText1		;	// Label of SAttText1
 		TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
 		Timestamp	SAttTimestamp1		;	// Label of SAttTimestamp1
@@ -86,6 +89,7 @@ Dictionary TestClass : Used variables
 		Timestamp	SAttTimestamp1		;	// Label of SAttTimestamp1
 		TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
 		Text	SAttText1		;	// Label of SAttText1
+		TextList	SAttTextList1		;	// Label of SAttTextList1
 		Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
 		Entity(AttributeClass)	SAttEntity2		;	// Label of SAttEntity2
 		Table(AttributeClass)	SAttTable1		;	// Label of SAttTable1
@@ -103,6 +107,7 @@ Dictionary TestClass : Loaded variables
 		Timestamp	SAttTimestamp1		;	// Label of SAttTimestamp1
 		TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
 		Text	SAttText1		;	// Label of SAttText1
+		TextList	SAttTextList1		;	// Label of SAttTextList1
 		Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
 		Entity(AttributeClass)	SAttEntity2		;	// Label of SAttEntity2
 		Table(AttributeClass)	SAttTable1		;	// Label of SAttTable1
@@ -113,6 +118,7 @@ Dictionary TestClass : Dense categorical variables
 Dictionary TestClass : Text variables
 		Text	SAttText1		;	// Label of SAttText1
 Dictionary TestClass : TextList variables
+		TextList	SAttTextList1		;	// Label of SAttTextList1
 Dictionary TestClass : Dense relation variables
 		Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
 		Entity(AttributeClass)	SAttEntity2		;	// Label of SAttEntity2
@@ -135,15 +141,17 @@ Dictionary TestClass : List iteration
 		Timestamp	SAttTimestamp1		; <_NotLoaded>	// Label of SAttTimestamp1
 		TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
 	Unused	Text	SAttText1		;	// Label of SAttText1
-		Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
-		Entity(AttributeClass)	SAttEntity2		; <_NotLoaded>	// Label of SAttEntity2
-	Unused	Table(AttributeClass)	SAttTable1		;	// Label of SAttTable1
-		Table(AttributeClass)	SAttTable2		; <_NotLoaded>	// Label of SAttTable2
+		TextList	SAttTextList1		;	// Label of SAttTextList1
+		Entity(AttributeClass)	SAttEntity1		; <_NotLoaded>	// Label of SAttEntity1
+	Unused	Entity(AttributeClass)	SAttEntity2		;	// Label of SAttEntity2
+		Table(AttributeClass)	SAttTable1		; <_NotLoaded>	// Label of SAttTable1
+		Table(AttributeClass)	SAttTable2		;	// Label of SAttTable2
 Dictionary TestClass : Inverse list iteration
-		Table(AttributeClass)	SAttTable2		; <_NotLoaded>	// Label of SAttTable2
-	Unused	Table(AttributeClass)	SAttTable1		;	// Label of SAttTable1
-		Entity(AttributeClass)	SAttEntity2		; <_NotLoaded>	// Label of SAttEntity2
-		Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
+		Table(AttributeClass)	SAttTable2		;	// Label of SAttTable2
+		Table(AttributeClass)	SAttTable1		; <_NotLoaded>	// Label of SAttTable1
+	Unused	Entity(AttributeClass)	SAttEntity2		;	// Label of SAttEntity2
+		Entity(AttributeClass)	SAttEntity1		; <_NotLoaded>	// Label of SAttEntity1
+		TextList	SAttTextList1		;	// Label of SAttTextList1
 	Unused	Text	SAttText1		;	// Label of SAttText1
 		TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
 		Timestamp	SAttTimestamp1		; <_NotLoaded>	// Label of SAttTimestamp1
@@ -165,21 +173,24 @@ Dictionary TestClass : Used variables
 		Date	SAttDate1		; <_NotLoaded>	// Label of SAttDate1
 		Timestamp	SAttTimestamp1		; <_NotLoaded>	// Label of SAttTimestamp1
 		TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
-		Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
-		Entity(AttributeClass)	SAttEntity2		; <_NotLoaded>	// Label of SAttEntity2
-		Table(AttributeClass)	SAttTable2		; <_NotLoaded>	// Label of SAttTable2
+		TextList	SAttTextList1		;	// Label of SAttTextList1
+		Entity(AttributeClass)	SAttEntity1		; <_NotLoaded>	// Label of SAttEntity1
+		Table(AttributeClass)	SAttTable1		; <_NotLoaded>	// Label of SAttTable1
+		Table(AttributeClass)	SAttTable2		;	// Label of SAttTable2
 Dictionary TestClass : Loaded variables
 		Categorical	Key1		;	// Label of Key1
 		Numerical	AttN1		;	// Label of AttN1
 		Numerical	SAttN3		; <VarKey="3">	// Label of SAttN3
 		TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
-		Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
+		TextList	SAttTextList1		;	// Label of SAttTextList1
+		Table(AttributeClass)	SAttTable2		;	// Label of SAttTable2
 Dictionary TestClass : Dense categorical variables
 		Categorical	Key1		;	// Label of Key1
 Dictionary TestClass : Text variables
 Dictionary TestClass : TextList variables
+		TextList	SAttTextList1		;	// Label of SAttTextList1
 Dictionary TestClass : Dense relation variables
-		Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
+		Table(AttributeClass)	SAttTable2		;	// Label of SAttTable2
 
 // Label of TestClass
 Root	Dictionary	TestClass	(Key1)
@@ -200,10 +211,11 @@ Unused	Time	SAttTime1		;	// Label of SAttTime1
 	Timestamp	SAttTimestamp1		; <_NotLoaded>	// Label of SAttTimestamp1
 	TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
 Unused	Text	SAttText1		;	// Label of SAttText1
-	Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
-	Entity(AttributeClass)	SAttEntity2		; <_NotLoaded>	// Label of SAttEntity2
-Unused	Table(AttributeClass)	SAttTable1		;	// Label of SAttTable1
-	Table(AttributeClass)	SAttTable2		; <_NotLoaded>	// Label of SAttTable2
+	TextList	SAttTextList1		;	// Label of SAttTextList1
+	Entity(AttributeClass)	SAttEntity1		; <_NotLoaded>	// Label of SAttEntity1
+Unused	Entity(AttributeClass)	SAttEntity2		;	// Label of SAttEntity2
+	Table(AttributeClass)	SAttTable1		; <_NotLoaded>	// Label of SAttTable1
+	Table(AttributeClass)	SAttTable2		;	// Label of SAttTable2
 };
 
 
@@ -220,7 +232,8 @@ Root	Dictionary	TestClassClone	(Key1)
 	Numerical	SAttN3		; <VarKey="3">	// Label of SAttN3
 	}	SAttNumericalBlock		; <DefaultNumericalValue=0>	
 	TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
-	Entity(AttributeClass)	SAttEntity1		;	// Label of SAttEntity1
+	TextList	SAttTextList1		;	// Label of SAttTextList1
+	Table(AttributeClass)	SAttTable2		;	// Label of SAttTable2
 };
 
 
@@ -240,9 +253,10 @@ Root	Dictionary	TestClassClone	(Key1)
 	Numerical	SAttN3		; <VarKey="3">	// Label of SAttN3
 	}	SAttNumericalBlock		; <DefaultNumericalValue=0>	
 	TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
-	Numerical	LastAtt_1		;	// Label of SAttEntity1
-	Entity(AttributeClass)	LastAtt		;	// Label of SAttEntity1
-	Categorical	LastAtt_2		;	// Label of SAttEntity1
+	TextList	SAttTextList1		;	// Label of SAttTextList1
+	Numerical	LastAtt_1		;	// Label of SAttTable2
+	Table(AttributeClass)	LastAtt		;	// Label of SAttTable2
+	Categorical	LastAtt_2		;	// Label of SAttTable2
 };
 
 Dictionary TestClassClone : List iteration
@@ -253,9 +267,10 @@ Dictionary TestClassClone : List iteration
 		Numerical	AttN1		;	// Label of AttN1
 		Numerical	SAttN3		; <VarKey="3">	// Label of SAttN3
 		TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
-		Numerical	LastAtt_1		;	// Label of SAttEntity1
-		Entity(AttributeClass)	LastAtt		;	// Label of SAttEntity1
-		Categorical	LastAtt_2		;	// Label of SAttEntity1
+		TextList	SAttTextList1		;	// Label of SAttTextList1
+		Numerical	LastAtt_1		;	// Label of SAttTable2
+		Table(AttributeClass)	LastAtt		;	// Label of SAttTable2
+		Categorical	LastAtt_2		;	// Label of SAttTable2
 Dictionary TestClassClone : Loaded variables
 		Categorical	Key1		;	
 		Numerical	FirstAtt_1		;	// Label of Key1
@@ -264,7 +279,8 @@ Dictionary TestClassClone : Loaded variables
 		Numerical	AttN1		;	// Label of AttN1
 		Numerical	SAttN3		; <VarKey="3">	// Label of SAttN3
 		TimestampTZ	SAttTimestampTZ1		;	// Label of SAttTimestampTZ1
-		Numerical	LastAtt_1		;	// Label of SAttEntity1
-		Entity(AttributeClass)	LastAtt		;	// Label of SAttEntity1
-		Categorical	LastAtt_2		;	// Label of SAttEntity1
+		TextList	SAttTextList1		;	// Label of SAttTextList1
+		Numerical	LastAtt_1		;	// Label of SAttTable2
+		Table(AttributeClass)	LastAtt		;	// Label of SAttTable2
+		Categorical	LastAtt_2		;	// Label of SAttTable2
 

--- a/test/UnitTests/Learning/results.ref/KWData_KWClassDomain.txt
+++ b/test/UnitTests/Learning/results.ref/KWData_KWClassDomain.txt
@@ -29,6 +29,7 @@ Dictionary	Class2	(Key1, Key2)
 	Timestamp	Timestamp1		;	// Label of Timestamp1
 	TimestampTZ	TimestampTZ1		;	// Label of TimestampTZ1
 	Text	Text1		;	// Label of Text1
+	TextList	TextList1		;	// Label of TextList1
 	Entity(Class1)	Entity1		;	// Label of Entity1
 	Entity(Class1)	Entity2		;	// Label of Entity2
 	Entity(Class1)	Entity3		;	// Label of Entity3
@@ -77,6 +78,7 @@ Dictionary	Class2	(Key1, Key2)
 	Timestamp	Timestamp1		;	// Label of Timestamp1
 	TimestampTZ	TimestampTZ1		;	// Label of TimestampTZ1
 	Text	Text1		;	// Label of Text1
+	TextList	TextList1		;	// Label of TextList1
 	Entity(Class1)	Entity1		;	// Label of Entity1
 	Entity(Class1)	Entity2		;	// Label of Entity2
 	Entity(Class1)	Entity3		;	// Label of Entity3

--- a/test/UnitTests/Utils/TestServices.cpp
+++ b/test/UnitTests/Utils/TestServices.cpp
@@ -66,6 +66,7 @@ boolean FileCompareForTest(const ALString& sFileNameReference, const ALString& s
 	boolean bOk1;
 	boolean bOk2;
 	boolean bSame = true;
+	boolean bDifferentLineNumber = false;
 	const char sSys[] = "SYS";
 	int nLineIndex;
 	const int nMaxSize = 5000; // Permet de stocker un path tres long
@@ -109,6 +110,7 @@ boolean FileCompareForTest(const ALString& sFileNameReference, const ALString& s
 	if (not fileTest)
 	{
 		fclose(fileRef);
+		cout << "Unable to open test file" << endl;
 		return false;
 	}
 
@@ -118,10 +120,12 @@ boolean FileCompareForTest(const ALString& sFileNameReference, const ALString& s
 	{
 		nLineIndex++;
 
-		// Si il manque des lignes, il y a une erreur
+		// Si il manque des lignes en test, il y a une erreur
 		if (fgets(lineTest, sizeof(lineTest), fileTest) == NULL)
 		{
 			bSame = false;
+			bDifferentLineNumber = true;
+			cout << endl << "error not enough lines in test (Test: " << nLineIndex << " lines)" << endl;
 			break;
 		}
 
@@ -157,7 +161,17 @@ boolean FileCompareForTest(const ALString& sFileNameReference, const ALString& s
 				break;
 		}
 	}
-	if (not bSame)
+
+	// Si il y a trop de lignes en test, il y a une erreur
+	if (fgets(lineTest, sizeof(lineTest), fileTest) != NULL)
+	{
+		bSame = false;
+		bDifferentLineNumber = true;
+		cout << endl << "error too many lines in test (Ref: " << nLineIndex << " lines)" << endl;
+	}
+
+	// Erreur si ligne differente, sans probleme de difference de nombre de lignes
+	if (not bSame and not bDifferentLineNumber)
 	{
 		cout << endl << "error at line " << nLineIndex << endl;
 		cout << "Ref:  " << sLineRef << endl;
@@ -208,6 +222,9 @@ boolean TestAndCompareResults(const char* sTestPath, const char* test_suite, con
 	ALString sFileName;
 	FILE* stream;
 	int fdInit;
+
+	// Parametrage de l'arret pour la memoire
+	//MemSetAllocIndexExit(3391);
 
 	// On passe en mode batch pour avoir des parametres par defaut, sans interaction utilisateur
 	SetAcquireBatchMode(true);

--- a/test/UnitTests/Utils/TestServices.cpp
+++ b/test/UnitTests/Utils/TestServices.cpp
@@ -224,7 +224,9 @@ boolean TestAndCompareResults(const char* sTestPath, const char* test_suite, con
 	int fdInit;
 
 	// Parametrage de l'arret pour la memoire
-	//MemSetAllocIndexExit(3391);
+	// Le framework de gestion des tests unitaires n'ayant pas de main(), cela semble etre
+	// l'endroit pertinent pour la detection des fuites memoire
+	// MemSetAllocIndexExit(3391);
 
 	// On passe en mode batch pour avoir des parametres par defaut, sans interaction utilisateur
 	SetAcquireBatchMode(true);


### PR DESCRIPTION
Correction des bugs des tests unitaires
- finalisation des méthodes du framework (comparaison de fichier)
- correction des test unitaires de Learning_test
  - fuite mémoire dans KWClass::Test et KWClassDomain::Test
  - assertion dans KWProbabilityTable::Test

Plus au passage, simplification des méthode Insert, Rename, Remove de KWClass et KWClassDomain
- passage de code retour void plutôt que que boolean: simplification du code existant, pour ces codes retour jamais utilisée
- controle effectuer par require: pour détecter les bugs plus vite