### PR TITLE
307 openmpi related error on rocky linux

### DIFF
--- a/.github/actions/test-khiops-install/action.yml
+++ b/.github/actions/test-khiops-install/action.yml
@@ -1,0 +1,57 @@
+---
+name: Test Khiops Installation
+description: Check the outputs of Khiops in the console
+runs:
+  using: composite
+  # Test if the output of Khiops in the console is as expected (no mpi or java errors)
+  # We expect only one line in stdout+stderr when running 'khiops -v'
+  steps:
+    - name: Print status for debugging
+      shell: bash
+      # We force the process number to 4 because the runner has only 2 proc.
+      # With 2 proc khiops-env switches to serial and mpi is not used.
+      # The env var OMPI_MCA_rmaps_base_oversubscribe is for openmpi it corresponds to
+      # the flag --oversubscribe (Nodes are allowed to be oversubscribed)
+      env:
+        KHIOPS_PROC_NUMBER: 4
+        OMPI_MCA_rmaps_base_oversubscribe: true
+      run: |
+        khiops-env --env
+    - name: Check Khiops output
+      shell: bash
+      env:
+        KHIOPS_PROC_NUMBER: 4
+        OMPI_MCA_rmaps_base_oversubscribe: true
+      run: |
+        khiops -s
+        khiops -v &> output
+        LINE_NUMBER=$(wc -l < output)
+        if [ $LINE_NUMBER -gt 1 ] ;
+        then 
+          echo "::error::Unexpected output in khiops scripts"
+          false
+        fi
+    - name: Check Khiops coclustering output
+      shell: bash
+      run: |-
+        khiops_coclustering -s
+        khiops_coclustering -v &> output
+        LINE_NUMBER=$(wc -l < output)
+        if [ $LINE_NUMBER -gt 1 ] ;
+        then 
+          echo "::error::Unexpected output in khiops_coclustering scripts"
+          false
+        fi
+    - name: Check process number
+      shell: bash
+      env:
+        KHIOPS_PROC_NUMBER: 4
+        OMPI_MCA_rmaps_base_oversubscribe: true
+      run: |-
+        PROC_NUMBER_LIST=($(khiops -s | grep 'Logical processes on system'))
+        PROC_NUMBER=${PROC_NUMBER_LIST[-1]}
+        if [ "$PROC_NUMBER" != "$KHIOPS_PROC_NUMBER" ] ;
+        then
+          echo "::error::Wrong proc number ($PROC_NUMBER vs $KHIOPS_PROC_NUMBER)"
+          false
+        fi

--- a/.github/actions/test-khiops-on-iris/action.yml
+++ b/.github/actions/test-khiops-on-iris/action.yml
@@ -1,5 +1,5 @@
 ---
-name: Test Khiops Installation
+name: Test Khiops on Iris
 description: Tests a Khiops installation on the Iris dataset
 runs:
   using: composite

--- a/.github/actions/test-khiops-on-iris/action.yml
+++ b/.github/actions/test-khiops-on-iris/action.yml
@@ -10,6 +10,7 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
+        # Detect Debian based OS
         if [ -d "/etc/apt" ]
         then
           apt-get install -y python3 > /dev/null
@@ -40,13 +41,17 @@ runs:
         fi
     - name: Check Khiops installation
       shell: bash
+      env:
+        KHIOPS_PROC_NUMBER: 4
+        OMPI_MCA_rmaps_base_oversubscribe: true
       run: |
-        export KHIOPS_PROC_NUMBER=4 
-        export OMPI_MCA_rmaps_base_oversubscribe=true
         "$KHIOPS_SCRIPT" -s
         "$KHIOPS_CC_SCRIPT" -s
     - name: Run Khiops tests
       shell: bash
+      env:
+        KHIOPS_PROC_NUMBER: 4
+        OMPI_MCA_rmaps_base_oversubscribe: true
       run: |
         cd test/LearningTest/TestKhiops/Standard/Iris/
         "$KHIOPS_SCRIPT" -b -i test.prm -e results/err.txt

--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -121,9 +121,9 @@ jobs:
           khiops-env --env
           khiops -s
           khiops_coclustering -s
-      - name: Test Khiops installation
+      - name: Test Khiops on Iris dataset
         continue-on-error: ${{ matrix.os == 'debian:11' }}
-        uses: ./.github/actions/test-khiops-install
+        uses: ./.github/actions/test-khiops-on-iris
   test-kni:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -108,19 +108,13 @@ jobs:
           dpkg -i ./artifacts/khiops-core* || true
           apt-get -f install -y
       - name: Check Khiops core installation
-        run: |
-          khiops-env --env
-          khiops -s
-          khiops_coclustering -s
+        uses: ./.github/actions/test-khiops-install
       - name: Install Khiops Desktop (with java)
         run: |
           dpkg -i ./artifacts//khiops_* || true
           apt-get -f install -y
       - name: Check Khiops installation
-        run: |
-          khiops-env --env
-          khiops -s
-          khiops_coclustering -s
+        uses: ./.github/actions/test-khiops-install
       - name: Test Khiops on Iris dataset
         continue-on-error: ${{ matrix.os == 'debian:11' }}
         uses: ./.github/actions/test-khiops-on-iris

