### PR TITLE
Improve Linux packaging

### DIFF
--- a/packaging/install.cmake
+++ b/packaging/install.cmake
@@ -57,77 +57,80 @@ configure_file(${PROJECT_SOURCE_DIR}/packaging/common/KNI/template-README.md ${T
 
 # ######################################## Khiops and Khiops Coclustering installation
 
-# replace MPIEXEC MPIEXEC_NUMPROC_FLAG and MPI_IMPL KHIOPS_MPI_EXTRA_FLAG
-if("${MPI_IMPL}" STREQUAL "openmpi")
-  set(KHIOPS_MPI_EXTRA_FLAG "--allow-run-as-root")
-endif()
-configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops-env.in ${TMP_DIR}/khiops-env @ONLY
-               NEWLINE_STYLE UNIX)
-configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/debian/khiops-core/postinst.in ${TMP_DIR}/postinst @ONLY
-               NEWLINE_STYLE UNIX)
+if(UNIX)
 
-if(NOT IS_FEDORA_LIKE)
-  install(TARGETS MODL MODL_Coclustering RUNTIME DESTINATION usr/bin COMPONENT KHIOPS_CORE)
+  # replace MPIEXEC MPIEXEC_NUMPROC_FLAG and MPI_IMPL KHIOPS_MPI_EXTRA_FLAG
+  if("${MPI_IMPL}" STREQUAL "openmpi")
+    set(KHIOPS_MPI_EXTRA_FLAG "--allow-run-as-root")
+  endif()
+  configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops-env.in ${TMP_DIR}/khiops-env @ONLY
+                 NEWLINE_STYLE UNIX)
+  configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/debian/khiops-core/postinst.in ${TMP_DIR}/postinst @ONLY
+                 NEWLINE_STYLE UNIX)
 
