### PR TITLE
Eliminate LearningTest directory naming requirement from kht_test

### DIFF
--- a/test/LearningTestTool/py/_kht_check_results.py
+++ b/test/LearningTestTool/py/_kht_check_results.py
@@ -10,15 +10,15 @@ Verification des resultats d'un repertoire de test terminal
 
 La comparaison est effectue entre les resultats de test, et les resultats de reference
 correspondant au contexte en cours (plateforme, parallel ou sequuentiel...).
-Elle se fait sur tous les ficgier du repertoire de facon hierarchique
-- nombre de fichier de chaque repertoire
+Elle se fait sur tous les fichiers du repertoire de facon hierarchique
+- nombre de fichiers de chaque repertoire
 - noms des fichiers
 - pour chaque fichier
-  - nombre de ligne
+  - nombre de lignes
   - contenu
     - comparaison des lignes
       - si necessaire, comparaison des champs des lignes, pour un separateur tabulation
-        - si necessaire, comparaions des tokens du champs,
+        - si necessaire, comparaison des tokens du champs,
           dans le cas de la tokenisation d'un fichier json ou kdic
 
 La comparaison se fait en etant tolerant aux variations 'normales' selon le contexte d'execution
@@ -298,15 +298,15 @@ def check_results(test_dir, forced_context=None):
     # Comparaison effective si possible
     if error_number == 0:
         # Acces aux fichiers des repertoires de reference et de test
-        # On passe par le format bytes des nom de fichier pour avoir acces
+        # On passe par le format bytes des noms de fichier pour avoir acces
         # aux fichier quelque soit la plateforme
         # - Windows ne supporte que l'utf8
-        # - Linux stocke les nom directement sous la forme de bytes
+        # - Linux stocke les noms directement sous la forme de bytes
         ref_byte_file_names = os.listdir(os.fsencode(results_ref_dir))
         test_byte_file_names = os.listdir(os.fsencode(results_dir))
 
         # On memorise les noms de fichiers sous forme de string pour faciliter le reporting
-        # Tout en gardant l'association entre le nom python (utf8) et les nom en bytes
+        # Tout en gardant l'association entre le nom python (utf8) et les noms en bytes
         #
         # Attention, la methode fsdecode utilise des 'surrogate characters' invisible
         # permettant de garder trace des bytes non utf8 pour le re-encodage par fsencode si necessaire
@@ -389,7 +389,7 @@ def check_results(test_dir, forced_context=None):
                 show=True,
             )
             error_number = error_number + 1
-            # Affichage des noms des fichier supplementaires
+            # Affichage des noms des fichiers supplementaires
             max_file_reported = 20
             if test_result_file_number > ref_result_file_number:
                 # Message specifique en cas de fichiers en trop
@@ -430,7 +430,7 @@ def check_results(test_dir, forced_context=None):
         for file_name in ref_file_names:
             compared_files_number = compared_files_number + 1
 
-            # Path des fichier utilises pour le reporting
+            # Path des fichiers utilises pour le reporting
             ref_file_path = os.path.join(results_ref_dir, file_name)
             test_file_path = os.path.join(results_dir, file_name)
 
@@ -464,7 +464,7 @@ def check_results(test_dir, forced_context=None):
 
             # Comparaison si ok
             if ref_file_lines is not None and test_file_lines is not None:
-                # Cas des fichier stdout et stderr, que l'on filtre du prefix de process id presnet en parallele
+                # Cas des fichiers stdout et stderr, que l'on filtre du prefix de process id presnet en parallele
                 if file_name in [kht.STDOUT_ERROR_LOG, kht.STDERR_ERROR_LOG]:
                     ref_file_lines = utils.filter_process_id_prefix_from_lines(
                         ref_file_lines
@@ -482,7 +482,7 @@ def check_results(test_dir, forced_context=None):
                     # Identification des lignes de message
                     ref_file_lines = strip_user_message_lines(ref_file_lines)
                     test_file_lines = strip_user_message_lines(test_file_lines)
-                # Cas des fichier json
+                # Cas des fichiers json
                 elif is_file_with_json_extension(file_name):
                     contains_user_messages = True
                     # Pretraitement des lignes de message pour les mettre dans le meme format
@@ -1143,7 +1143,7 @@ def strip_user_message_lines_in_json_file(lines):
             cleaned_message = cleaned_message[1:-1]
         return cleaned_message
 
-    # Recherche des ligne du fichier dans les sections "messages"
+    # Recherche des lignes du fichier dans les sections "messages"
     in_message_section = False
     result_lines = []
     # Pretraitement des lignes
@@ -1184,7 +1184,7 @@ def extract_key_matching_lines_in_json_file(lines, pattern):
 
 
 def extract_striped_lines(lines):
-    """Retourne la sous_liste des ligne stripees de la liste en entree"""
+    """Retourne la sous_liste des lignes stripees de la liste en entree"""
     striped_lines = []
     for line in lines:
         if is_line_striped(line):
@@ -1195,14 +1195,14 @@ def extract_striped_lines(lines):
 def filter_sequential_messages_lines(lines, log_file=None):
     """Filtrage des errors et warning sequentiel d'un ensemble de lignes
 
-    En sequentiel, de nouveaux message de type 100th ou ...
+    En sequentiel, de nouveaux messages de type 100th ou ...
     sont emis, alors qu'il sont absents en parallele
-    En les filtrant, on rend les version sequentielle et parallele comparable
+    En les filtrant, on rend les versions sequentielle et parallele comparables
     Retourne les ligne filtrees, avec un message dans le log sur le nombre de lignes filtrees
     """
 
     def is_specific_line_pair_sequential(line1, line2):
-        """Test si une paire de ligne correspond a un pattern de message sequentiel
+        """Test si une paire de lignes correspond a un pattern de message sequentiel
         Premiere ligne avec 100th, 1000th error ou warning
         Seconde ligne avec '...'
         """
@@ -1308,8 +1308,8 @@ def check_file_lines(
 
     Retourne
     - errors: nombre d'erreurs
-    - warnings: nombre de warning
-    - user_message_warnings: nombre de warning lie a une tolerance sur la variation des messages utilisateurs
+    - warnings: nombre de warnings
+    - user_message_warnings: nombre de warnings lie a une tolerance sur la variation des messages utilisateurs
       (ex: "too much memory")
 
     Les noms des fichiers en parametre permettent de specialiser les comparaisons selon le type de fichier
@@ -1319,7 +1319,7 @@ def check_file_lines(
     de sous-parties que l'on ne souhaite pas comparer.
 
     Compare les fichiers ligne par ligne, champ par champ (separateur '\t'), et token par token
-    dans le cas des fichier json ou dictionnaire
+    dans le cas des fichiers json ou dictionnaire
     On a avec des tolerances selon le type de fichier.
     Pour les valeurs numeriques, une difference relative de 0.00001 est toleree
     - ecrit les difference dans le fichier log_file et affiche le nb d'erreur dans le terminal
@@ -1328,7 +1328,7 @@ def check_file_lines(
     """
 
     def filter_time(value):
-        # Supression d'un pattern de time d'une valeur
+        # Suppression d'un pattern de time d'une valeur
         pos_start_time = value.find(" time:")
         if pos_start_time >= 0:
             begin_value = value[:pos_start_time]

--- a/test/LearningTestTool/py/_kht_constants.py
+++ b/test/LearningTestTool/py/_kht_constants.py
@@ -63,16 +63,16 @@ TOOL_DIR_NAMES = {
 }
 assert set(TOOL_DIR_NAMES) == set(TOOL_NAMES), "Tool dir must be defined for each tool"
 
-# Alias pour des nom speciaux
-ALIAS_CHECK = "check"  # Pour declencher une comparaions entre resultats de test et de reference, plutot qu'un test
+# Alias pour des noms speciaux
+ALIAS_CHECK = "check"  # Pour declencher une comparaison entre resultats de test et de reference, plutot qu'un test
 ALIAS_R = "r"  # Designe le repertoire des binaires des outils en release dans l'environnement de developpement
 ALIAS_D = "d"  # Designe le repertoire des binaires des outils en debug dans l'environnement de developpement
 
-""" Dictionnaire inverse des noms d'outil avec les nom d'exe en cle """
+""" Dictionnaire inverse des noms d'outil avec les noms d'exe en cle """
 TOOL_NAMES_PER_EXE_NAME = dict((v, k) for k, v in TOOL_EXE_NAMES.items())
 assert set(TOOL_NAMES_PER_EXE_NAME.values()) == set(TOOL_NAMES)
 
-""" Dictionnaire inverse des noms d'outil avec les nom des sous-repertoires en cle """
+""" Dictionnaire inverse des noms d'outil avec les noms des sous-repertoires en cle """
 TOOL_NAMES_PER_DIR_NAME = dict((v, k) for k, v in TOOL_DIR_NAMES.items())
 assert set(TOOL_NAMES_PER_DIR_NAME.values()) == set(TOOL_NAMES)
 

--- a/test/LearningTestTool/py/_kht_one_shot_instructions.py
+++ b/test/LearningTestTool/py/_kht_one_shot_instructions.py
@@ -12,7 +12,7 @@ import _kht_standard_instructions as standard_instructions
 Instruction pour des usages uniques
 Peu documente et developpe rapidment sous forme de prototype
 Exemples:
-- manipulation a faire une fois sur l'ensemble des repertoire de test
+- manipulation a faire une fois sur l'ensemble des repertoires de test
 - modification des scenario selon evoilution de l'ergonomie de Khiops core
 - evaluation de l'impcat sur les performances d'une evolution des algorithme de Khiops core
 - ...

--- a/test/LearningTestTool/py/_kht_results_management.py
+++ b/test/LearningTestTool/py/_kht_results_management.py
@@ -50,7 +50,7 @@ Examples d'ensemble correct de noms de repertoire
 # Nombre de process utilisex
 process_number = 1
 
-# Memorisation d'une plateforme force pour la comparaison entre resultstats de test de de reference
+# Memorisation d'une plateforme force pour la comparaison entre resultats de test de de reference
 # Par defaut, on utilise la platforme courante
 forced_platform = None
 
@@ -234,8 +234,8 @@ def is_candidate_results_ref_dir(dir_name):
 
 
 def get_candidate_results_ref_dirs(test_dir):
-    """Recherche de la liste des nom repertoires candidats a etre des resultats de reference
-    Il s'agit des repertoire de nom results.ref, avec ou sans contexte"""
+    """Recherche de la liste des noms repertoires candidats a etre des resultats de reference
+    Il s'agit des repertoires de nom results.ref, avec ou sans contexte"""
     candidate_results_ref_dirs = []
     test_dir_names = os.listdir(test_dir)
     test_dir_names.sort()
@@ -454,9 +454,9 @@ def _search_results_ref_dir(
                     new_context.append(value)
                     new_contexts.append(new_context)
             all_evaluated_contexts = new_contexts
-        # Parcours de tous les contextes possibles pour verifier si l'ensemble des repertoire de reference est coherent
+        # Parcours de tous les contextes possibles pour verifier si l'ensemble des repertoires de reference est coherent
         for evaluated_context in all_evaluated_contexts:
-            # Initialisation d'un liste comportant la liste des repertoire candidats par nombre de "match"
+            # Initialisation d'un liste comportant la liste des repertoires candidats par nombre de "match"
             # On va prioriser les "match" les plus specialises, apres avoire verifie qu'il n'y a pas d'ambiguite
             candidate_dirs_per_match_number = [None]
             for i in range(results_ref_type_number):

--- a/test/LearningTestTool/py/_kht_utils.py
+++ b/test/LearningTestTool/py/_kht_utils.py
@@ -27,46 +27,61 @@ En cas d'erreur, un message est affiche est on sort du programme
 
 def check_test_dir(checked_dir):
     """Test si un chemin est celui d'un repertoire de test"""
-    home_dir_name = parent_dir_name(checked_dir, 3)
-    tool_dir_name = parent_dir_name(checked_dir, 2)
+    checked_home_dir_path = parent_dir_path(checked_dir, 3)
+    checked_tool_dir_name = parent_dir_name(checked_dir, 2)
     if (
-        home_dir_name != kht.LEARNING_TEST
-        or tool_dir_name not in kht.TOOL_DIR_NAMES.values()
+        not check_home_dir(checked_home_dir_path)
+        or checked_tool_dir_name not in kht.TOOL_DIR_NAMES.values()
     ):
         fatal_error(checked_dir + " should be a test directory of " + kht.LEARNING_TEST)
+    return True
 
 
 def check_suite_dir(checked_dir):
     """Test si un chemin est celui d'un repertoire de suite"""
-    home_dir_name = parent_dir_name(checked_dir, 2)
-    tool_dir_name = parent_dir_name(checked_dir, 1)
+    checked_home_dir_path = parent_dir_path(checked_dir, 3)
+    checked_tool_dir_name = parent_dir_name(checked_dir, 1)
     if (
-        home_dir_name != kht.LEARNING_TEST
-        or tool_dir_name not in kht.TOOL_DIR_NAMES.values()
+        not check_home_dir(checked_home_dir_path)
+        or checked_tool_dir_name not in kht.TOOL_DIR_NAMES.values()
     ):
         fatal_error(
             checked_dir + " should be a suite directory of " + kht.LEARNING_TEST
         )
+    return True
 
 
 def check_tool_dir(checked_dir):
     """Test si un chemin est celui d'un repertoire d'outil"""
-    home_dir_name = parent_dir_name(checked_dir, 1)
-    tool_dir_name = parent_dir_name(checked_dir, 0)
+    checked_home_dir_path = parent_dir_path(checked_dir, 3)
+    checked_tool_dir_name = parent_dir_name(checked_dir, 0)
     if (
-        home_dir_name != kht.LEARNING_TEST
-        or tool_dir_name not in kht.TOOL_DIR_NAMES.values()
+        not check_home_dir(checked_home_dir_path)
+        or checked_tool_dir_name not in kht.TOOL_DIR_NAMES.values()
     ):
         fatal_error(checked_dir + " should be a tool directory of " + kht.LEARNING_TEST)
+    return True
 
 
-def check_home_dir(checked_dir):
+def check_home_dir(checked_dir, fatal_error_if_false=True):
     """Test si un chemin est celui du repertoire LearningTest"""
-    home_dir_name = parent_dir_name(checked_dir, 0)
-    if home_dir_name != kht.LEARNING_TEST:
+    checked_home_dir_path = parent_dir_path(checked_dir, 0)
+    # On n'impose pas que le repertoire racine ait le nom predefini kht.LEARNING_TEST
+    # On verifie juste que le repertoire contient au moins un des repertoires d'outil
+    for name in kht.TOOL_DIR_NAMES.values():
+        checked_tool_dir_name = os.path.join(checked_home_dir_path, name)
+        if os.path.isdir(checked_tool_dir_name):
+            return True
+    # Echec si aucun repertoire d'outil trouve
+    if fatal_error_if_false:
         fatal_error(
-            checked_dir + " should be the '" + kht.LEARNING_TEST + "' directory"
+            checked_dir
+            + " should be a valid '"
+            + kht.LEARNING_TEST
+            + "' home dir, containing at least one the tools directory "
+            + list_to_label(kht.TOOL_DIR_NAMES.values())
         )
+    return False
 
 
 def get_learning_test_sub_dir_depth(checked_dir):
@@ -79,42 +94,35 @@ def get_learning_test_sub_dir_depth(checked_dir):
     """
     if not os.path.isdir(checked_dir):
         fatal_error(checked_dir + " should be a directory")
-    path_components = os.path.realpath(checked_dir).split(os.sep)
-    if kht.LEARNING_TEST not in path_components:
-        fatal_error(
-            checked_dir
-            + " must be in a tree whose root is called '"
-            + kht.LEARNING_TEST
-            + "'"
-        )
-    else:
-        depth = 0
-        path_component_number = len(path_components)
-        while depth < path_component_number:
-            if path_components[-(1 + depth)] == kht.LEARNING_TEST:
-                break
-            depth += 1
-        if depth > 3:
-            fatal_error(
-                checked_dir
-                + " must be in a tree whose root is called '"
-                + kht.LEARNING_TEST
-                + "' with a maximum of three levels above it in the directory tree"
-            )
-
-        return depth
+    checked_home_dir_path = os.path.realpath(checked_dir)
+    depth = 0
+    while depth < 4:
+        if check_home_dir(checked_home_dir_path, fatal_error_if_false=False):
+            return depth
+        checked_home_dir_path = os.path.dirname(checked_home_dir_path)
+        depth += 1
+    fatal_error(
+        checked_dir
+        + " must be in a directory tree located a maximum of three levels above a valid '"
+        + kht.LEARNING_TEST
+        + "' home dir, containing at least one the tools directory "
+        + list_to_label(kht.TOOL_DIR_NAMES.values())
+    )
 
 
 def get_home_dir(home_dir):
     """Retourne le repertoire de base LearningTest a partir d'un sous-repertoire de profondeur quelconque"""
-    assert kht.LEARNING_TEST in os.path.realpath(home_dir).split(os.sep), (
-        kht.LEARNING_TEST + " should be a directory in path " + home_dir
-    )
     # On remonte dans le chemin (reel) jusqu'a trouver le repertoire racine
-    home_dir = os.path.realpath(home_dir)
-    while os.path.basename(home_dir) != kht.LEARNING_TEST:
-        home_dir = os.path.dirname(home_dir)
-    return home_dir
+    checked_home_dir_path = os.path.realpath(home_dir)
+    depth = 0
+    while depth < 4:
+        if check_home_dir(checked_home_dir_path, fatal_error_if_false=False):
+            return checked_home_dir_path
+        checked_home_dir_path = os.path.dirname(checked_home_dir_path)
+        depth += 1
+    assert False, (
+        "No valid '" + kht.LEARNING_TEST + "' home dir found in path " + home_dir
+    )
 
 
 def test_dir_name(test_dir):
@@ -137,8 +145,8 @@ def dir_name(dir_path):
     return parent_dir_name(dir_path, 0)
 
 
-def parent_dir_name(dir_path, depth):
-    """Renvoie le nom d'un repertoire parent a une profondeur donnee
+def parent_dir_path(dir_path, depth):
+    """Renvoie le chemin d'un repertoire parent a une profondeur donnee
     Le nom est le nom reel absolu, meme si le parametre en entree est un chemin relatif
     Ainsi, utiliser depth=0 permet d'avoir le nom reel du repertoire de base dans tous les cas
 
@@ -156,8 +164,23 @@ def parent_dir_name(dir_path, depth):
         relative_parent_path += "/.."
     # Nom reel du chemin
     real_parent_path = os.path.realpath(relative_parent_path)
+    return real_parent_path
+
+
+def parent_dir_name(dir_path, depth):
+    """Renvoie le nom d'un repertoire parent a une profondeur donnee
+    Le nom est le nom reel absolu, meme si le parametre en entree est un chemin relatif
+    Ainsi, utiliser depth=0 permet d'avoir le nom reel du repertoire de base dans tous les cas
+
+    Example: pour un test path dir_path=<root_path>/LearningTest/TestKhiops/Standard/Iris/.
+    - test dir: parent_dir_name(dir_path, 0) -> Iris
+    - suite dir: parent_dir_name(dir_path, 1) -> Standard
+    - tool dir: parent_dir_name(dir_path, 2) -> TestKhiops
+    - home dir: parent_dir_name(dir_path, 3) -> LearningTest
+    """
+    parent_path = parent_dir_path(dir_path, depth)
     # On extrait le nom du repertoire
-    result_name = os.path.basename(real_parent_path)
+    result_name = os.path.basename(parent_path)
     return result_name
 
 

--- a/test/LearningTestTool/py/_kht_utils.py
+++ b/test/LearningTestTool/py/_kht_utils.py
@@ -27,17 +27,23 @@ En cas d'erreur, un message est affiche est on sort du programme
 
 def check_test_dir(checked_dir):
     """Test si un chemin est celui d'un repertoire de test"""
-    home_dir = parent_dir_name(checked_dir, 3)
-    tool_dir = parent_dir_name(checked_dir, 2)
-    if home_dir != kht.LEARNING_TEST or tool_dir not in kht.TOOL_DIR_NAMES.values():
+    home_dir_name = parent_dir_name(checked_dir, 3)
+    tool_dir_name = parent_dir_name(checked_dir, 2)
+    if (
+        home_dir_name != kht.LEARNING_TEST
+        or tool_dir_name not in kht.TOOL_DIR_NAMES.values()
+    ):
         fatal_error(checked_dir + " should be a test directory of " + kht.LEARNING_TEST)
 
 
 def check_suite_dir(checked_dir):
     """Test si un chemin est celui d'un repertoire de suite"""
-    home_dir = parent_dir_name(checked_dir, 2)
-    tool_dir = parent_dir_name(checked_dir, 1)
-    if home_dir != kht.LEARNING_TEST or tool_dir not in kht.TOOL_DIR_NAMES.values():
+    home_dir_name = parent_dir_name(checked_dir, 2)
+    tool_dir_name = parent_dir_name(checked_dir, 1)
+    if (
+        home_dir_name != kht.LEARNING_TEST
+        or tool_dir_name not in kht.TOOL_DIR_NAMES.values()
+    ):
         fatal_error(
             checked_dir + " should be a suite directory of " + kht.LEARNING_TEST
         )
@@ -45,16 +51,19 @@ def check_suite_dir(checked_dir):
 
 def check_tool_dir(checked_dir):
     """Test si un chemin est celui d'un repertoire d'outil"""
-    home_dir = parent_dir_name(checked_dir, 1)
-    tool_dir = parent_dir_name(checked_dir, 0)
-    if home_dir != kht.LEARNING_TEST or tool_dir not in kht.TOOL_DIR_NAMES.values():
+    home_dir_name = parent_dir_name(checked_dir, 1)
+    tool_dir_name = parent_dir_name(checked_dir, 0)
+    if (
+        home_dir_name != kht.LEARNING_TEST
+        or tool_dir_name not in kht.TOOL_DIR_NAMES.values()
+    ):
         fatal_error(checked_dir + " should be a tool directory of " + kht.LEARNING_TEST)
 
 
 def check_home_dir(checked_dir):
     """Test si un chemin est celui du repertoire LearningTest"""
-    home_dir = parent_dir_name(checked_dir, 0)
-    if home_dir != kht.LEARNING_TEST:
+    home_dir_name = parent_dir_name(checked_dir, 0)
+    if home_dir_name != kht.LEARNING_TEST:
         fatal_error(
             checked_dir + " should be the '" + kht.LEARNING_TEST + "' directory"
         )
@@ -333,7 +342,7 @@ def argument_parser_check_source_argument(parser, source):
             + " in "
             + os.path.realpath(source)
             + " should be a tool dir "
-            + utils.list_to_label(kht.TOOL_DIR_NAMES.values())
+            + list_to_label(kht.TOOL_DIR_NAMES.values())
         )
     source_home_dir = get_home_dir(source)
     return (
@@ -387,7 +396,7 @@ Gestion du contenu d'un fichier
 
 def read_file_lines(file_path, log_file=None, show=False):
     """Chargement en memoire des lignes d'un fichier
-    Retourne la liste des fichier si ok, None sinon
+    Retourne la liste des fichiers si ok, None sinon
     Ecrit un message dans le log en cas d'erreur
     """
     # lecture des lignes du fichier
@@ -516,7 +525,7 @@ def filter_empty_lines(lines):
 
 
 """
-Gestion des fichier et repertoires
+Gestion des fichiers et repertoires
 """
 
 
@@ -529,7 +538,7 @@ def copy_file(src_file_path, dest_file_path):
 
 
 def remove_file(file_path):
-    """Supression d'un fichier, avec message d'erreur"""
+    """Suppression d'un fichier, avec message d'erreur"""
     try:
         os.chmod(file_path, stat.S_IWRITE)
         os.remove(file_path)
@@ -546,7 +555,7 @@ def make_dir(dest_dir):
 
 
 def remove_dir(dir_to_remove):
-    """Supression d'un repertoire cense etre vide, avec message d'erreur"""
+    """Suppression d'un repertoire cense etre vide, avec message d'erreur"""
     try:
         os.rmdir(dir_to_remove)
     except (IOError, os.error) as why:

--- a/test/LearningTestTool/py/kht_apply.py
+++ b/test/LearningTestTool/py/kht_apply.py
@@ -21,14 +21,14 @@ def apply_instruction_on_suite_dir(
     min_test_time=None,
     max_test_time=None,
 ):
-    """Application d'une instruction sur une suite ou sur un repertoire de est specifique"""
+    """Application d'une instruction sur une suite ou sur un repertoire de test specifique"""
     assert suite_dir != ""
 
     # Erreur si repertoire de suite absent
     if not os.path.isdir(suite_dir):
         utils.fatal_error("missing directory for test suite " + suite_dir)
 
-    # Collecte des sous-repertoire de test
+    # Collecte des sous-repertoires de test
     test_list = []
     # Cas avec un repertoire de test specifique
     if input_test_dir_name is not None:
@@ -154,7 +154,7 @@ def main():
         help_test_dir_name=None,
         help_options=None,
     ):
-        """Construction d'une lige d'aide pour un usage de la command test"""
+        """Construction d'une ligne d'aide pour un usage de la commande test"""
         source_dir = os.path.join(".", kht.LEARNING_TEST)
         if help_test_dir_name is not None:
             source_dir = os.path.join(

--- a/test/LearningTestTool/py/kht_collect_results.py
+++ b/test/LearningTestTool/py/kht_collect_results.py
@@ -187,7 +187,7 @@ def main():
         help_test_dir_name=None,
         help_options=None,
     ):
-        """Construction d'une lige d'aide pour un usage de la command test"""
+        """Construction d'une ligne d'aide pour un usage de la commande test"""
         source_dir = os.path.join(".", kht.LEARNING_TEST)
         if help_test_dir_name is not None:
             source_dir = os.path.join(

--- a/test/LearningTestTool/py/kht_export.py
+++ b/test/LearningTestTool/py/kht_export.py
@@ -182,7 +182,7 @@ def export_learning_test_tree(
                                     if pos_comment >= 0:
                                         line = line[:pos_comment]
                                         line = line.strip()
-                                    # Parsing de la ligne pour recherche les nom de dataset en derniere position
+                                    # Parsing de la ligne pour recherche les noms de dataset en derniere position
                                     # En effet, les patterns de type "ClassFileName ../../../datasets/Adult/Adult.kdic"
                                     # peuvent etre separes par un ou plusieurs caracteres blancs ou tabulation
                                     line = line.replace("\t", " ")
@@ -241,7 +241,7 @@ def export_learning_test_tree(
                         dataset_collection,
                     )
                     utils.make_dir(target_dataset_collection_dir)
-                    # Creation des repertoire elementaire de jeux de donnees
+                    # Creation des repertoires elementaires de jeux de donnees
                     for dataset_name in used_dataset_names:
                         source_dataset_dir = os.path.join(
                             home_dir, dataset_collection, dataset_name
@@ -332,7 +332,7 @@ def main():
         help_test_dir_name=None,
         help_options=None,
     ):
-        """Construction d'une lige d'aide pour un usage de la command test"""
+        """Construction d'une ligne d'aide pour un usage de la commande test"""
         source_dir = os.path.join(".", kht.LEARNING_TEST)
         if help_test_dir_name is not None:
             source_dir = os.path.join(

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -570,7 +570,7 @@ def evaluate_tool_on_suite_dir(tool_exe_path, suite_dir, test_dir_name=None, **k
 def evaluate_tool(tool_name, tool_exe_path, home_dir, test_suites, **kwargs):
     """Lance les tests d'un outil sur un ensemble de suites de tests"""
     assert tool_name in kht.TOOL_NAMES
-    utils.check_home_dir(home_dir)
+    assert utils.check_home_dir(home_dir)
     # Recherche du repertoire lie a l'outil
     tool_dir_name = kht.TOOL_DIR_NAMES[tool_name]
     # Lancement des tests sur les repertoires valides

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -28,7 +28,7 @@ def build_tool_exe_path(tool_binaries_dir, tool_name):
     - 'check': pour effectuer seulment une comparaison entre resultats de test et de reference
     On renvoie:
     - le path complet d'un binaire d'un outil si un repertoire est specifie, 'check' sinon, None si erreur
-    - le message d'erreeur en cas d'error
+    - le message d'erreur en cas d'error
     """
     assert tool_name in kht.TOOL_NAMES
     tool_exe_path = None
@@ -81,7 +81,7 @@ def build_tool_exe_path(tool_binaries_dir, tool_name):
                 + "' not found in current khiops repo under the bin dir "
                 + build_dir
             )
-        # Erreur si plusieurs repertoires des binaires non trouve
+        # Erreur si plusieurs repertoires des binaires non trouves
         elif len(candidate_binaries_dirs) > 1:
             error_message = (
                 "Multiple tool binaries dir found for alias '"
@@ -385,11 +385,11 @@ def evaluate_tool_on_test_dir(
             lines = stdout.split("\n")
             lines = utils.filter_process_id_prefix_from_lines(
                 lines
-            )  # Supression de l'eventuel prefix de type '[0] '
+            )  # Suppression de l'eventuel prefix de type '[0] '
             lines = utils.filter_copyright_lines(
                 lines
-            )  # Supression eventuelle des lignes de copyright
-            lines = utils.filter_empty_lines(lines)  # Suopression des lignes vides
+            )  # Suppression eventuelle des lignes de copyright
+            lines = utils.filter_empty_lines(lines)  # Suppression des lignes vides
 
             # Pour les test KNI, le stdout contient une ligne avec le nombre de records
             if is_kni:
@@ -602,7 +602,7 @@ def evaluate_all_tools_on_learning_test_tree(
     **kwargs
 ):
     """Lance les tests des outils un ensemble de suites de tests
-    Toute ou partie de l'arborescence est prise en compte selon la specification
+    Tout ou partie de l'arborescence est prise en compte selon la specification
      des operandes tool_dir_name, suite_dir_name, test_dir_name, qui peuvent etre None sinon.
     - home_dir: repertoire principal de l'aborescence source
     - tool_dir_name, suite_dir_name, test_dir_name: pour ne prendre en compte qu'une sous-partie
@@ -738,7 +738,7 @@ def main():
         help_test_dir_name=None,
         help_options=None,
     ):
-        """Construction d'une lige d'aide pour un usage de la command test"""
+        """Construction d'une ligne d'aide pour un usage de la commande test"""
         source_dir = os.path.join(".", kht.LEARNING_TEST)
         if help_test_dir_name is not None:
             source_dir = os.path.join(
@@ -839,7 +839,7 @@ def main():
     # Verifications supplementaires des arguments
     # On nomme les arguments concerne de la meme facon que pour le comportement par defaut
     # des controles automatiques du parser
-    # Le rappel des nom des argument est redondant avec la definition des arguments ajoutes,
+    # Le rappel des noms des arguments est redondant avec la definition des arguments ajoutes,
     # mais ce n'est pas trop lourd a maintenir
     # (il n'y a pas d'api officielle d'introspection de la classe argparse)
 


### PR DESCRIPTION
Modification essentiellement dans _kht_utils.py:
- check_home_dir:
  - un repertoire est un home dir de LearningTest s'il contient au moins un des sous-reprtoire de test des outils
  - au lieu de simplement comparer le nom à "LearningTest"
- on passe désormais systematiquement par la methode check_home_dir, avec un chemin en parametre
  - ajout de la fonction utilitaire parent_dir_path, soeur de la fonction parent_dir_name

Tests avec des repertoires de nom quelconques, valides ou non valides

Plus de nombreuse corrections de typos dans les commentaire, dans un commit a part.