### PR TITLE
fix  wrong driver list in the status info

### DIFF
--- a/packaging/install.cmake
+++ b/packaging/install.cmake
@@ -69,7 +69,7 @@ if(UNIX)
 
   # replace MPIEXEC MPIEXEC_NUMPROC_FLAG and MPI_IMPL KHIOPS_MPI_EXTRA_FLAG
   if("${MPI_IMPL}" STREQUAL "openmpi")
-    set(KHIOPS_MPI_EXTRA_FLAG "--allow-run-as-root")
+    set(KHIOPS_MPI_EXTRA_FLAG "--allow-run-as-root --quiet")
   endif()
   configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops-env.in ${TMP_DIR}/khiops-env @ONLY
                  NEWLINE_STYLE UNIX)

--- a/packaging/linux/common/khiops-env.in
+++ b/packaging/linux/common/khiops-env.in
@@ -28,11 +28,11 @@ help()
     echo "The following variables are not defined by default and can be used to"
     echo "change some default properties of Khiops:"
     echo
-    echo "KHIOPS_TMP_DIR: Khiops temporary directory location (default : the"
+    echo "KHIOPS_TMP_DIR: Khiops' temporary directory location (default : the"
     echo "   system default) This location can be modified from the tool as well"
-    echo "KHIOPS_MEMORY_LIMIT: Khiops' memory limit (default: the system"
-    echo "   memory limit). This setting is ignored if it is above the system"
-    echo "   memory limit. It can only be reduced from the tool"
+    echo "KHIOPS_MEMORY_LIMIT: Khiops' memory limit in MB (default : the system's memory limit)."
+    echo "   The minimum value is 100 MB; this setting is ignored if it is above the system's memory limit."
+    echo "   It can only be reduced from the tool."    
     echo "KHIOPS_RAW_GUI: graphical user interface for file name selection"
     echo "  . default behavior if not set: depending on the file drivers available for Khiops"
     echo "  . set to 'true' to allow file name selection with uri schemas"
@@ -82,7 +82,7 @@ fi
 
 if command -v mpiexec &> /dev/null
 then
-    KHIOPS_MPI_COMMAND="mpiexec --allow-run-as-root --quiet @KHIOPS_MPI_EXTRA_FLAG@ @MPIEXEC_NUMPROC_FLAG@ $KHIOPS_PROC_NUMBER"
+    KHIOPS_MPI_COMMAND="mpiexec @KHIOPS_MPI_EXTRA_FLAG@ @MPIEXEC_NUMPROC_FLAG@ $KHIOPS_PROC_NUMBER"
 else
     echo "We didn't find mpiexec in the regular path. Parallel computation is unavailable: Khiops is launched in serial"
     KHIOPS_MPI_COMMAND="" 

--- a/packaging/windows/nsis/CreateKhiopsEnvCmdFileFunc.nsh
+++ b/packaging/windows/nsis/CreateKhiopsEnvCmdFileFunc.nsh
@@ -66,9 +66,9 @@ Function CreateKhiopsEnvCmdFile
     FileWrite $0 `echo.$\r$\n`
     FileWrite $0 `echo KHIOPS_TMP_DIR: Khiops' temporary directory location (default : the$\r$\n`
     FileWrite $0 `echo   system's default) This location can be modified from the tool as well$\r$\n`
-    FileWrite $0 `echo KHIOPS_MEMORY_LIMIT: Khiops' memory limit (default : the system's$\r$\n`
-    FileWrite $0 `echo   memory limit). This setting is ignored if it is above the system's$\r$\n`
-    FileWrite $0 `echo   memory limit. It can only be reduced from the tool$\r$\n`
+    FileWrite $0 `echo "KHIOPS_MEMORY_LIMIT: Khiops' memory limit in MB (default : the system's memory limit).$\r$\n`
+    FileWrite $0 `echo "   The minimum value is 100 MB; this setting is ignored if it is above the system's memory limit.$\r$\n`
+    FileWrite $0 `echo "   It can only be reduced from the tool.$\r$\n`
     FileWrite $0 `echo KHIOPS_API_MODE: standard or api mode for the management of output result files created by Khiops$\r$\n`
     FileWrite $0 `echo                 In standard mode, the result files are stored in the train database directory,$\r$\n`
     FileWrite $0 `echo                   unless an absolute path is specified, and the file extension is forced if necessary.$\r$\n`