-  # We install the binary with mpi suffix and create a symlink without the suffix
-  get_target_property(MODL_NAME MODL OUTPUT_NAME)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/bin/${MODL_NAME} ${TMP_DIR}/MODL)
+  if(NOT IS_FEDORA_LIKE)
+    install(TARGETS MODL MODL_Coclustering RUNTIME DESTINATION usr/bin COMPONENT KHIOPS_CORE)
+
+    # We install the binary with mpi suffix and create a symlink without the suffix
+    get_target_property(MODL_NAME MODL OUTPUT_NAME)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/bin/${MODL_NAME} ${TMP_DIR}/MODL)
+    install(
+      FILES ${TMP_DIR}/MODL
+      DESTINATION usr/bin
+      COMPONENT KHIOPS_CORE)
+  else()
+
+    # On fedora binaries built with mpi must follow these rules :
+    #
+    # - the binaries MUST be suffixed with $MPI_SUFFIX
+    # - MPI implementation specific files MUST be installed in the directories used by the MPI compiler e.g. $MPI_BIN
+    #
+    # see https://docs.fedoraproject.org/en-US/packaging-guidelines/MPI/
+    #
+    install(TARGETS MODL RUNTIME DESTINATION ./${MPI_BIN}/khiops COMPONENT KHIOPS_CORE)
+    install(TARGETS MODL_Coclustering RUNTIME DESTINATION /usr/bin COMPONENT KHIOPS_CORE)
+
+    # We install the binary under $MPI_BIN and create a symlink to it
+    get_target_property(MODL_NAME MODL OUTPUT_NAME)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${MPI_BIN}/khiops/${MODL_NAME} ${TMP_DIR}/MODL)
+    install(
+      FILES ${TMP_DIR}/MODL
+      DESTINATION usr/bin
+      COMPONENT KHIOPS_CORE)
+
+  endif()
+
   install(
-    FILES ${TMP_DIR}/MODL
+    PROGRAMS ${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops
+             ${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops_coclustering ${TMP_DIR}/khiops-env
     DESTINATION usr/bin
     COMPONENT KHIOPS_CORE)
-else()
 
-  # On fedora binaries built with mpi must follow these rules :
-  #
-  # - the binaries MUST be suffixed with $MPI_SUFFIX
-  # - MPI implementation specific files MUST be installed in the directories used by the MPI compiler e.g. $MPI_BIN
-  #
-  # see https://docs.fedoraproject.org/en-US/packaging-guidelines/MPI/
-  #
-  install(TARGETS MODL RUNTIME DESTINATION ./${MPI_BIN}/khiops COMPONENT KHIOPS_CORE)
-  install(TARGETS MODL_Coclustering RUNTIME DESTINATION /usr/bin COMPONENT KHIOPS_CORE)
-
-  # We install the binary under $MPI_BIN and create a symlink to it
-  get_target_property(MODL_NAME MODL OUTPUT_NAME)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${MPI_BIN}/khiops/${MODL_NAME} ${TMP_DIR}/MODL)
   install(
-    FILES ${TMP_DIR}/MODL
-    DESTINATION usr/bin
+    FILES ${PROJECT_SOURCE_DIR}/LICENSE
+    DESTINATION usr/share/doc/khiops
     COMPONENT KHIOPS_CORE)
 
-endif()
+  install(
+    FILES ${PROJECT_SOURCE_DIR}/packaging/common/khiops/WHATSNEW.txt
+          ${PROJECT_SOURCE_DIR}/packaging/common/khiops/README.txt
+    DESTINATION usr/share/doc/khiops
+    COMPONENT KHIOPS)
 
-install(
-  PROGRAMS ${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops
-           ${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops_coclustering ${TMP_DIR}/khiops-env
-  DESTINATION usr/bin
-  COMPONENT KHIOPS_CORE)
+  install(
+    FILES ${PROJECT_SOURCE_DIR}/packaging/common/images/khiops.png
+          ${PROJECT_SOURCE_DIR}/packaging/common/images/khiops_coclustering.png
+    DESTINATION usr/share/pixmaps
+    COMPONENT KHIOPS)
 
-install(
-  FILES ${PROJECT_SOURCE_DIR}/LICENSE
-  DESTINATION usr/share/doc/khiops
-  COMPONENT KHIOPS_CORE)
+  install(
+    FILES ${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops.desktop
+          ${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops-coclustering.desktop
+    DESTINATION usr/share/applications
+    COMPONENT KHIOPS)
 
-install(
-  FILES ${PROJECT_SOURCE_DIR}/packaging/common/khiops/WHATSNEW.txt
-        ${PROJECT_SOURCE_DIR}/packaging/common/khiops/README.txt
-  DESTINATION usr/share/doc/khiops
-  COMPONENT KHIOPS)
-
-install(
-  FILES ${PROJECT_SOURCE_DIR}/packaging/common/images/khiops.png
-        ${PROJECT_SOURCE_DIR}/packaging/common/images/khiops_coclustering.png
-  DESTINATION usr/share/pixmaps
-  COMPONENT KHIOPS)
-
-install(
-  FILES ${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops.desktop
-        ${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops-coclustering.desktop
-  DESTINATION usr/share/applications
-  COMPONENT KHIOPS)
-
-install(
-  FILES ${CMAKE_BINARY_DIR}/jars/norm.jar ${CMAKE_BINARY_DIR}/jars/khiops.jar
-  DESTINATION usr/share/khiops
-  COMPONENT KHIOPS)
+  install(
+    FILES ${CMAKE_BINARY_DIR}/jars/norm.jar ${CMAKE_BINARY_DIR}/jars/khiops.jar
+    DESTINATION usr/share/khiops
+    COMPONENT KHIOPS)
+endif(UNIX)

--- a/packaging/linux/common/khiops-env.in
+++ b/packaging/linux/common/khiops-env.in
@@ -80,11 +80,11 @@ if [[ -z $KHIOPS_PROC_NUMBER ]]; then
     KHIOPS_PROC_NUMBER=$(lscpu -b -p=Core,Socket | grep -v '^#' | sort -u | wc -l)
 fi
 
-if command -v @MPIEXEC@ &> /dev/null
+if command -v mpiexec &> /dev/null
 then
-    KHIOPS_MPI_COMMAND="@MPIEXEC@ -bind-to hwthread -map-by core @KHIOPS_MPI_EXTRA_FLAG@ @MPIEXEC_NUMPROC_FLAG@ $KHIOPS_PROC_NUMBER"
+    KHIOPS_MPI_COMMAND="mpiexec --allow-run-as-root --quiet @KHIOPS_MPI_EXTRA_FLAG@ @MPIEXEC_NUMPROC_FLAG@ $KHIOPS_PROC_NUMBER"
 else
-    echo "We didn't find @MPIEXEC@ in the regular path. Parallel computation is unavailable: Khiops is launched in serial"
+    echo "We didn't find mpiexec in the regular path. Parallel computation is unavailable: Khiops is launched in serial"
     KHIOPS_MPI_COMMAND="" 
 fi
 

--- a/packaging/packaging.cmake
+++ b/packaging/packaging.cmake
@@ -115,11 +115,13 @@ elseif("${MPI_IMPL}" STREQUAL "intel")
   set(CPACK_DEBIAN_KHIOPS_CORE_PACKAGE_DEPENDS "intel-hpckit")
 endif()
 set(CPACK_DEBIAN_KHIOPS_PACKAGE_DEPENDS
-    "khiops-core${PACKAGE_SUFFIX} (=${KHIOPS_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}), default-jre (>=1.8)")
+    "khiops-core (=${KHIOPS_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}), default-jre (>=1.8)")
 
 # packages recommends
 set(CPACK_DEBIAN_KHIOPS_CORE_PACKAGE_RECOMMENDS "khiops, khiops-visualization")
-set(CPACK_DEBIAN_KHIOPS_KNI_RECOMMENDS kni-doc)
+
+# packages provides
+set(CPACK_DEBIAN_KHIOPS_CORE_PACKAGE_PROVIDES "khiops-core (= ${KHIOPS_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE})")
 
 # packages posinst and triggers
 set(CPACK_DEBIAN_KHIOPS_CORE_PACKAGE_CONTROL_EXTRA "${TMP_DIR}/postinst")
@@ -159,9 +161,12 @@ set(CPACK_RPM_KNI_DOC_PACKAGE_SUMMARY "Khiops Native Interface documentation")
 set(CPACK_RPM_KHIOPS_CORE_PACKAGE_OBSOLETES "khiops-core <= 10.2.1-2")
 
 # packages requires
-set(CPACK_RPM_KHIOPS_PACKAGE_REQUIRES "khiops-core${PACKAGE_SUFFIX} = ${KHIOPS_VERSION}-${CPACK_RPM_PACKAGE_RELEASE}")
+set(CPACK_RPM_KHIOPS_PACKAGE_REQUIRES "khiops-core = ${KHIOPS_VERSION}-${CPACK_RPM_PACKAGE_RELEASE}")
 set(CPACK_RPM_KHIOPS_PACKAGE_REQUIRES "java >= 1.8")
 set(CPACK_RPM_KHIOPS_CORE_PACKAGE_REQUIRES "util-linux")
+
+# packages provides
+set(CPACK_RPM_KHIOPS_CORE_PACKAGE_PROVIDES "khiops-core = ${KHIOPS_VERSION}")
 
 # packages post/postun install scripts
 set(CPACK_RPM_KNI_POST_INSTALL_SCRIPT_FILE "${PROJECT_SOURCE_DIR}/packaging/linux/redhat/kni.post")

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -337,8 +337,8 @@ def evaluate_tool_on_test_dir(
                 khiops_params.append("--oversubscribe")
                 # permet de lancer en tant que root
                 khiops_params.append("--allow-run-as-root")
-                # Ajoute le rang du processus dans les traces
-                khiops_params.append("--tag-output")
+                # Supprime les traces en cas d'erreur fatale de khiops
+                khiops_params.append("--quiet")
             khiops_params.append("-n")
             khiops_params.append(str(tool_process_number))
         khiops_params.append(tool_exe_path)


### PR DESCRIPTION
* Install KHIOPS and KHIOPS_CORE components only for linux (suppress cmake warning on windows)

* Improve generation of khiops-env with cmake (remove absolute path of mpiexec)
* The khiops-core-openmpi package provides the virtual package khiops-core. It improves dependency managment.
* Suppress output of OpenMPI in stdout