### PR TITLE
Fix bug for unsupported entries containing only empty sparse blocks

### DIFF
--- a/src/Learning/KWData/KWDataTableDriverTextFile.cpp
+++ b/src/Learning/KWData/KWDataTableDriverTextFile.cpp
@@ -385,10 +385,16 @@ KWObject* KWDataTableDriverTextFile::Read()
 				kwoObject = NULL;
 				break;
 			}
-			// Sinon, on sort pour ne pas comptabiliser le champs,
-			// uniquement si on est dans le cas d'un dictionnaire sans attribut natif
+			// Sinon, on sort si on est dans le cas d'un dictionnaire sans attribut natif
 			else if (kwcClass->GetNativeDataItemNumber() == 0)
+			{
+				// On comptabilise le champ dans le cas d'un champ dans le fichier pour indiquer que l'on a bien
+				// lu tous les champs de la ligne, dans ce cas particulier d'un ligne vide interpretee comme
+				// une ligne comportant un seul champ avec valeur manquante
+				if (livDataItemLoadIndexes.GetSize() == 1)
+					nField++;
 				break;
+			}
 		}
 
 		// Alimentation des champs de la derniere cle lue si necessaire
@@ -1896,7 +1902,8 @@ boolean KWDataTableDriverTextFile::ComputeDataItemLoadIndexes(const KWClass* kwc
 	// Affichage du resultat d'indexation
 	if (bDisplay)
 	{
-		cout << "Compute data item indexes of dictionary " << kwcClass->GetName() << endl;
+		cout << "Compute data item indexes of dictionary " << kwcClass->GetName() << " " << GetDataTableName()
+		     << endl;
 
 		// Cas avec classe de ligne d'entete
 		if (kwcHeaderLineClass != NULL)
@@ -1940,6 +1947,11 @@ boolean KWDataTableDriverTextFile::ComputeDataItemLoadIndexes(const KWClass* kwc
 				}
 			}
 		}
+
+		// Affichage des dictionnaires
+		cout << "Logical class\n" << *kwcLogicalClass << endl;
+		if (kwcHeaderLineClass != NULL)
+			cout << "Header line class\n" << *kwcHeaderLineClass << endl;
 	}
 	assert(not bOk or lastReadRootKey.GetSize() > 0 or not kwcClass->GetRoot());
 	return bOk;


### PR DESCRIPTION
Bug detecte par Vladimir, 2024-04-11
  Currently, entries that only have one column which is a sparse block which has all variables as missing (undefined)
   are not processed and predictions are not computed.
  Namely, entries which only contain one single sparse block for which all values are missing are not being predicted targets for.
  These entries are specified through dictionaries which have all variables in a single block (which is the sparse block).

Jeu de test: LearningTest\TestKhiops\SideEffects\BugMissingSparseData
- dictionnaire avec un bloc sparse et une variable cible
- deploiement selon trois cas
  - table initiale avec les deux colonnes
  - table avec colonne en entree uniquement (toleree, car la variable cible est un Unsued dans le deploiement d'un predicteur)
    - avec une partie des ligne a vide
    - avec toutes les lignes a vide
 - BUG: toutes les lignes vides sont ignoree et non scoree
   - avec warning "Ignored record, bad field number (0 read fields for 1 expected fields)"

 Analyse du probleme
 - lors de la lecture d'un fichier, on controle que le nombre de variables natives du dictionnaire est egal au nombre de colonnes du fichier
   - erreur si nombres differents
   - message d'erreur specifique dans le cas des lignes vides
 - effet de bord des lignes vides
   - erreur si plusieurs variable natives attendues
   - sauf si une seule variable native attendue, et valeur manquante
   - sauf si aucune variable native attendue, et valeur manquante
  - ici, il s'agit d'un effet de bord "multiple"
   - un seul bloc (ou une seule variable) en entree en plus de la variable de classe
   - fichier a deployer avec une seule colonne (sans la colonne de la variable de classe)
   - valeurs manquantes dans cette colonne
   - aucune variable informative, et donc bloc en entree non utilise pour le calcul des scores et il est inutile de le lire
   - le dictionnaire de deploiement n'utilise alors aucune variable native
     - celle de la classe est en unused
     - les variable natives en entree sont egalement en unused, et aucune n'est utilisee en operande de calcul pour les scores - le dictionnaire "physique" exploite pour le deploiement n'a donc besoin de lire aucune variable dans le fichier
        - il ne contient aucunne variable native
        - il n'a besoin que de gerer les enregistrement, un par ligne, meme si les lignes sont vides

 Correction
 - prise en compte de l'effet de bord dans la methode KWDataTableDriverTextFile::Read