### PR TITLE
Make unit tests reproductible

### DIFF
--- a/src/Norm/base/Obdic.cpp
+++ b/src/Norm/base/Obdic.cpp
@@ -761,6 +761,9 @@ void ObjectDictionary::Test()
 	int nStartClock;
 	int nStopClock;
 
+	// Initialisation de la graine pour rendre le test reproductible
+	SetRandomSeed(1);
+
 	// Initialisation de 11 Strings
 	soArray[0].SetString("zero");
 	soArray[1].SetString("un");
@@ -1125,6 +1128,9 @@ void LongintDictionary::Test()
 	Object* oValue;
 	int nRemovedKeyNumber;
 
+	// Initialisation de la graine pour rendre le test reproductible
+	SetRandomSeed(1);
+
 	/////
 	cout << "Test des fonctionnalites de base\n";
 	//
@@ -1332,6 +1338,9 @@ void LongintNumericKeyDictionary::Test()
 	LongintObject* loCount;
 	Object* oValue;
 	int nRemovedKeyNumber;
+
+	// Initialisation de la graine pour rendre le test reproductible
+	SetRandomSeed(1);
 
 	/////
 	cout << "Test des fonctionnalites de base\n";

--- a/test/UnitTests/Norm/results.ref/base_LongintDictionary.txt
+++ b/test/UnitTests/Norm/results.ref/base_LongintDictionary.txt
@@ -34,20 +34,20 @@ Test de changement de taille dynamique
 Nombre d'elements inseres) (1 to 100000) [1000]:
 Nombre d'iterations (1 to 100000) [1000]:
   HashTableSize = 2729
-SYS TIME	LongintDictionary change size	0.682495
+SYS TIME	LongintDictionary change size	0.153191
 Test de performance de base
 Nombre maxi d'elements inseres (Random) (1 to 10000000) [100000]:
 Nombre d'iterations (1 to 1000) [20]:
-	Iteration 0	Size = 63202	Found = 63202
-	Iteration 1	Size = 86472	Found = 86472
-	Iteration 2	Size = 95058	Found = 95058
-	Iteration 3	Size = 98171	Found = 98171
-	Iteration 4	Size = 99340	Found = 99340
-	Iteration 5	Size = 99737	Found = 99737
-	Iteration 6	Size = 99902	Found = 99902
+	Iteration 0	Size = 63191	Found = 63191
+	Iteration 1	Size = 86377	Found = 86377
+	Iteration 2	Size = 94988	Found = 94988
+	Iteration 3	Size = 98217	Found = 98217
+	Iteration 4	Size = 99369	Found = 99369
+	Iteration 5	Size = 99774	Found = 99774
+	Iteration 6	Size = 99913	Found = 99913
 	Iteration 7	Size = 99968	Found = 99968
-	Iteration 8	Size = 99990	Found = 99990
-	Iteration 9	Size = 99995	Found = 99995
+	Iteration 8	Size = 99992	Found = 99992
+	Iteration 9	Size = 99997	Found = 99997
 	Iteration 10	Size = 100000	Found = 100000
 	Iteration 11	Size = 100000	Found = 100000
 	Iteration 12	Size = 100000	Found = 100000
@@ -58,17 +58,17 @@ Nombre d'iterations (1 to 1000) [20]:
 	Iteration 17	Size = 100000	Found = 100000
 	Iteration 18	Size = 100000	Found = 100000
 	Iteration 19	Size = 100000	Found = 100000
-SYS TIME	LongintDictionary access	1.3488
+SYS TIME	LongintDictionary access	0.916553
 SYS MEMORY	Used memory	100000	6606986	6606986
 
 Test de performance de comptage
 Nombre max d'elements (1 to 10000000) [1000000]:
 Nombre d'iterations (1 to 100000000) [10000000]:
 	Total = 10000000
-SYS TIME	LongintDictionary counts	4.95287
-SYS MEMORY	Used memory	999948	61365764	61365764	149802496
+SYS TIME	LongintDictionary counts	3.9873
+SYS MEMORY	Used memory	999962	61366311	61366311	92787648
 
 Test de performance de comptage via un dictionnaire de LongintObject
 	Total = 10000000
-SYS TIME	LongintDictionary counts	5.39525
-SYS MEMORY	Used memory	999946	61365683	77364819	214282048
+SYS TIME	LongintDictionary counts	4.16964
+SYS MEMORY	Used memory	999959	61366191	77365535	116901952

--- a/test/UnitTests/Norm/results.ref/base_LongintNumericKeyDictionary.txt
+++ b/test/UnitTests/Norm/results.ref/base_LongintNumericKeyDictionary.txt
@@ -34,41 +34,41 @@ Test de changement de taille dynamique
 Nombre d'elements inseres) (1 to 100000) [1000]:
 Nombre d'iterations (1 to 100000) [1000]:
   HashTableSize = 2729
-SYS TIME	LongintNumericKeyDictionary change size	0.303255
+SYS TIME	LongintNumericKeyDictionary change size	0.024012
 Test de performance de base
 Nombre maxi d'elements inseres (Random) (1 to 10000000) [100000]:
 Nombre d'iterations (1 to 1000) [20]:
