### PR TITLE
Replay scenario in batch mode with fast exit in case of errors

### DIFF
--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -251,6 +251,7 @@ int KWMTDatabaseCompareMappingMainClass(const void* first, const void* second)
 
 void KWMTDatabase::UpdateMultiTableMappings()
 {
+	static ALString sLastUpdatedClassName;
 	KWClass* mainClass;
 	ObjectArray oaPreviousMultiTableMappings;
 	ObjectDictionary odReferenceClasses;
@@ -271,6 +272,20 @@ void KWMTDatabase::UpdateMultiTableMappings()
 
 	// Recherche du dictionnaire associe a la base
 	mainClass = KWClassDomain::GetCurrentDomain()->LookupClass(GetClassName());
+
+	// Ajout d'un message d'erreur si on parametre un dictionnaire inexistant
+	// Permet de generer une erreur explicite dans les scenarios dans ce cas
+	// Sinon, on obtient une erreur fatale en essayant ensuite de parametrer
+	// les fichiers d'une base multi-table
+	if (GetClassName() != "" and mainClass == NULL)
+	{
+		// On evite les messages d'erreur repete en memorisant le dernier dictionnaire manquant
+		// Sinon, les bases d'apprentissage et de test, ainsi que les multiples Refresh appelant
+		// cette methode generent des erreurs qui doublonnent
+		if (sLastUpdatedClassName != GetClassName())
+			AddError("Dictionary " + GetClassName() + " not found");
+	}
+	sLastUpdatedClassName = GetClassName();
 
 	// Si pas de dictionnaire associe, on nettoie le mapping
 	if (mainClass == NULL)

--- a/src/Learning/KWLearningProblem/KWLearningProject.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProject.cpp
@@ -185,6 +185,9 @@ void KWLearningProject::StartMaster(int argc, char** argv)
 	if (not UIObject::IsBatchMode())
 		cout << GetLearningShellBanner() << endl;
 
+	// Parametrage du mode fast exist
+	UIObject::SetFastExitMode(GetLearningFastExitMode());
+
 	// Parametrage du repertoire temporaire via les variables d'environnement
 	// (la valeur du repertoire temporaire peut etre modifiee par l'IHM)
 	sTmpDirFromEnv = p_getenv("KHIOPS_TMP_DIR");
@@ -444,6 +447,7 @@ boolean KWLearningProject::ShowSystemInformation(const ALString& sValue)
 	svEnvironmentVariables.Add("KhiopsExpertMode");
 	svEnvironmentVariables.Add("KhiopsHardMemoryLimitMode");
 	svEnvironmentVariables.Add("KhiopsCrashTestMode");
+	svEnvironmentVariables.Add("KhiopsFastExitMode");
 	svEnvironmentVariables.Add("KhiopsPreparationTraceMode");
 	svEnvironmentVariables.Add("KhiopsIOTraceMode");
 	svEnvironmentVariables.Add("KhiopsForestExpertMode");

--- a/src/Learning/KWUtils/KWVersion.cpp
+++ b/src/Learning/KWUtils/KWVersion.cpp
@@ -370,6 +370,33 @@ boolean GetLearningCrashTestMode()
 	return GetLearningExpertMode() and bLearningCrashTestMode;
 }
 
