### PR TITLE
Fix windows conda build

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -31,7 +31,7 @@ jobs:
           # Linux: We use the Khiops dev debian:10 container to build with glibc 2.28
           #        It ensures compatibility with glibc >= 2.28 (in particular Rocky 8)
           - {os: ubuntu-22.04, os-family: linux-64, json-image: '{"image": "ghcr.io/khiopsml/khiops/khiopsdev-debian10:latest"}'}
-          - {os: windows-2022, os-family: win-64, json-image: '{"image": null}'}
+          - {os: windows-2019, os-family: win-64, json-image: '{"image": null}'}
           - {os: macos-13, os-family: osx-64, json-image: '{"image": null}'}
           - {os: macos-14, os-family: osx-arm64, json-image: '{"image": null}'}
     container: ${{ fromJSON(matrix.setup.json-image) }}


### PR DESCRIPTION
_Cherry-pick of the same fix for `dev-v10`, issue #271_

The windows-2022 runner does not contain the VS2017 tools and runtime to build the conda khiops package. We will use windows-2019 until the conda-forge packages use a more recent VS.