-	Iteration 0	Size = 63236	Found = 63236
-	Iteration 1	Size = 86457	Found = 86457
-	Iteration 2	Size = 94996	Found = 94996
-	Iteration 3	Size = 98104	Found = 98104
-	Iteration 4	Size = 99299	Found = 99299
-	Iteration 5	Size = 99759	Found = 99759
-	Iteration 6	Size = 99904	Found = 99904
-	Iteration 7	Size = 99964	Found = 99964
-	Iteration 8	Size = 99982	Found = 99982
-	Iteration 9	Size = 99996	Found = 99996
-	Iteration 10	Size = 99996	Found = 99996
-	Iteration 11	Size = 99997	Found = 99997
-	Iteration 12	Size = 99999	Found = 99999
-	Iteration 13	Size = 99999	Found = 99999
+	Iteration 0	Size = 63191	Found = 63191
+	Iteration 1	Size = 86377	Found = 86377
+	Iteration 2	Size = 94988	Found = 94988
+	Iteration 3	Size = 98217	Found = 98217
+	Iteration 4	Size = 99369	Found = 99369
+	Iteration 5	Size = 99774	Found = 99774
+	Iteration 6	Size = 99913	Found = 99913
+	Iteration 7	Size = 99968	Found = 99968
+	Iteration 8	Size = 99992	Found = 99992
+	Iteration 9	Size = 99997	Found = 99997
+	Iteration 10	Size = 100000	Found = 100000
+	Iteration 11	Size = 100000	Found = 100000
+	Iteration 12	Size = 100000	Found = 100000
+	Iteration 13	Size = 100000	Found = 100000
 	Iteration 14	Size = 100000	Found = 100000
 	Iteration 15	Size = 100000	Found = 100000
 	Iteration 16	Size = 100000	Found = 100000
 	Iteration 17	Size = 100000	Found = 100000
 	Iteration 18	Size = 100000	Found = 100000
 	Iteration 19	Size = 100000	Found = 100000
-SYS TIME	LongintNumericKeyDictionary access	0.477858
+SYS TIME	LongintNumericKeyDictionary access	0.177419
 SYS MEMORY	Used memory	100000	6118096	6118096
 
 Test de performance de comptage
 Nombre max d'elements (1 to 10000000) [1000000]:
 Nombre d'iterations (1 to 100000000) [10000000]:
 	Total = 10000000
-SYS TIME	LongintNumericKeyDictionary counts	2.54879
-SYS MEMORY	Used memory	999935	55476751	55476751	93710528
+SYS TIME	LongintNumericKeyDictionary counts	1.64938
+SYS MEMORY	Used memory	999962	55477642	55477642	76536704
 
 Test de performance de comptage via un dictionnaire de LongintObject
 	Total = 10000000
-SYS TIME	LongintNumericKeyDictionary counts	3.64789
-SYS MEMORY	Used memory	999952	55477312	71476544	158190080
+SYS TIME	LongintNumericKeyDictionary counts	2.64298
+SYS MEMORY	Used memory	999959	55477543	71476887	100651008

--- a/test/UnitTests/Norm/results.ref/base_ObjectDictionary.txt
+++ b/test/UnitTests/Norm/results.ref/base_ObjectDictionary.txt
@@ -48,21 +48,21 @@ Test de changement de taille dynamique
 Nombre d'elements inseres) (1 to 100000) [1000]:
 Nombre d'iterations (1 to 100000) [1000]:
   HashTableSize = 2729
-SYS TIME	ObjectDictionary change size	0.672772
+SYS TIME	ObjectDictionary change size	0.144636
 
 Test de performance A
 Nombre maxi d'elements inseres (Random) (1 to 10000000) [100000]:
 Nombre d'iterations (1 to 1000) [20]:
-	Iteration 0	Size = 63482	Found = 63482
-	Iteration 1	Size = 86479	Found = 86479
-	Iteration 2	Size = 95062	Found = 95062
-	Iteration 3	Size = 98198	Found = 98198
-	Iteration 4	Size = 99367	Found = 99367
-	Iteration 5	Size = 99779	Found = 99779
-	Iteration 6	Size = 99919	Found = 99919
-	Iteration 7	Size = 99973	Found = 99973
-	Iteration 8	Size = 99990	Found = 99990
-	Iteration 9	Size = 99998	Found = 99998
+	Iteration 0	Size = 63569	Found = 63569
+	Iteration 1	Size = 86495	Found = 86495
+	Iteration 2	Size = 95030	Found = 95030
+	Iteration 3	Size = 98229	Found = 98229
+	Iteration 4	Size = 99375	Found = 99375
+	Iteration 5	Size = 99778	Found = 99778
+	Iteration 6	Size = 99915	Found = 99915
+	Iteration 7	Size = 99969	Found = 99969
+	Iteration 8	Size = 99992	Found = 99992
+	Iteration 9	Size = 99997	Found = 99997
 	Iteration 10	Size = 100000	Found = 100000
 	Iteration 11	Size = 100000	Found = 100000
 	Iteration 12	Size = 100000	Found = 100000
@@ -73,14 +73,14 @@ Nombre d'iterations (1 to 1000) [20]:
 	Iteration 17	Size = 100000	Found = 100000
 	Iteration 18	Size = 100000	Found = 100000
 	Iteration 19	Size = 100000	Found = 100000
-SYS TIME	ObjectDictionary access	1.44445
+SYS TIME	ObjectDictionary access	0.897363
 SYS MEMORY	Used memory	100000	6606986	9806986
 Test de performance B
 Nombre de chaines inserees (1 to 10000000) [10000]:
-SYS TIME	ObjectDictionary insertion	0.00406
+SYS TIME	ObjectDictionary insertion	0.001257
 
 Nombre de recherches (1 to 100000000) [100000]:
-SYS TIME	ObjectDictionary lookup	0.00325
+SYS TIME	ObjectDictionary lookup	0.000907
 
 Nombre de supressions: 10000
-SYS TIME	ObjectDictionary remove	0.003043
+SYS TIME	ObjectDictionary remove	0.001482


### PR DESCRIPTION
Add random seed in tests of LongintDictionary, LongintNumericKeyDictionary and ObjectDictionary (all in Obdic.cpp) 
The 3 reference files are updated