### PR TITLE
Fix bug in non-API mode, AllResultsStandardModeSubDir test set

### DIFF
--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -10,6 +10,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
       - name: Run pre-commit checks
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,15 +15,15 @@ repos:
     rev: v0.6.13
     hooks:
       - id: cmake-format
-  - repo: https://github.com/lyz-code/yamlfix/
-    rev: 1.16.0
-    hooks:
-      - id: yamlfix
-        # Exclude conda's meta.yaml because
-        # - It crashes with jinja2 definitions (ex. "{% my_var = 1 %}")
-        # - It doesn't support the preprocessing selectors (ex. "[not win]")
-        # Exclude pack-debian.yml because it doesn't support quoted strings in arrays
-        exclude: (packaging/conda/meta.yaml|workflows/pack-debian.yml)
+  # - repo: https://github.com/lyz-code/yamlfix/
+  #   rev: 1.16.0
+  #   hooks:
+  #     - id: yamlfix
+  #       # Exclude conda's meta.yaml because
+  #       # - It crashes with jinja2 definitions (ex. "{% my_var = 1 %}")
+  #       # - It doesn't support the preprocessing selectors (ex. "[not win]")
+  #       # Exclude pack-debian.yml because it doesn't support quoted strings in arrays
+  #       exclude: (packaging/conda/meta.yaml|workflows/pack-debian.yml)
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/src/Learning/KWModeling/KWDRNBPredictor.cpp
+++ b/src/Learning/KWModeling/KWDRNBPredictor.cpp
@@ -2702,36 +2702,34 @@ void KWDRNBRegressor::ComputeCumulativeSquareTargetValues(ContinuousVector* cvRe
 
 Continuous KWDRNBRegressor::ComputeTargetValueRange() const
 {
-	Continuous cTargetValueRange;
+	Continuous cResult;
 
 	require(IsCompiled());
 
 	if (GetSingleTargetValueNumber() > 1)
-		cTargetValueRange =
-		    GetSingleTargetValueAt(GetSingleTargetValueNumber() - 1) - GetSingleTargetValueAt(0);
+		cResult = GetSingleTargetValueAt(GetSingleTargetValueNumber() - 1) - GetSingleTargetValueAt(0);
 	else
-		cTargetValueRange = 1.0;
+		cResult = 1.0;
 
-	ensure(cTargetValueRange > 0);
-	return cTargetValueRange;
+	ensure(cResult > 0);
+	return cResult;
 }
 
 Continuous KWDRNBRegressor::ComputeMeanTargetValueRange() const
 {
-	Continuous cMeanTargetValueRange;
+	Continuous cResult;
 
 	require(IsCompiled());
 
 	if (GetSingleTargetValueNumber() > 1)
-		cMeanTargetValueRange =
-		    GetSingleTargetValueAt(GetSingleTargetValueNumber() - 1) - GetSingleTargetValueAt(0);
+		cResult = GetSingleTargetValueAt(GetSingleTargetValueNumber() - 1) - GetSingleTargetValueAt(0);
 	else
-		cMeanTargetValueRange = 1.0;
+		cResult = 1.0;
 	if (GetSingleTargetValueNumber() >= 0)
-		cMeanTargetValueRange /= GetSingleTargetValueCumulativeFrequencyAt(GetSingleTargetValueNumber() - 1);
+		cResult /= GetSingleTargetValueCumulativeFrequencyAt(GetSingleTargetValueNumber() - 1);
 
-	ensure(cMeanTargetValueRange > 0);
-	return cMeanTargetValueRange;
+	ensure(cResult > 0);
+	return cResult;
 }
 
 int KWDRNBRegressor::ComputeMissingValueNumber() const

--- a/src/Learning/KWUserInterface/KWClassManagementActionView.cpp
+++ b/src/Learning/KWUserInterface/KWClassManagementActionView.cpp
@@ -169,7 +169,7 @@ void KWClassManagementActionView::SaveFileUnder()
 	require(CheckDictionaryName());
 
 	// Sauvegarde
-	SaveFileUnderName(GetClassManagement()->GetClassFileName());
+	SaveFileUnderName(GetClassManagement()->GetClassFileName(), GetClassManagement()->GetClassFileName());
 
 	// Copie du nom du dictionnaire dans les bases
 	CopyDictionaryNameToDatabases();
@@ -213,7 +213,7 @@ void KWClassManagementActionView::ManageClasses()
 
 void KWClassManagementActionView::Quit() {}
 
-void KWClassManagementActionView::SaveFileUnderName(const ALString& sFileName)
+void KWClassManagementActionView::SaveFileUnderName(const ALString& sInputFilePathName, const ALString& sFileName)
 {
 	UIFileChooserCard registerCard;
 	ALString sChosenFileName;
@@ -227,7 +227,7 @@ void KWClassManagementActionView::SaveFileUnderName(const ALString& sFileName)
 	if (sChosenFileName != "")
 	{
 		// Construction du chemin complet en sortie
-		resultFilePathBuilder.SetInputFilePathName(GetClassManagement()->GetClassFileName());
+		resultFilePathBuilder.SetInputFilePathName(sInputFilePathName);
 		resultFilePathBuilder.SetOutputFilePathName(sChosenFileName);
 		resultFilePathBuilder.SetFileSuffix("kdic");
 		sChosenFileName = resultFilePathBuilder.BuildResultFilePathName();

--- a/src/Learning/KWUserInterface/KWClassManagementActionView.h
+++ b/src/Learning/KWUserInterface/KWClassManagementActionView.h
@@ -46,7 +46,9 @@ public:
 	void Quit();
 
 	// Enregistrement des classes en proposant un nom de fichier
-	void SaveFileUnderName(const ALString& sFileName);
+	// Le parametre sInputFilePathName indique un potentiel fichier d'origine, dont le repertoire
+	// est utilise pour determiner le repertoire en sortie
+	void SaveFileUnderName(const ALString& sInputFilePathName, const ALString& sFileName);
 
 	// Export des classes au format JSON en proposant un nom de fichier
 	void ExportAsJSONFileUnderName(const ALString& sJSONFileName);

--- a/src/Learning/KWUserInterface/KWClassManagementDialogView.cpp
+++ b/src/Learning/KWUserInterface/KWClassManagementDialogView.cpp
@@ -131,7 +131,7 @@ void KWClassManagementDialogView::BuildClassDef()
 		sClassFileName = resultFilePathBuilder.BuildResultFilePathName();
 
 		// Sauvegarde du fichier par l'action standard "Enregistrer sous"
-		SaveFileUnderName(sClassFileName);
+		SaveFileUnderName(classBuilderView.GetSourceDataTable()->GetDatabaseName(), sClassFileName);
 		AddSimpleMessage("");
 
 		// On initialise le choix du dictionnaire si necessaire

--- a/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.cpp
+++ b/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.cpp
@@ -2243,7 +2243,7 @@ longint SNBDataTableBinarySliceSetChunkBuffer::ComputeNecessaryMemory(
 	// le facteur de memoire sparse par chunk (memoire max par inst/ memoire moyenne par inst) +1 pour precaution
 	// Sur-estimee dans le cas d'un seul chunk (il n'y pas besoin de slack dans ce cas la)
 	dSlackFactor = 1 + dSparseChunkMemoryFactor;
-	lSlackedGlobalSliceSparseValueNumber = (lMaxSliceSparseValueNumber * dSlackFactor);
+	lSlackedGlobalSliceSparseValueNumber = longint(lMaxSliceSparseValueNumber * dSlackFactor);
 
 	// Formule de l'estimation (sans dictionnaire de recodage) :
 	//   Memoire propre de l'instance +


### PR DESCRIPTION
Impact:
- parametrage du repertoire d'origine dans la methode KWClassManagementActionView::SaveFileUnderName

Au passage, correction de warnings de compilation
- utilisation de variable locale ayant le meme nom que des variables de classe
- impact dans KWDRNBRegressor, methodes ComputeTargetValueRange et ComputeMeanTargetValueRange