### PR TITLE
Enable executable and lib signatures in macOS

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -53,19 +53,27 @@ jobs:
         run: |
           wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.10.sdk.tar.xz
           sudo tar -zxvf MacOSX10.10.sdk.tar.xz -C /opt
-      - name: Put the Khiops Conda version in the environment
+      - name: Set the environment variables
         shell: bash
         run: |
-          # Obtain the Khiops version
+          # Put the Khiops package version
+          # The conda version cannot have '-' as a character so we eliminate it
           if [[ "${{ github.ref_type }}" == "tag" ]]
           then
             KHIOPS_RAW_VERSION="${{ github.ref_name }}"
           else
             KHIOPS_RAW_VERSION="$(./scripts/khiops-version)"
           fi
-
-          # The conda version cannot have '-' as a character so we eliminate it
           echo "KHIOPS_VERSION=$(echo $KHIOPS_RAW_VERSION | sed 's/-//')" >> "$GITHUB_ENV"
+
+          # On tag and macOS: Set the environment variables to sign the binaries
+          if [[ "${{ runner.os }}" == "macOS" && "${{ github.ref_type }}" == "tag" ]]
+          then
+            echo "KHIOPS_APPLE_CERTIFICATE_COMMON_NAME=${{ secrets.KHIOPS_APPLE_CERTIFICATE_COMMON_NAME }}" >> "$GITHUB_ENV"
+            echo "KHIOPS_APPLE_CERTIFICATE_BASE64=${{ secrets.KHIOPS_APPLE_CERTIFICATE_BASE64 }}" >> "$GITHUB_ENV"
+            echo "KHIOPS_APPLE_CERTIFICATE_PASSWORD=${{ secrets.KHIOPS_APPLE_CERTIFICATE_PASSWORD }}" >> "$GITHUB_ENV"
+            echo "KHIOPS_APPLE_TMP_KEYCHAIN_PASSWORD=${{ secrets.KHIOPS_APPLE_TMP_KEYCHAIN_PASSWORD }}" >> "$GITHUB_ENV"
+          fi
       - name: Build conda packages (Windows)
         if: runner.os == 'Windows'
         run: conda build --output-folder ./build/conda ./packaging/conda

--- a/packaging/conda/README.md
+++ b/packaging/conda/README.md
@@ -26,7 +26,7 @@ the `MODL*` binaries. You may have to input your password.
 Alternatively, a certificate file encoded in base64 may be provided by additionally setting the
 following environment variables:
 - `KHIOPS_APPLE_CERTIFICATE_BASE64`: The base64 encoding of the signing certificate.
--`KHIOPS_APPLE_CERTIFICATE_PASSWORD`: The password of the signing certificate.
+- `KHIOPS_APPLE_CERTIFICATE_PASSWORD`: The password of the signing certificate.
 - `KHIOPS_APPLE_TMP_KEYCHAIN_PASSWORD` : A password for the temporary keychain created in the process.
 
 If the process is executed as root (eg. Github Runner) then there is no need to input a password to

--- a/packaging/conda/meta.yaml
+++ b/packaging/conda/meta.yaml
@@ -17,10 +17,10 @@ build:
     - KHIOPS_APPLE_CERTIFICATE_PASSWORD    # [osx]
     - KHIOPS_APPLE_TMP_KEYCHAIN_PASSWORD   # [osx]
     {% endif %}
-    {% endif %}
-  # Binary relocation of MODL and MODL_Coclustering is done in build.sh script
-  # This is to be able to sign it, see the script for more details.
-  # Only done when "KHIOPS_APPLE_CERTIFICATE_COMMON_NAME is defined in the environment.
+  {% endif %}
+  # Only when "KHIOPS_APPLE_CERTIFICATE_COMMON_NAME is defined in the environment:
+  #   Binary relocation of MODL, MODL_Coclustering and KNI is done in build.sh script
+  #   This is to be able to sign it, see the script for more details.
   {% if "KHIOPS_APPLE_CERTIFICATE_COMMON_NAME" in os.environ %}
   binary_relocation: false               # [osx]
   detect_binary_files_with_prefix: false # [osx]
@@ -60,7 +60,7 @@ outputs:
   # kni package (do not need khiops-core as a runtime dependency)
   - name: kni
     version: {{ os.environ.get('KHIOPS_VERSION') }}
-    files: 
+    files:
       - lib/libKhiopsNativeInterface.so* # [linux]
       - lib/libKhiopsNativeInterface*.dylib # [osx]
       - lib/KhiopsNativeInterface.dll # [win]
@@ -69,7 +69,7 @@ outputs:
         - cmake
         - ninja
         - {{ compiler('cxx') }}
-  
+
   # kni-transfer package (designed only to test kni)
   - name: kni-transfer
     version: {{ os.environ.get('KHIOPS_VERSION') }}
@@ -79,15 +79,14 @@ outputs:
         - ninja
         - {{ compiler('cxx') }}
       run:
-        - kni 
-    files: 
+        - kni
+    files:
       - bin/KNITransfer.exe # [win]
       - bin/KNITransfer # [linux or osx]
-      
+
 about:
   home: https://khiops.org
   license: BSD+3-clause
   summary: Khiops is an AutoML suite for supervised and unsupervised learning
   doc_url: https://khiops.org
   dev_url: https://github.com/khiopsml/khiops
-


### PR DESCRIPTION
- Add to the CI conda workflow the necessary environment variables so the macOS packages are signed (only on tag). The necessary variables are all set to values from GitHub organization secrets.
- Add signature for the KNI library