+boolean GetLearningFastExitMode()
+{
+	static boolean bIsInitialized = false;
+	static boolean bLearningFastExitMode = true;
+
+	// Determination du mode FastExit au premier appel
+	if (not bIsInitialized)
+	{
+		ALString sUserName;
+		ALString sLearningFastExitMode;
+
+		// Recherche des variables d'environnement
+		sLearningFastExitMode = p_getenv("KhiopsFastExitMode");
+		sLearningFastExitMode.MakeLower();
+
+		// Determination du mode FastExit
+		if (sLearningFastExitMode == "true")
+			bLearningFastExitMode = true;
+		else if (sLearningFastExitMode == "false")
+			bLearningFastExitMode = false;
+
+		// Memorisation du flag d'initialisation
+		bIsInitialized = true;
+	}
+	return GetLearningExpertMode() and bLearningFastExitMode;
+}
+
 boolean GetPreparationTraceMode()
 {
 	static boolean bIsInitialized = false;

--- a/src/Learning/KWUtils/KWVersion.h
+++ b/src/Learning/KWUtils/KWVersion.h
@@ -126,6 +126,11 @@ boolean GetLearningHardMemoryLimitMode();
 // Ce mode expert est controlable par la variable d'environnement KhiopsCrashTestMode a true ou false
 boolean GetLearningCrashTestMode();
 
+// Indicateur du mode de l'outil avec gestion du mode fast exist pour l'execution d'un scenario
+// Cf. UIObject::SetFastExitMode
+// Ce mode expert est controlable par la variable d'environnement KhiopsFastExitMode a true ou false
+boolean GetLearningFastExitMode();
+
 // Indicateur du mode trace pour le dimensionnement des taches de preparation
 // Ce mode expert est controlable par la variable d'environnement KhiopsPreparationTraceMode a true ou false
 boolean GetPreparationTraceMode();

--- a/src/Learning/MODL/MODL.cpp
+++ b/src/Learning/MODL/MODL.cpp
@@ -15,7 +15,7 @@ void SetWindowsDebugDir(const ALString& sDatasetFamily, const ALString& sDataset
 	// A parametrer pour chaque utilisateur
 	// Devra etre fait plus proprement quand tout l'equipe sera sur git, par exemple via une variable
 	// d'environnement et quelques commentaires clairs
-	sUserRootPath = "D:/Users/miib6422/Documents/boullema/LearningTest.V10.5.0-a1/TestKhiops/";
+	sUserRootPath = "C:/Applications/boullema/LearningTest.V10.5.2-b.0/TestKhiops/";
 
 	// Pour permettre de continuer a utiliser LearningTest, on ne fait rien s'il y a deja un fichier test.prm
 	// dans le repertoire courante

--- a/src/Norm/base/UIObject.cpp
+++ b/src/Norm/base/UIObject.cpp
@@ -1940,6 +1940,16 @@ boolean UIObject::IsBatchMode()
 	return bBatchMode;
 }
 
+void UIObject::SetFastExitMode(boolean bValue)
+{
+	bFastExitMode = bValue;
+}
+
+boolean UIObject::GetFastExitMode()
+{
+	return bFastExitMode;
+}
+
 void UIObject::SetTextualInteractiveModeAllowed(boolean bValue)
 {
 	bTextualInteractiveModeAllowed = bValue;
@@ -2423,6 +2433,7 @@ int UIObject::nUIMode = Textual;
 int UIObject::nInstanceNumber = 0;
 boolean UIObject::bVerboseCommandReplay = false;
 boolean UIObject::bBatchMode = false;
+boolean UIObject::bFastExitMode = true;
 boolean UIObject::bTextualInteractiveModeAllowed = false;
 FILE* UIObject::fInputCommands = NULL;
 FILE* UIObject::fOutputCommands = NULL;

--- a/src/Norm/base/UIUnit.cpp
+++ b/src/Norm/base/UIUnit.cpp
@@ -131,9 +131,16 @@ void UIUnit::Open()
 						uiField->SetFieldStringValue(values, uiUnit->nCurrentItemIndex, sValue);
 						uiUnit->nFreshness++;
 
-						// Declenchement d'un refresh selon le parametrae du champ
+						// Declenchement d'un refresh selon le parametrage du champ
 						if (uiField->GetTriggerRefresh())
+						{
 							uiUnit->ExecuteUserActionAt("Refresh");
+
+							// Sortie en mode fast exit, pouvant etre declenchee par une erreur de refresh
+							if (bBatchMode and bFastExitMode and
+							    Global::IsAtLeastOneError())
+								GlobalExitOnSuccess();
+						}
 						break;
 					}
 					else

--- a/src/Norm/base/UIUnit.cpp
+++ b/src/Norm/base/UIUnit.cpp
@@ -102,6 +102,10 @@ void UIUnit::Open()
 					AddSimpleMessage("Replay user action\t: " + sCommand);
 				WriteOutputCommand(sCommand, sValue, uiAction->GetUnformattedLabel());
 				uiUnit->ExecuteUserActionAt(uiAction->GetIdentifier());
+
+				// Sortie en mode fast exit
+				if (bBatchMode and bFastExitMode and Global::IsAtLeastOneError())
+					GlobalExitOnSuccess();
 				break;
 			}
 

--- a/src/Norm/base/UserInterface.h
+++ b/src/Norm/base/UserInterface.h
@@ -233,6 +233,18 @@ public:
 	// Ce mode peut etre modifie suite a un parametrage de la ligne de commande
 	static boolean IsBatchMode();
 