--- a/src/Learning/KWLearningProblem/KWLearningProject.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProject.cpp
@@ -476,17 +476,80 @@ boolean KWLearningProject::ShowSystemInformation(const ALString& sValue)
 	int i;
 	const SystemFileDriver* fileDriver;
 	ALString sTmp;
+	StringVector svEnvironmentVariables;
+	ALString sEnv;
+	ALString sEnvValue;
+	boolean bEnvVarDefined;
 
 	// Version
 	ShowVersion(sTmp);
+	cout << endl;
 
 	// Drivers
-	for (i = 0; i < SystemFileDriverCreator::GetExternalDriverNumber(); i++)
+	if (SystemFileDriverCreator::GetDriverNumber() > 0)
 	{
-		fileDriver = SystemFileDriverCreator::GetRegisteredDriverAt(i);
-		cout << " \tDriver '" << fileDriver->GetDriverName() << "' for URI scheme '" << fileDriver->GetScheme()
-		     << "'" << endl;
+		cout << "Drivers:" << endl;
+		for (i = 0; i < SystemFileDriverCreator::GetDriverNumber(); i++)
+		{
+			fileDriver = SystemFileDriverCreator::GetRegisteredDriverAt(i);
+			cout << "\t'" << fileDriver->GetDriverName() << "' for URI scheme '" << fileDriver->GetScheme()
+			     << "'" << endl;
+		}
 	}
+
+	// Affichage des variables d'environement propres a Khiops, seulement si elles sont definies
+	svEnvironmentVariables.Add("KHIOPS_RAW_GUI");
+	svEnvironmentVariables.Add("KHIOPS_TMP_DIR");
+	svEnvironmentVariables.Add("KHIOPS_HOME");
+	svEnvironmentVariables.Add("KHIOPS_API_MODE");
+	svEnvironmentVariables.Add("KHIOPS_MEMORY_LIMIT");
+	svEnvironmentVariables.Sort();
+	bEnvVarDefined = false;
+	cout << "Environment variables:" << endl;
+	for (i = 0; i < svEnvironmentVariables.GetSize(); i++)
+	{
+		sEnv = svEnvironmentVariables.GetAt(i);
+		sEnvValue = p_getenv(sEnv);
+		if (sEnvValue != "")
+		{
+			cout << "\t" << sEnv << "\t" << sEnvValue << endl;
+			bEnvVarDefined = true;
+		}
+	}
+	if (not bEnvVarDefined)
+		cout << "\tNone" << endl;
+
+	svEnvironmentVariables.Initialize();
+	bEnvVarDefined = false;
+	svEnvironmentVariables.Add("KhiopsExpertMode");
+	svEnvironmentVariables.Add("KhiopsHardMemoryLimitMode");
+	svEnvironmentVariables.Add("KhiopsCrashTestMode");
+	svEnvironmentVariables.Add("KhiopsPreparationTraceMode");
+	svEnvironmentVariables.Add("KhiopsIOTraceMode");
+	svEnvironmentVariables.Add("KhiopsForestExpertMode");
+	svEnvironmentVariables.Add("KhiopsCoclusteringExpertMode");
+	svEnvironmentVariables.Add("KhiopsCoclusteringIVExpertMode");
+	svEnvironmentVariables.Add("KhiopsExpertParallelMode");
+	svEnvironmentVariables.Add("KhiopsParallelTrace");
+	svEnvironmentVariables.Add("KhiopsFileServerActivated");
+	svEnvironmentVariables.Add("hiopsPriorStudyModeRAW");
+	svEnvironmentVariables.Add("KhiopsDistanceStudyMode");
+	svEnvironmentVariables.Sort();
+
+	// Affichage des variables d'environement techniques
+	cout << "Internal environment variables:" << endl;
+	for (i = 0; i < svEnvironmentVariables.GetSize(); i++)
+	{
+		sEnv = svEnvironmentVariables.GetAt(i);
+		sEnvValue = p_getenv(sEnv);
+		if (sEnvValue != "")
+		{
+			cout << "\t" << sEnv << "\t" << sEnvValue << endl;
+			bEnvVarDefined = true;
+		}
+	}
+	if (not bEnvVarDefined)
+		cout << "\tNone" << endl;
 
 	// Resources
 	cout << *RMResourceManager::GetResourceSystem();

