### PR TITLE
Add conda package for kni and KNITransfer

### DIFF
--- a/packaging/conda/bld.bat
+++ b/packaging/conda/bld.bat
@@ -3,11 +3,13 @@ REM Echo all output
 
 REM Build the Khiops binaries
 cmake --preset windows-msvc-release -DBUILD_JARS=OFF -DTESTING=OFF
-cmake --build --preset windows-msvc-release --parallel --target MODL MODL_Coclustering
+cmake --build --preset windows-msvc-release --parallel --target MODL MODL_Coclustering KhiopsNativeInterface KNITransfer 
 
 REM Copy the MODL binaries to the Conda PREFIX path
 mkdir %PREFIX%\bin
 copy build\windows-msvc-release\bin\MODL.exe %PREFIX%\bin
 copy build\windows-msvc-release\bin\MODL_Coclustering.exe %PREFIX%\bin
+copy build\windows-msvc-release\bin\KNITransfer.exe %PREFIX%\bin
+copy build\windows-msvc-release\bin\KhiopsNativeInterface.dll %PREFIX%\lib
 
 if errorlevel 1 exit 1

--- a/packaging/conda/build.sh
+++ b/packaging/conda/build.sh
@@ -15,10 +15,12 @@ fi
 cmake --fresh --preset $CMAKE_PRESET -DBUILD_JARS=OFF -DTESTING=OFF
 
 # Build MODL and MODL_Coclustering
-cmake --build --preset $CMAKE_PRESET --parallel --target MODL MODL_Coclustering
+cmake --build --preset $CMAKE_PRESET --parallel --target MODL MODL_Coclustering KhiopsNativeInterface KNITransfer 
 
-# Move the MODL binaries to the Conda PREFIX path
+# Move the binaries to the Conda PREFIX path
 mv ./build/$CMAKE_PRESET/bin/MODL* "$PREFIX/bin"
+mv ./build/$CMAKE_PRESET/bin/KNITransfer* "$PREFIX/bin"
+mv ./build/$CMAKE_PRESET/lib/libKhiopsNativeInterface* "$PREFIX/lib"
 
 # Custom rpath relocation and signing executables for macOS in arm64
 #

--- a/packaging/conda/meta.yaml
+++ b/packaging/conda/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: khiops-core
+  name: khiops-binaries
   version: {{ os.environ.get('KHIOPS_VERSION') }}
 
 source:
@@ -37,15 +37,57 @@ requirements:
     - {{ mpi }}
 
 outputs:
+
+  # khiops-core package
   - name: khiops-core
+    version: {{ os.environ.get('KHIOPS_VERSION') }}
+    requirements:
+      build:
+        - cmake
+        - ninja
+        - {{ compiler('cxx') }}
+      host:
+        - {{ mpi }}
+      run:
+        - {{ mpi }}
+    files:
+      - bin/MODL*
     test:
       commands:
-        - MODL -v
-        - MODL_Coclustering -v
+        - MODL -s
+        - MODL_Coclustering -s
 
+  # kni package (do not need khiops-core as a runtime dependency)
+  - name: kni
+    version: {{ os.environ.get('KHIOPS_VERSION') }}
+    files: 
+      - lib/libKhiopsNativeInterface.so* # [linux]
+      - lib/libKhiopsNativeInterface*.dylib # [osx]
+      - lib/KhiopsNativeInterface.dll # [win]
+    requirements:
+      build:
+        - cmake
+        - ninja
+        - {{ compiler('cxx') }}
+  
+  # kni-transfer package (designed only to test kni)
+  - name: kni-transfer
+    version: {{ os.environ.get('KHIOPS_VERSION') }}
+    requirements:
+      build:
+        - cmake
+        - ninja
+        - {{ compiler('cxx') }}
+      run:
+        - kni 
+    files: 
+      - bin/KNITransfer.exe # [win]
+      - bin/KNITransfer # [linux or osx]
+      
 about:
   home: https://khiops.org
   license: BSD+3-clause
   summary: Khiops is an AutoML suite for supervised and unsupervised learning
   doc_url: https://khiops.org
   dev_url: https://github.com/khiopsml/khiops