+	// Indicateur du mode de l'outil avec gestion du mode fast exist pour l'execution d'un scenario
+	// En mode fast exit a true (par defaut)
+	// - lors de l'execution d'un scenario en mode batch, on arrete des qu'une erreur applicative est detectee
+	// - on sort avec un exit code 0, avec dans le log la premiere erreur applicative detectee
+	//   - cela evite la sortie en fatal error, qui est plutot reservee au cas d'un scenario vraiment invalide
+	//   - cela est suffisant en informant correctement l'utilisateur sur la nature de l'erreur
+	// En mode fast exit a false
+	// - on continue l'execution du scenario
+	// - cela permet l'utilisation de scenarios testant de nombreux type d'erreur
+	static void SetFastExitMode(boolean bValue);
+	static boolean GetFastExitMode();
+
 	// Indique si le mode textuel peut-etre utilise de facon interactive
 	// avec des saisies d'actiosn ou de valeurs de champs depuis une fenetre shell
 	// Sort en erreur fatale si on ariive dans ce mode et qu'il n'est pas autorise
@@ -438,6 +450,7 @@ protected:
 	static int nInstanceNumber;
 	static boolean bVerboseCommandReplay;
 	static boolean bBatchMode;
+	static boolean bFastExitMode;
 	static boolean bTextualInteractiveModeAllowed;
 	static ALString sIconImageJarPath;
 	static ALString sLocalInputCommandsFileName;

--- a/test/LearningTestTool/py/_kht_constants.py
+++ b/test/LearningTestTool/py/_kht_constants.py
@@ -133,9 +133,10 @@ KHIOPS_MEM_STATS_LOG_FREQUENCY = "KhiopsMemStatsLogFrequency"
 KHIOPS_MEM_STATS_LOG_TO_COLLECT = "KhiopsMemStatsLogToCollect"
 KHIOPS_IO_TRACE_MODE = "KhiopsIOTraceMode"
 
-# Variables non documentee documentees, utilisee systematiquyement pour les tests
+# Variables non documentee documentees, utilisee systematiquement pour les tests
 KHIOPS_EXPERT_MODE = "KhiopsExpertMode"
 KHIOPS_CRASH_TEST_MODE = "KhiopsCrashTestMode"
+KHIOPS_FAST_EXIT_MODE = "KhiopsFastExitMode"
 KHIOPS_HARD_MEMORY_LIMIT_MODE = "KhiopsHardMemoryLimitMode"
 
 """

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -318,6 +318,10 @@ def evaluate_tool_on_test_dir(
         # khiops en mode expert via une variable d'environnement
         os.environ[kht.KHIOPS_EXPERT_MODE] = "true"
 
+        # khiops en mode fast exit a false via une variable d'environnement,
+        # pour executer des scenarios testant plusieurs cas d'erreur
+        os.environ[kht.KHIOPS_FAST_EXIT_MODE] = "false"
+
         # khiops en mode HardMemoryLimit via une variable d'environnement pour provoquer
         # un plantage physique de l'allocateur en cas de depassement des contraintes memoires des scenarios
         os.environ[kht.KHIOPS_HARD_MEMORY_LIMIT_MODE] = "true"


### PR DESCRIPTION
Pilotage de Khiops via des scenarios en mode batch
- En mode fast exit a true (par defaut)
  - lors de l'execution d'un scenario en mode batch, on arrete des qu'une erreur applicative est detectee
  - on sort avec un exit code 0, avec dans le log la premiere erreur applicative detectee
    - cela evite la sortie en fatal error, qui est plutot réservee au cas d'un scenario vraiment invalide
    - cela est suffisant en informant correctement l'utilisateur sur la nature de l'erreur
- En mode fast exit a false
  - on continue l'execution du scenario
  - cela permet l'utilisation de scenarios testant de nombreux type d'erreur
- Ce mode expert est controlable par la variable d'environnement KhiopsFastExitMode a true ou false

Impacts
- KWVersion: methode GetLearningFastExitMode dans KWVersion, pour gerer la variable d'environnement KhiopsFastExitMode
- UIObject::Set|GetFastExitMode: parametrage global du mode fast exist dans UIObject (defaut: true)
- UIUnit::Open: sortie rapide, conditionne par le mode batch, le mode fast exit et la prsence d'au moins une erreur applicative
- KWLearningProject::StartMaster: parametrage du mode fast exit selon la valeur de GetLearningFastExitMode
- KWLearningProject::ShowSystemInformation: ajout de l'affichage de la variable d'environnement interne KhiopsFastExitMode
- LearningTest
  - _kht_constants.py: declaration de KHIOPS_FAST_EXIT_MODE
  - kht_test.py: parametrage de KHIOPS_FAST_EXIT_MODE = false pour executer des scenarios testant plusieurs cas d'erreur