### PR TITLE
Fix bug for coclustering IxV with tiny dataset

### DIFF
--- a/src/Learning/KWDataPreparation/KWDataGridManager.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridManager.cpp
@@ -314,8 +314,7 @@ void KWDataGridManager::ExportDataGridWithRandomizedInnerAttributes(const KWData
 
 	// Nombre de tokens des innerAttributes de reference
 	nReferenceTokenNumber = referenceInnerAttributes->ComputeTotalInnerAttributeVarParts();
-
-	assert(nReferenceTokenNumber > nCurrentTokenNumber);
+	assert(nReferenceTokenNumber >= nCurrentTokenNumber);
 
 	// Cas ou le nombre de tokens objectif est inferieur au nombre de tokens en entree : recopie de la grille en entree a l'identique
 	// Cas ou le nombre de tokens de la partition de reference est inferieur au nombre de tokens en entree : pas de sur-tokenisation possible

--- a/src/Learning/KWDataPreparation/KWDataGridOptimizer.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridOptimizer.cpp
@@ -1790,6 +1790,9 @@ void KWDataGridOptimizer::GenerateNeighbourSolution(const KWDataGrid* initialDat
 		boolean bDisplayResults = false;
 		int nInitialSeed;
 
+		// Correction du nombre de tokens
+		nTargetTokenNumber = min(nTargetTokenNumber, initialDataGrid->GetGridFrequency());
+
 		// Memorisation de la graine initiale
 		nInitialSeed = GetRandomSeed();
 

--- a/src/Learning/KWDataPreparation/KWQuantileBuilder.cpp
+++ b/src/Learning/KWDataPreparation/KWQuantileBuilder.cpp
@@ -117,6 +117,7 @@ void KWQuantileIntervalBuilder::InitializeFrequencies(const IntVector* ivInputFr
 
 int KWQuantileIntervalBuilder::ComputeQuantiles(int nQuantileNumber)
 {
+	const double dEpsilon = 1e-10;
 	int nQuantile;
 	double dSearchedCumulativeFrequency;
 	int nSearchedCumulativeFrequency;
@@ -143,15 +144,14 @@ int KWQuantileIntervalBuilder::ComputeQuantiles(int nQuantileNumber)
 	bSequentialSearch = false;
 	for (nQuantile = 0; nQuantile < nQuantileNumber; nQuantile++)
 	{
-		// Calcul de l'index en passant par un longint pour eviter les problemes de depassement de capacite des
-		// int
+		// Calcul de l'index en passant par un double pour eviter les problemes de depassement de capacite des int
 		dSearchedCumulativeFrequency = nInstanceNumber * (nQuantile + 1.0) / nQuantileNumber;
 
 		// On biaise vers une des extremites
 		if (nQuantile >= nQuantileNumber / 2)
-			dSearchedCumulativeFrequency += 1.0 / nInstanceNumber;
+			dSearchedCumulativeFrequency += dEpsilon;
 		else
-			dSearchedCumulativeFrequency -= 1.0 / nInstanceNumber;
+			dSearchedCumulativeFrequency -= dEpsilon;
 		nSearchedCumulativeFrequency = (int)floor(dSearchedCumulativeFrequency + 0.5);
 		assert(0 <= nSearchedCumulativeFrequency and nSearchedCumulativeFrequency <= nInstanceNumber);
 

--- a/src/Learning/MODL_Coclustering/MODL_Coclustering.cpp
+++ b/src/Learning/MODL_Coclustering/MODL_Coclustering.cpp
@@ -39,7 +39,6 @@ int main(int argc, char** argv)
 	//SetWindowsDebugDir("y_CoclusteringIV_Standard", "IrisLight");
 	//SetWindowsDebugDir("y_CoclusteringIV_Standard", "Iris");
 	//SetWindowsDebugDir("Standard", "Iris");
-	SetWindowsDebugDir("y_CoclusteringIV_Standard", "ExtractClustersIris");
 
 	// Point d'arret sur l'allocation d'un bloc memoire
 	// MemSetAllocIndexExit(30406);


### PR DESCRIPTION
Contexte: experimentations pour l'article "Co-clustering For Large Scale Mixed Data Exploratory Analysis" Jeu de donnee reduit a deux instances

Corrections de detail pour des effets de bord: quelques lignes de code