### PR TITLE
Update LearningTestTool for invalid return code 2

### DIFF
--- a/test/LearningTestTool/py/_kht_check_results.py
+++ b/test/LearningTestTool/py/_kht_check_results.py
@@ -582,9 +582,7 @@ def check_results(test_dir, forced_context=None):
                             ):
                                 fatal_error_recovery = False
                         # Pattern dans le cas du code retour
-                        return_code_error_pattern = (
-                            "Wrong return code: 1 (should be 0 or 2)"
-                        )
+                        return_code_error_pattern = "Wrong return code: 1 (should be 0)"
                         if file_name == kht.RETURN_CODE_ERROR_LOG:
                             if (
                                 len(test_file_lines) == 0

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -536,7 +536,7 @@ def evaluate_tool_on_test_dir(
                     exception,
                 )
         # Cas du code retour
-        if khiops_process.returncode != 0 and khiops_process.returncode != 2:
+        if khiops_process.returncode != 0:
             try:
                 with open(
                     os.path.join(
@@ -548,7 +548,7 @@ def evaluate_tool_on_test_dir(
                     return_code_file.write(
                         "Wrong return code: "
                         + str(khiops_process.returncode)
-                        + " (should be 0 or 2)"
+                        + " (should be 0)"
                     )
             except Exception as exception:
                 print(


### PR DESCRIPTION
Auparavant, les codes retours valide de Khiops était 0 ou 2. Depuis le commit Change exit status on MODL and MODL_Coclustering associe a la PR "Switch to Open MPI" #252, Khiops ne retourne plus que 0 en cas de fonctionnement normal (en V10 et V11)