### PR TITLE
Drop macos-11 support, which is phased out by GitHub

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -90,7 +90,6 @@ jobs:
           - {os: ubuntu-22.04, os-family: linux-64}
           - {os: windows-2019, os-family: win-64}
           - {os: windows-2022, os-family: win-64}
-          - {os: macos-11, os-family: osx-64}
           - {os: macos-12, os-family: osx-64}
           - {os: macos-13, os-family: osx-64}
           - {os: macos-14, os-family: osx-arm64}


### PR DESCRIPTION
closes #308