### PR TITLE
Add defaultGroupIndex in instance x variable coclustering reports

### DIFF
--- a/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.cpp
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.cpp
@@ -2119,6 +2119,21 @@ const ALString CCCoclusteringBuilder::GetClassLabel() const
 	return GetLearningModuleName();
 }
 
+const ALString CCCoclusteringBuilder::GetObjectLabel() const
+{
+	// Cas d'un coclustering instances * variables: on renvoie le nom du dictionnaire
+	if (GetVarPartCoclustering())
+	{
+		if (GetClass() == NULL)
+			return "";
+		else
+			return GetClass()->GetName();
+	}
+	// Cas d'un coclustering de variable: on renvoie le nom des variables
+	else
+		return KWAttributeSubsetStats::GetObjectLabel();
+}
+
 boolean CCCoclusteringBuilder::CheckMemoryForDatabaseRead(KWDatabase* database) const
 {
 	boolean bOk = true;

--- a/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.h
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.h
@@ -141,6 +141,7 @@ public:
 
 	// Libelles utilisateur: nom du module de l'application (GetLearningModuleName())
 	const ALString GetClassLabel() const override;
+	const ALString GetObjectLabel() const override;
 
 	/////////////////////////////////////////////////
 	///// Implementation

--- a/src/Learning/MODL_Coclustering/MODL_Coclustering.cpp
+++ b/src/Learning/MODL_Coclustering/MODL_Coclustering.cpp
@@ -15,7 +15,7 @@ void SetWindowsDebugDir(const ALString& sDatasetFamily, const ALString& sDataset
 	// A parametrer pour chaque utilisateur
 	// Devra etre fait plus proprement quand tout l'equipe sera sur git, par exemple via une variable
 	// d'environnement et quelques commentaires clairs
-	sUserRootPath = "D:/Users/miib6422/Documents/boullema/LearningTest.V10.5.0-a1/LearningTest/TestCoclustering/";
+	sUserRootPath = "C:/Applications/boullema/LearningTest.V10.5.2-b.0/TestCoclustering/";
 
 	// Pour permettre de continuer a utiliser LearningTest, on ne fait rien s'il y a deja un fichier test.prm
 	// dans le repertoire courante
@@ -39,6 +39,7 @@ int main(int argc, char** argv)
 	//SetWindowsDebugDir("y_CoclusteringIV_Standard", "IrisLight");
 	//SetWindowsDebugDir("y_CoclusteringIV_Standard", "Iris");
 	//SetWindowsDebugDir("Standard", "Iris");
+	SetWindowsDebugDir("y_CoclusteringIV_Standard", "ExtractClustersIris");
 
 	// Point d'arret sur l'allocation d'un bloc memoire
 	// MemSetAllocIndexExit(30406);


### PR DESCRIPTION
Dans les rapport .khcj des modèle de coclustering instances x variables, ajout du "defaultGroupIndex" pour la la partition des parties de variables en "valuedGroups" Bien que cela ne soit pas utile dans ce contexte, cela permet de rendre les rapport plus generique et de les rendre lisible par pykhiops, comme ils le sont deja par l'outil de covisualisation

Impacts
- CCCoclusteringReport::WriteJSONAttributePartition: pour l'ecriture d'un rapport
- CCCoclusteringReport::ReadJSONAttributePartition: pour la lecture d'un rapport
- CCCoclusteringBuilder::GetObjectLabel: correction independante, pour l'amelioration des messages d'erreur

Tests complets et mise a jour de LearningTest/TestCoclustering/y_CoclusteringIV_Standard