--- a/src/Learning/KWLearningProblem/KWSystemParametersView.cpp
+++ b/src/Learning/KWLearningProblem/KWSystemParametersView.cpp
@@ -16,6 +16,7 @@ KWSystemParametersView::KWSystemParametersView()
 	longint lEnvMemoryLimit;
 	int nRound;
 	int i;
+	ALString sTmp;
 
 	SetIdentifier("KWSystemParameters");
 	SetLabel("System parameters");
@@ -105,6 +106,13 @@ KWSystemParametersView::KWSystemParametersView()
 		// Utilisation de StringToLongint car atol renvoie 0 en cas de pbm (contrairement a atoi)
 		lEnvMemoryLimit = StringToLongint(sMemoryLimit);
 	}
+	if (sMemoryLimit != "" and lEnvMemoryLimit < nMinMemory)
+		AddFatalError(
+		    sTmp +
+		    "The environment variable KHIOPS_MEMORY_LIMIT is ignored because it is set to a value inferior "
+		    "than required for Khiops "
+		    "(" +
+		    LongintToReadableString(lEnvMemoryLimit) + " MB < " + LongintToReadableString(nMinMemory) + " MB)");
 	if (lEnvMemoryLimit != 0 and lEnvMemoryLimit <= nMaxMemory and lEnvMemoryLimit >= nMinMemory)
 	{
 		nMaxMemory = (int)lEnvMemoryLimit;

--- a/src/Norm/base/SystemFileDriverCreator.cpp
+++ b/src/Norm/base/SystemFileDriverCreator.cpp
@@ -113,6 +113,14 @@ int SystemFileDriverCreator::GetExternalDriverNumber()
 	return nExternalDriverNumber;
 }
 
+int SystemFileDriverCreator::GetDriverNumber()
+{
+	int nDriverNumber = 0;
+	if (oaSystemFileDriver != NULL)
+		nDriverNumber = oaSystemFileDriver->GetSize();
+	return nDriverNumber;
+}
+
 void SystemFileDriverCreator::RegisterDriver(SystemFileDriver* driver)
 {
 	if (oaSystemFileDriver == NULL)

--- a/src/Norm/base/SystemFileDriverCreator.h
+++ b/src/Norm/base/SystemFileDriverCreator.h
@@ -18,11 +18,14 @@ public:
 	// Retourne le nombre de drivers correctement instancies
 	static int RegisterExternalDrivers();
 
-	// Renvoie true su les dribers on ete instanicies (correctement ou non)
+	// Renvoie true si les drivers on ete instancies (correctement ou non)
 	static boolean IsExternalDriversRegistered();
 
 	// Retourne le nombre de drivers instancies a partir de bibliotheques dynamiques
 	static int GetExternalDriverNumber();
+
+	// Retourne le nombre de drivers instancies
+	static int GetDriverNumber();
 
 	// Enregistrement d'un driver a partir d'un objet
 	static void RegisterDriver(SystemFileDriver* driver);


### PR DESCRIPTION
* Display all drivers in Show ShowSystemInformation

In the ShowSystemInformation method (it corresponds to the -s flag) we diplay the list of all drivers.

We print the list of the environment variables if they are defined.

* Add fatal error when KHIOPS_MEMORY_LIMIT is too small

if KHIOPS_MEMORY_LIMIT is inferior than the one required by khiops. It was simply ignored. I add a Fatal Error to inform the user

Minor corrections/update in the khiops-env scripts

cherry-pick from dev commit 9af20ba103f9c10ad59c10b5ca3f7280e249f097