### PR TITLE
Add file menu in "Manage dictionaries" dialog box

### DIFF
--- a/src/Learning/KWLearningProblem/KWLearningProblemView.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblemView.cpp
@@ -507,12 +507,14 @@ boolean KWLearningProblemView::BuildClassFromDataTable()
 
 	// Warning utilisateur pour prevenir de cet usage un peu atypique et de ses limites
 	if (bOk)
+	{
+		Global::AddSimpleMessage("");
 		Global::AddWarning("", "",
 				   "A dictionary has been generated automatically. "
-				   "The field types should be checked and the dictionary saved if necessary. "
+				   "The field types should be checked and the dictionary saved if necessary.\n"
 				   "For standard use, refer to the '" +
 				       sClassManagementMenuItemName + "' menu.\n");
-
+	}
 	return bOk;
 }
 

--- a/src/Learning/KWUserInterface/KWClassManagementActionView.cpp
+++ b/src/Learning/KWUserInterface/KWClassManagementActionView.cpp
@@ -4,8 +4,12 @@
 
 #include "KWClassManagementActionView.h"
 
+// Inclusion dans le fichier source pour eviter un cycle de dependance des headers
+#include "KWClassManagementDialogView.h"
+
 KWClassManagementActionView::KWClassManagementActionView()
 {
+	// Titre
 	SetIdentifier("KWClassManagementAction");
 	SetLabel("Dictionary management");
 
@@ -193,9 +197,14 @@ void KWClassManagementActionView::ManageClasses()
 
 	require(CheckDictionaryName());
 
+	// Parametrage des bases de train et test
+	manageClassesDialogView.SetTrainDatabase(GetTrainDatabase());
+	manageClassesDialogView.SetTestDatabase(GetTestDatabase());
+
 	// Ouverture de la boite avec l'objet edite en cours
 	// On prend le RawObject pour avoir l'objet directement, sans synchronisation avec l'interface
 	manageClassesDialogView.SetObject(GetRawObject());
+
 	manageClassesDialogView.Open();
 
 	// Copie du nom du dictionnaire dans les bases

--- a/src/Learning/KWUserInterface/KWClassManagementActionView.h
+++ b/src/Learning/KWUserInterface/KWClassManagementActionView.h
@@ -7,7 +7,6 @@
 #include "UserInterface.h"
 #include "KWClassManagement.h"
 #include "KWClassSpecArrayView.h"
-#include "KWClassManagementDialogView.h"
 #include "KWVersion.h"
 
 ////////////////////////////////////////////////////////////

--- a/src/Learning/KWUserInterface/KWClassManagementDialogView.h
+++ b/src/Learning/KWUserInterface/KWClassManagementDialogView.h
@@ -6,6 +6,7 @@
 
 #include "UserInterface.h"
 #include "KWClassManagement.h"
+#include "KWClassManagementActionView.h"
 
 #include "KWVersion.h"
 #include "KWClassSpecArrayView.h"
@@ -17,7 +18,7 @@
 // Classe KWClassManagementDialogView
 //    Dictionary management
 // Editeur de KWClassManagement
-class KWClassManagementDialogView : public UIObjectView
+class KWClassManagementDialogView : public KWClassManagementActionView
 {
 public:
 	// Constructeur
@@ -36,27 +37,13 @@ public:
 	// Mise a jour des valeurs de l'interface par l'objet
 	void EventRefresh(Object* object) override;
 
-	// Libelles utilisateur
-	const ALString GetClassLabel() const override;
-	const ALString GetObjectLabel() const override;
-
-	// Actions de menu
+	// Nouvelles actions specifiques
 	void BuildClassDef();
-	void ReloadFile();
 	void EditFile();
-
-	// Enregistrement des classes en proposant un nom de fichier
-	void SaveFileUnderName(const ALString& sFileName);
-
-	// Parametrage de l'objet edite
-	void SetObject(Object* object) override;
 
 	////////////////////////////////////////////////////////
 	///// Implementation
 protected:
-	// Acces a l'objet sous son bon type
-	KWClassManagement* GetClassManagement();
-
 	// Vue sur le constructeur de dictionnaire, pour en memoriser le parametrage de la base
 	// d'une utilisation a l'autre
 	KWClassBuilderView classBuilderView;

--- a/src/Learning/MODL/MDKhiopsLearningProject.cpp
+++ b/src/Learning/MODL/MDKhiopsLearningProject.cpp
@@ -59,7 +59,7 @@ void MDKhiopsLearningProject::OpenLearningEnvironnement()
 	sQuickStartInfo +=
 	    "<li>Allow recoding of data or deployment of prediction scores via the 'Deploy Model' feature</li> ";
 	sQuickStartInfo += "<p>A dictionary file contains one or several dictionaries.</p> ";
-	sQuickStartInfo += "<h3>Normal path</h3> ";
+	sQuickStartInfo += "<h3>Standard path</h3> ";
 	sQuickStartInfo += "<h4>Manage data dictionaries</h4> ";
 	sQuickStartInfo += "<li>Click on the 'Manage dictionaries' sub-menu of the 'Data dictionary' menu</li> ";
 	sQuickStartInfo += "<p>A dialog box appears, which allows you to build a dictionary from a data file and edit "

--- a/src/Learning/MODL_Coclustering/CCLearningProblemView.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemView.cpp
@@ -309,12 +309,14 @@ boolean CCLearningProblemView::BuildClassFromDataTable()
 
 	// Warning utilisateur pour prevenir de cet usage un peu atypique et de ses limites
 	if (bOk)
+	{
+		Global::AddSimpleMessage("");
 		Global::AddWarning("", "",
 				   "A dictionary has been generated automatically. "
-				   "The field types should be checked and the dictionary saved if necessary. "
+				   "The field types should be checked and the dictionary saved if necessary.\n"
 				   "For standard use, refer to the '" +
 				       sClassManagementMenuItemName + "' menu.\n");
-
+	}
 	return bOk;
 }
 

--- a/src/Learning/MODL_Coclustering/CCLearningProject.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProject.cpp
@@ -49,7 +49,7 @@ void CCLearningProject::OpenLearningEnvironnement()
 	sQuickStartInfo +=
 	    "<li>Allow recoding of data or deployment of prediction scores via the 'Deploy Model' feature</li> ";
 	sQuickStartInfo += "<p>A dictionary file contains one or several dictionaries.</p> ";
-	sQuickStartInfo += "<h3>Normal path</h3> ";
+	sQuickStartInfo += "<h3>Standard path</h3> ";
 	sQuickStartInfo += "<h4>Manage data dictionaries</h4> ";
 	sQuickStartInfo += "<li>Click on the 'Manage dictionaries' sub-menu of the 'Data dictionary' menu</li> ";
 	sQuickStartInfo += "<p>A dialog box appears, which allows you to build a dictionary from a data file and edit "

--- a/test/LearningTest/TestCoclustering/Standard/IrisFastPath/results.ref/err.txt
+++ b/test/LearningTest/TestCoclustering/Standard/IrisFastPath/results.ref/err.txt
@@ -1,11 +1,13 @@
 File format detected: header line and field separator tabulation
 Database ../../../datasets/Iris/Iris.txt : Recognized variable types: 1 Categorical, 4 Numerical
-warning : A dictionary has been generated automatically. The field types should be checked and the dictionary saved if necessary. For standard use, refer to the 'Data dictionary/Manage dictionaries...' menu.
+
+warning : A dictionary has been generated automatically. The field types should be checked and the dictionary saved if necessary.
+For standard use, refer to the 'Data dictionary/Manage dictionaries...' menu.
 
 Database ../../../datasets/Iris/Iris.txt : Read records: 150
   0:00:00	Write intermediate report Coclustering(1).khcj	Level: 0.05003	Size: 2*2	Granularity: 1
   0:00:00	Write intermediate report Coclustering(2).khcj	Level: 0.0676747	Size: 3*3	Granularity: 3
   0:00:00	Write intermediate report Coclustering(3).khcj	Level: 0.0850057	Size: 3*3
 Write coclustering report ./results/Coclustering.khcj
-Coclustering analysis time: 0:00:00.02
+Coclustering analysis time: 0:00:00.03
 

--- a/test/LearningTest/TestKhiops/Standard/IrisFastPath/results.ref/err.txt
+++ b/test/LearningTest/TestKhiops/Standard/IrisFastPath/results.ref/err.txt
@@ -1,11 +1,13 @@
 File format detected: header line and field separator tabulation
 Database ../../../datasets/Iris/Iris.txt : Recognized variable types: 1 Categorical, 4 Numerical
-warning : A dictionary has been generated automatically. The field types should be checked and the dictionary saved if necessary. For standard use, refer to the 'Data dictionary/Manage dictionaries...' menu.
+
+warning : A dictionary has been generated automatically. The field types should be checked and the dictionary saved if necessary.
+For standard use, refer to the 'Data dictionary/Manage dictionaries...' menu.
 
 Train supervised model for classification of target variable Class
 Database ../../../datasets/Iris/Iris.txt: Read records: 150	Selected records: 105
-Data preparation time: 0:00:00.05
-SNB train time: 0:00:00.01
+Data preparation time: 0:00:00.01
+SNB train time: 0:00:00
 Build Selective Naive Bayes SNB_Iris
 Train evaluation of Selective Naive Bayes on database ../../../datasets/Iris/Iris.txt
 Test evaluation of Selective Naive Bayes on database ../../../datasets/Iris/Iris.txt


### PR DESCRIPTION
Ajout d'un menu dans la sous-fenetre dediee a la gestion des dictionnaires
- menu identique a celui de la fenetre principale
  - sauf items "Manage dictionaries" et "Quit"
- suppression du bouton "Inspect current dictionary" pour ne garder que le menu contextuel
- impacts
  - classes KWClassManagementActionView et KWClassManagementDialogView
  - la classe KWClassManagementDialogView herite desormais de KWClassManagementActionView

Menu "Help/Quick start": "Fast path" vs "Normal path"
- Renommage "Normal path" en "Standard path"

Mettre le warning associe au fast path en gras
- suggestion initiale: "dans la fenêtre de log, je mettrais tout le warning en gras, histoire qu'on le voit bien"
- il n'est pas simple de passer le message du warning en gras
  - cela demanderait une extension du moteur d'interface graphique de Norm, specifique pour ce cas
- a la place, on choisit simplement une mise en forme du warning, avec une ligne avant et une ligne apres, pour le rendre plus visible 
~~~

warning: A dictionary has been generated automatically. The field types should be checked and the dictionary saved if necessary.
For standard use, refer to the 'Data dictionary/Manage dictionaries...' menu.

~~~