### PR TITLE
force gcc optimization to O1 in KWDGPODiscretizer

### DIFF
--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -108,7 +108,7 @@ jobs:
           khiops -v
           khiops_coclustering -v
       - name: Test Khiops installation
-        continue-on-error: ${{ matrix.os == 'debian:11' || matrix.os == 'debian:12' }}
+        continue-on-error: ${{ matrix.os == 'debian:11' }}
         uses: ./.github/actions/test-khiops-install
   test-kni:
     needs: build

--- a/src/Learning/KWDataPreparation/KWDataGridPostOptimizer.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridPostOptimizer.cpp
@@ -560,6 +560,19 @@ void KWDGPODiscretizer::InitializeCellFrequencyVector(KWDGPOCellFrequencyVector*
 // Index de l'attribut a post-optimiser (et donc a ignorer pour le calcul de la signature exogene
 static int nKWDGPODiscretizerPostOptimizationAttributeIndex = -1;
 
+// Bug detecte sur debian 12 avec la version 12.2.0 de gcc. Ce bug apparait en release mais pas en debug.
+// On force la compilation en O1 car il doit y avoir une sur-optimisation de gcc en mode 02 :
+// il y a un segmentation fault, gdb indique que cell1 est a NULL.
+// En ajoutant la ligne suivante (inutile) apres les cast, le bug disparait
+// if (cell1==NULL or cell2==NULL) exit(1);
+// Bug similaire dans KWSortableIndex.h, classe KWIntVectorSorter
+#if defined NDEBUG && defined __GNUC__ && !defined __clang__
+#if __GNUC__ >= 12
+#pragma GCC push_options
+#pragma GCC optimize("O1")
+#endif
+#endif
+
 // Fonction de comparaison de deux cellules basee sur leur signature exogene
 int KWDGPODiscretizerCompareCell(const void* elem1, const void* elem2)
 {
@@ -595,6 +608,12 @@ int KWDGPODiscretizerCompareCell(const void* elem1, const void* elem2)
 	}
 	return 0;
 }
+
+#if defined NDEBUG && defined __GNUC__ && !defined __clang__
+#if __GNUC__ >= 12
+#pragma GCC pop_options
+#endif
+#endif
 
 void KWDGPODiscretizer::InitializeHashCellDictionary(NumericKeyDictionary* nkdHashCells,
 						     const KWDataGrid* dataGrid) const
@@ -1495,6 +1514,15 @@ void KWDGPOGrouper::InitializeCellFrequencyVector(KWDGPOCellFrequencyVector* cel
 // Index de l'attribut a post-optimiser (et donc a ignorer pour le calcul de la signature exogene
 static int nKWDGPOGrouperPostOptimizationAttributeIndex = -1;
 
+// On force l'optimisation en O1 car il y a un probleme avec gcc v12
+// Cf. pbm similaire pour la methode KWDGPODiscretizerCompareCell
+#if defined NDEBUG && defined __GNUC__ && !defined __clang__
+#if __GNUC__ >= 12
+#pragma GCC push_options
+#pragma GCC optimize("O1")
+#endif
+#endif
+
 // Fonction de comparaison de deux cellules basee sur leur signature exogene
 int KWDGPOGrouperCompareCell(const void* elem1, const void* elem2)
 {
@@ -1530,6 +1558,12 @@ int KWDGPOGrouperCompareCell(const void* elem1, const void* elem2)
 	}
 	return 0;
 }
+
+#if defined NDEBUG && defined __GNUC__ && !defined __clang__
+#if __GNUC__ >= 12
+#pragma GCC pop_options
+#endif
+#endif
 
 void KWDGPOGrouper::InitializeHashCellDictionary(NumericKeyDictionary* nkdHashCells, const KWDataGrid* dataGrid) const
 {


### PR DESCRIPTION
With gcc 12.2.0 (on debian 12), gcc seems too aggressive. The only way to fix a segmentation fault is to force the optimization level to O1 instead of O2.

The segmentation fault occurred while accessing the variable cell1 which is NULL. By adding the following (unnecessary) line, the segmentation fault vanishes: 
```cpp
if (cell1==NULL or cell2==NULL) exit(1);
```
With O1 optimization level, this line is not necessary to cope with this segmentation fault
close #163 