+

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -311,14 +311,27 @@ def evaluate_tool_on_test_dir(
                 utils.remove_file(file_path)
 
         # khiops en mode expert via une variable d'environnement
-        os.putenv(kht.KHIOPS_EXPERT_MODE, "true")
+        os.environ[kht.KHIOPS_EXPERT_MODE] = "true"
 
         # khiops en mode HardMemoryLimit via une variable d'environnement pour provoquer
         # un plantage physique de l'allocateur en cas de depassement des contraintes memoires des scenarios
-        os.putenv(kht.KHIOPS_HARD_MEMORY_LIMIT_MODE, "true")
+        os.environ[kht.KHIOPS_HARD_MEMORY_LIMIT_MODE] = "true"
 
         # khiops en mode crash test via une variable d'environnement
-        os.putenv(kht.KHIOPS_CRASH_TEST_MODE, "true")
+        os.environ[kht.KHIOPS_CRASH_TEST_MODE] = "true"
+
+        # Ajout de variables d'environements propres a OpenMPI, elles remplacent les parametres
+        # on peut ansi lancer indiferemment mpich ou openmpi
+        if platform.system() == "Linux":
+            # Supprime les traces en cas d'erreur fatale de khiops. Option --quiet
+            os.environ["OMPI_MCA_orte_execute_quiet"] = "true"
+
+            # permet de lancer plus de processus qu'il n'y a de coeurs. Option --oversubscribe
+            os.environ["OMPI_MCA_rmaps_base_oversubscribe"] = "true"
+
+            # permet de lancer en tant que root. Option --allow-run-as-root
+            os.environ["OMPI_ALLOW_RUN_AS_ROOT"] = "1"
+            os.environ["OMPI_ALLOW_RUN_AS_ROOT_CONFIRM"] = "1"
 
         # Construction des parametres
         khiops_params = []

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -333,6 +333,16 @@ def evaluate_tool_on_test_dir(
             os.environ["OMPI_ALLOW_RUN_AS_ROOT"] = "1"
             os.environ["OMPI_ALLOW_RUN_AS_ROOT_CONFIRM"] = "1"
 
+        # Ajout de variables d'environements propres a OpenMPI, elles remplacent les parametres
+        if platform.system() == "Linux":
+            # Supprime les traces en cas d'erreur fatale de khiops. Option --quiet
+            os.environ["OMPI_MCA_orte_execute_quiet"] = "true"
+            # permet de lancer plus de processus qu'il n'y a de coeurs. Option --oversubscribe
+            os.environ["OMPI_MCA_rmaps_base_oversubscribe"] = "true"
+            # permet de lancer en tant que root. Option --allow-run-as-root
+            os.environ["OMPI_ALLOW_RUN_AS_ROOT"] = "1"
+            os.environ["OMPI_ALLOW_RUN_AS_ROOT_CONFIRM"] = "1"
+
         # Construction des parametres
         khiops_params = []
         if tool_process_number > 1:
@@ -344,14 +354,6 @@ def evaluate_tool_on_test_dir(
             if platform.system() == "Darwin":
                 khiops_params.append("-host")
                 khiops_params.append("localhost")
-            # Options specifiques a Open MPI
-            if platform.system() == "Linux":
-                # permet de lancer plus de processus qu'il n'y a de coeurs
-                khiops_params.append("--oversubscribe")
-                # permet de lancer en tant que root
-                khiops_params.append("--allow-run-as-root")
-                # Supprime les traces en cas d'erreur fatale de khiops
-                khiops_params.append("--quiet")
             khiops_params.append("-n")
             khiops_params.append(str(tool_process_number))
         khiops_params.append(tool_exe_path)


### PR DESCRIPTION
In `LearningTestRunner`, the new python api (kht_test) runs systematically the tests for Khiops, Khiops_coclustering and **KNI**. It fails if KNITransfer is missing. Therefore I added 2 new conda packages (as sub-packages): kni and kni-transfer.

A second commit concerns `kht_test.py`. The origin of the problem is that linux packages use **openmpi** and conda package use **mpich**. `kht_test` is now compliant with both: the flags specific to openmpi are translate in environment variables. 