--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -116,12 +116,10 @@ jobs:
       - name: Check Khiops installation
         uses: ./.github/actions/test-khiops-install
       - name: Test Khiops on Iris dataset
-        continue-on-error: ${{ matrix.os == 'debian:11' }}
         uses: ./.github/actions/test-khiops-on-iris
   test-kni:
     needs: build
     runs-on: ubuntu-latest
-    continue-on-error: true
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Checkout the khiops sources
         uses: actions/checkout@v4
       - name: Test the installation
-        uses: ./.github/actions/test-khiops-install
+        uses: ./.github/actions/test-khiops-on-iris
   test-kni:
     needs: build
     runs-on: windows-2022

--- a/.github/workflows/pack-rpm.yml
+++ b/.github/workflows/pack-rpm.yml
@@ -105,18 +105,12 @@ jobs:
         run: |
           yum install -y ./artifacts/khiops-core*
       - name: Check Khiops core installation
-        run: |
-          khiops-env --env
-          khiops -s
-          khiops_coclustering -s
+        uses: ./.github/actions/test-khiops-install
       - name: Install Khiops Desktop (with java)
         run: |
           yum install -y ./artifacts/khiops-*
-      - name: Check Khiops  installation
-        run: |
-          khiops-env --env
-          khiops -s
-          khiops_coclustering -s
+      - name: Check Khiops installation
+        uses: ./.github/actions/test-khiops-install
       - name: Test Khiops on Iris dataset
         uses: ./.github/actions/test-khiops-on-iris
   test-kni:

--- a/.github/workflows/pack-rpm.yml
+++ b/.github/workflows/pack-rpm.yml
@@ -117,8 +117,8 @@ jobs:
           khiops-env --env
           khiops -s
           khiops_coclustering -s
-      - name: Test Khiops installation
-        uses: ./.github/actions/test-khiops-install
+      - name: Test Khiops on Iris dataset
+        uses: ./.github/actions/test-khiops-on-iris
   test-kni:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/pack-rpm.yml
+++ b/.github/workflows/pack-rpm.yml
@@ -75,7 +75,6 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
-    continue-on-error: true
     defaults:
       run:
         shell: bash
@@ -116,7 +115,6 @@ jobs:
   test-kni:
     needs: build
     runs-on: ubuntu-latest
-    continue-on-error: true
     defaults:
       run:
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: trailing-whitespace
         types_or: [c, c++, java, python, markdown]
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.0
+    rev: 0.28.6
     hooks:
       - id: check-github-workflows
       - id: check-github-actions

--- a/packaging/install.cmake
+++ b/packaging/install.cmake
@@ -67,10 +67,20 @@ endif()
 
 if(UNIX)
 
-  # replace MPIEXEC MPIEXEC_NUMPROC_FLAG and MPI_IMPL KHIOPS_MPI_EXTRA_FLAG
+  # replace MPIEXEC MPIEXEC_NUMPROC_FLAG and MPI_IMPL KHIOPS_MPI_EXTRA_FLAG ADDITIONAL_EN_VAR
   if("${MPI_IMPL}" STREQUAL "openmpi")
     set(KHIOPS_MPI_EXTRA_FLAG "--allow-run-as-root --quiet")
+    set(ADDITIONAL_EN_VAR "export OMPI_MCA_btl_vader_single_copy_mechanism=none # issue on docker")
+    if(IS_FEDORA_LIKE)
+      set(ADDITIONAL_EN_VAR "${ADDITIONAL_EN_VAR}\nexport PSM3_DEVICES=self # issue one rocky linux")
+    endif()
   endif()
+
+  # Add header comment to the variable definition (if any variable is defined)
+  if(ADDITIONAL_EN_VAR)
+    set(ADDITIONAL_EN_VAR "# Additional variables for MPI\n${ADDITIONAL_EN_VAR}")
+  endif()
+
   configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops-env.in ${TMP_DIR}/khiops-env @ONLY
                  NEWLINE_STYLE UNIX)
   configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/debian/khiops-core/postinst.in ${TMP_DIR}/postinst @ONLY

--- a/packaging/linux/common/khiops-env.in
+++ b/packaging/linux/common/khiops-env.in
@@ -74,6 +74,8 @@ if [ -f "/usr/share/khiops/khiops.jar" ]; then
     fi
 fi
 
+@ADDITIONAL_EN_VAR@
+
 # Number of processes in use (must be set according to the physical cores number)
 if [[ -z $KHIOPS_PROC_NUMBER ]]; then
     KHIOPS_PROC_NUMBER=$(lscpu -b -p=Core,Socket | grep -v '^#' | sort -u | wc -l)


### PR DESCRIPTION
* Add new environment variables to khiops-env
To fix the bug with PSM3, we add "PSM3_DEVICES=self"
For explanation, see https://github.com/open-mpi/ompi/issues/11295#issuecomment-1384244610
We also add OMPI_MCA_btl_vader_single_copy_mechanism=none
to remove the mpi message "Read -1, expected 65536, errno = 1" that appears on docker

* Rename github actions test-khiops-install > test-khiops-on-iris
* Add new github action to test khiops installation
The test-khiops-install checks if the output of Khiops in the console is as expected (no mpi or java errors)