### PR TITLE
347 simplify management of data path for multi table schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ KhiopsMemoryStats.all_stats.xlsx
 # Python
 *.pyc
 __pycache__/
+.idea/

--- a/src/Learning/KDDomainKnowledge/KDEntity.cpp
+++ b/src/Learning/KDDomainKnowledge/KDEntity.cpp
@@ -13,7 +13,7 @@ KDEntity::~KDEntity() {}
 
 void KDEntity::SetName(const ALString sValue)
 {
-	require(sValue == "" or KWClass::CheckName(sValue, NULL));
+	require(sValue == "" or KWClass::CheckName(sValue, KWClass::None, NULL));
 	sName = sValue;
 }
 
@@ -24,7 +24,7 @@ const ALString& KDEntity::GetName() const
 
 void KDEntity::SetPartName(const ALString sValue)
 {
-	require(sValue == "" or KWClass::CheckName(sValue, NULL));
+	require(sValue == "" or KWClass::CheckName(sValue, KWClass::None, NULL));
 	sPartName = sValue;
 }
 
@@ -66,9 +66,9 @@ boolean KDEntity::Check() const
 {
 	boolean bOk = true;
 
-	if (sName != "" and KWClass::CheckName(sName, this))
+	if (sName != "" and KWClass::CheckName(sName, KWClass::None, this))
 		bOk = false;
-	if (sPartName != "" and KWClass::CheckName(sPartName, this))
+	if (sPartName != "" and KWClass::CheckName(sPartName, KWClass::None, this))
 		bOk = false;
 	return bOk;
 }

--- a/src/Learning/KNITransfer/KNIDatabaseTransferView.cpp
+++ b/src/Learning/KNITransfer/KNIDatabaseTransferView.cpp
@@ -66,7 +66,7 @@ void KNIDatabaseTransferView::KNITransferDatabase()
 		if (sourceMTDatabase->IsReferencedClassMapping(mapping))
 		{
 			strcpy(recodingOperands.ExternalFiles[recodingOperands.ExternalFileNumber].DataRoot,
-			       mapping->GetDataPathClassName());
+			       mapping->GetOriginClassName());
 			strcpy(recodingOperands.ExternalFiles[recodingOperands.ExternalFileNumber].DataPath,
 			       mapping->GetDataPathAttributeNames());
 			strcpy(recodingOperands.ExternalFiles[recodingOperands.ExternalFileNumber].FileName,

--- a/src/Learning/KNITransfer/KNITransfer.cpp
+++ b/src/Learning/KNITransfer/KNITransfer.cpp
@@ -4,11 +4,37 @@
 
 #include "KNITransfer.h"
 
+// Debogage sous Windows Visual C++ 2022 (bug https://github.com/microsoft/vscode-cpptools/issues/8084)
+// Choix en dur du repertoire de lancement
+void SetWindowsDebugDir(const ALString& sDatasetFamily, const ALString& sDataset)
+{
+#ifdef _WIN32
+	ALString sUserRootPath;
+	int nRet;
+
+	// A parametrer pour chaque utilisateur
+	// Devra etre fait plus proprement quand tout l'equipe sera sur git, par exemple via une variable
+	// d'environnement et quelques commentaires clairs
+	sUserRootPath = "C:/Applications/boullema/LearningTest.V10.5.3-b.0/TestKNI/";
+
+	// Pour permettre de continuer a utiliser LearningTest, on ne fait rien s'il y a deja un fichier test.prm
+	// dans le repertoire courante
+	if (FileService::FileExists("test.prm"))
+		return;
+
+	// Changement de repertoire, uniquement pour Windows
+	nRet = _chdir(sUserRootPath + sDatasetFamily + "/" + sDataset);
+#endif
+}
+
 int main(int argc, char** argv)
 {
 	KNITransferProject learningProject;
 
 	// MemSetAllocIndexExit(1290133);
+
+	// Choix du repertoire de lancement pour le debugage sous Windows (a commenter apres fin du debug)
+	// SetWindowsDebugDir("Standard", "Iris");
 
 	// Lancement du projet
 	learningProject.Start(argc, argv);

--- a/src/Learning/KWData/KWAttribute.cpp
+++ b/src/Learning/KWData/KWAttribute.cpp
@@ -198,11 +198,11 @@ boolean KWAttribute::Check() const
 		parentClass->GetDomain()->LookupClass(parentClass->GetName()) == parentClass);
 
 	// Nom
-	if (not KWClass::CheckName(GetName(), this))
+	if (not KWClass::CheckName(GetName(), KWClass::Attribute, this))
 		bOk = false;
 
 	// Libelle
-	if (not KWClass::CheckLabel(GetLabel(), this))
+	if (not KWClass::CheckLabel(GetLabel(), KWClass::Attribute, this))
 		bOk = false;
 
 	// Type
@@ -278,7 +278,7 @@ boolean KWAttribute::Check() const
 			AddError("No reference dictionary for type " + KWType::ToString(GetType()));
 			bOk = false;
 		}
-		else if (not KWClass::CheckName(attributeClass->GetName(), this))
+		else if (not KWClass::CheckName(attributeClass->GetName(), KWClass::Class, this))
 		{
 			AddError("Incorrect name of reference dictionary for type " + KWType::ToString(GetType()));
 			bOk = false;
@@ -323,7 +323,7 @@ boolean KWAttribute::Check() const
 			AddError("No name for type Structure");
 			bOk = false;
 		}
-		else if (not KWClass::CheckName(GetStructureName(), this))
+		else if (not KWClass::CheckName(GetStructureName(), KWClass::Structure, this))
 		{
 			AddError("Incorrect name for type Structure");
 			bOk = false;

--- a/src/Learning/KWData/KWAttribute.cpp
+++ b/src/Learning/KWData/KWAttribute.cpp
@@ -263,15 +263,6 @@ boolean KWAttribute::Check() const
 	// Classe si type Object
 	if (KWType::IsGeneralRelation(GetType()))
 	{
-		// Une variable native de type relation ne doit pas avoir de back-quote dans son nom, pour qu'il n'y
-		// ait pas d'ambiguite dans les DataPath natifs (cf database multi-tables)
-		if (kwdrRule == NULL and attributeBlock == NULL and GetName().Find('`') >= 0)
-		{
-			AddError("Incorrect name for a native variable of type " + KWType::ToString(GetType()) +
-				 ": must not contain back-quote");
-			bOk = false;
-		}
-
 		// Presence de la classe
 		if (attributeClass == NULL)
 		{

--- a/src/Learning/KWData/KWAttributeBlock.cpp
+++ b/src/Learning/KWData/KWAttributeBlock.cpp
@@ -127,7 +127,7 @@ boolean KWAttributeBlock::Check() const
 	int nAttributeKey;
 
 	// Nom
-	if (not KWClass::CheckName(GetName(), this))
+	if (not KWClass::CheckName(GetName(), KWClass::AttributeBlock, this))
 		bOk = false;
 
 	// Tests de base sur la specification du block

--- a/src/Learning/KWData/KWCYac.cpp
+++ b/src/Learning/KWData/KWCYac.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2024 Orange. All rights reserved.
+// This software is distributed under the BSD 3-Clause-clear License, the text of which is available
+// at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
+
 /* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C

--- a/src/Learning/KWData/KWCYac.cpp
+++ b/src/Learning/KWData/KWCYac.cpp
@@ -1,7 +1,3 @@
-// Copyright (c) 2024 Orange. All rights reserved.
-// This software is distributed under the BSD 3-Clause-clear License, the text of which is available
-// at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
-
 /* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
@@ -68,7 +64,7 @@
 #define YYPULL 1
 
 /* First part of user prologue.  */
-#line 1 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 /* ATTENTION: les regles openparenthesis et closeparenthesis generent             */
 /* 3 shift/reduce conflicts et 15 reduce/reduce conflicts                         */
@@ -120,7 +116,7 @@ static int nFileParsingErrorNumber = 0;
 extern char   *yyptok(int i);
 */
 
-#line 127 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 127 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 #ifndef YY_CAST
 #ifdef __cplusplus
@@ -557,10 +553,10 @@ static const yytype_int8 yytranslate[] = {
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] = {
     0,    134,  134,  138,  145,  149,  153,  157,  161,  165,  169,  173,  177,  181,  185,  189,  193,  197,  201,
-    207,  220,  221,  224,  227,  237,  245,  286,  365,  384,  395,  438,  485,  577,  584,  592,  598,  608,  621,
-    641,  663,  682,  699,  707,  842,  854,  861,  873,  880,  885,  892,  897,  904,  908,  912,  916,  920,  924,
-    928,  932,  936,  940,  944,  952,  957,  963,  967,  971,  976,  985,  990,  996,  1016, 1032, 1210, 1214, 1221,
-    1234, 1245, 1259, 1268, 1277, 1287, 1297, 1308, 1317, 1324, 1325, 1329, 1334, 1340, 1341, 1345, 1350, 1362, 1364};
+    207,  220,  221,  224,  227,  237,  245,  287,  367,  386,  397,  441,  489,  582,  589,  597,  603,  613,  626,
+    646,  668,  687,  704,  712,  847,  859,  866,  878,  885,  890,  897,  902,  909,  913,  917,  921,  925,  929,
+    933,  937,  941,  945,  949,  957,  962,  968,  972,  976,  981,  990,  995,  1001, 1021, 1037, 1215, 1219, 1226,
+    1239, 1250, 1264, 1273, 1282, 1292, 1302, 1313, 1322, 1329, 1330, 1334, 1339, 1345, 1346, 1350, 1355, 1367, 1369};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -907,243 +903,243 @@ static void yydestruct(const char* yymsg, yysymbol_kind_t yykind, YYSTYPE* yyval
 	switch (yykind)
 	{
 	case YYSYMBOL_BASICIDENTIFIER: /* BASICIDENTIFIER  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1030 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1030 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_EXTENDEDIDENTIFIER: /* EXTENDEDIDENTIFIER  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1036 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1036 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_STRINGLITTERAL: /* STRINGLITTERAL  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1042 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1042 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_LABEL: /* LABEL  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1048 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1048 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_APPLICATIONID: /* APPLICATIONID  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1054 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1054 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_IDENTIFIER: /* IDENTIFIER  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1060 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1060 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_SIMPLEIDENTIFIER: /* SIMPLEIDENTIFIER  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1066 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1066 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_oaAttributeArrayDeclaration: /* oaAttributeArrayDeclaration  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).oaAttributes) != NULL)
 			delete ((*yyvaluep).oaAttributes);
 		((*yyvaluep).oaAttributes) = NULL;
 	}
-#line 1072 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1072 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_keyFields: /* keyFields  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).svValue) != NULL)
 			delete ((*yyvaluep).svValue);
 		((*yyvaluep).svValue) = NULL;
 	}
-#line 1078 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1078 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_keyFieldList: /* keyFieldList  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).svValue) != NULL)
 			delete ((*yyvaluep).svValue);
 		((*yyvaluep).svValue) = NULL;
 	}
-#line 1084 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1084 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_metaData: /* metaData  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwmdMetaData) != NULL)
 			delete ((*yyvaluep).kwmdMetaData);
 		((*yyvaluep).kwmdMetaData) = NULL;
 	}
-#line 1090 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1090 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_kwattributeDeclaration: /* kwattributeDeclaration  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwaValue) != NULL)
 			delete ((*yyvaluep).kwaValue);
 		((*yyvaluep).kwaValue) = NULL;
 	}
-#line 1096 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1096 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_applicationids: /* applicationids  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1102 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1102 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_comments: /* comments  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1108 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1108 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_refIdentifier: /* refIdentifier  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1114 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1114 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_usedDerivationRule: /* usedDerivationRule  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1120 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1120 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_referenceRule: /* referenceRule  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1126 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1126 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_referenceRuleBody: /* referenceRuleBody  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1132 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1132 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRule: /* derivationRule  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1138 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleBody: /* derivationRuleBody  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1144 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1144 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleHeader: /* derivationRuleHeader  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1150 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1150 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleBegin: /* derivationRuleBegin  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1156 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1156 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleOperand: /* derivationRuleOperand  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdroValue) != NULL)
 			delete ((*yyvaluep).kwdroValue);
 		((*yyvaluep).kwdroValue) = NULL;
 	}
-#line 1162 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1162 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_bigstring: /* bigstring  */
-#line 125 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1168 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1168 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	default:
@@ -1393,143 +1389,143 @@ yyreduce:
 	switch (yyn)
 	{
 	case 2: /* IDENTIFIER: SIMPLEIDENTIFIER  */
-#line 135 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 135 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1440 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1440 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 3: /* IDENTIFIER: EXTENDEDIDENTIFIER  */
-#line 139 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 139 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1448 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1448 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 4: /* SIMPLEIDENTIFIER: BASICIDENTIFIER  */
-#line 146 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 146 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1456 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1456 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 5: /* SIMPLEIDENTIFIER: CLASS  */
-#line 150 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 150 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Dictionary");
 	}
-#line 1464 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1464 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 6: /* SIMPLEIDENTIFIER: CONTINUOUSTYPE  */
-#line 154 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 154 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Numerical");
 	}
-#line 1472 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1472 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 7: /* SIMPLEIDENTIFIER: SYMBOLTYPE  */
-#line 158 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 158 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Categorical");
 	}
-#line 1480 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1480 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 8: /* SIMPLEIDENTIFIER: OBJECTTYPE  */
-#line 162 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 162 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Entity");
 	}
-#line 1488 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1488 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 9: /* SIMPLEIDENTIFIER: OBJECTARRAYTYPE  */
-#line 166 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 166 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Table");
 	}
-#line 1496 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1496 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 10: /* SIMPLEIDENTIFIER: ROOT  */
-#line 170 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 170 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Root");
 	}
-#line 1504 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1504 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 11: /* SIMPLEIDENTIFIER: UNUSED  */
-#line 174 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 174 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Unused");
 	}
-#line 1512 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1512 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 12: /* SIMPLEIDENTIFIER: DATETYPE  */
-#line 178 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 178 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Date");
 	}
-#line 1520 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1520 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 13: /* SIMPLEIDENTIFIER: TIMETYPE  */
-#line 182 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 182 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Time");
 	}
-#line 1528 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1528 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 14: /* SIMPLEIDENTIFIER: TIMESTAMPTYPE  */
-#line 186 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 186 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Timestamp");
 	}
-#line 1536 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1536 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 15: /* SIMPLEIDENTIFIER: TIMESTAMPTZTYPE  */
-#line 190 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 190 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("TimestampTZ");
 	}
-#line 1544 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1544 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 16: /* SIMPLEIDENTIFIER: TEXTTYPE  */
-#line 194 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 194 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Text");
 	}
-#line 1552 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1552 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 17: /* SIMPLEIDENTIFIER: TEXTLISTTYPE  */
-#line 198 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 198 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("TextList");
 	}
-#line 1560 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1560 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 18: /* SIMPLEIDENTIFIER: STRUCTURETYPE  */
-#line 202 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 202 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Structure");
 	}
-#line 1568 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1568 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 19: /* kwclassFile: applicationids kwclasses comments  */
-#line 208 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 208 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore l'identification d'application */
 		if ((yyvsp[-2].sValue) != NULL)
@@ -1539,20 +1535,20 @@ yyreduce:
 		if ((yyvsp[0].sValue) != NULL)
 			delete (yyvsp[0].sValue);
 	}
-#line 1582 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1582 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 21: /* kwclasses: kwclasses error  */
-#line 222 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 222 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Error outside the definition of a dictionary");
 		YYABORT;
 	}
-#line 1589 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1589 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 23: /* kwclass: kwclassBegin '}' semicolon  */
-#line 228 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 228 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* La completion des informations de type (CompleteTypeInfo) est centralisee */
 		/* au niveau du domaine en fin de parsing */
@@ -1560,11 +1556,11 @@ yyreduce:
 		/* Reinitialisation de la classe courante */
 		kwcLoadCurrentClass = NULL;
 	}
-#line 1601 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1601 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 24: /* kwclassBegin: kwclassHeader comments  */
-#line 238 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 238 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore les premiers comemntaires */
 		if ((yyvsp[0].sValue) != NULL)
@@ -1572,14 +1568,15 @@ yyreduce:
 		assert(kwcLoadCurrentClass == (yyvsp[-1].kwcValue));
 		(yyval.kwcValue) = (yyvsp[-1].kwcValue);
 	}
-#line 1613 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1613 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 25: /* kwclassBegin: kwclassBegin kwattributeDeclaration  */
-#line 246 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 246 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-1].kwcValue);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
+		ALString sMessage;
 		assert(kwcLoadCurrentClass == (yyvsp[-1].kwcValue));
 
 		/* Si attribut non valide: on ne fait rien */
@@ -1589,10 +1586,9 @@ yyreduce:
 		else if (kwcClass == NULL)
 			delete attribute;
 		/* Sinon, test de validite du nom de l'attribut */
-		else if (!kwcClass->CheckName(attribute->GetName(), kwcClass))
+		else if (!kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		{
-			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ": Incorrect variable name",
-						  -1);
+			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ", " + sMessage, -1);
 			delete attribute;
 		}
 		/* Test de non existence parmi les attributs */
@@ -1620,11 +1616,11 @@ yyreduce:
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1658 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1659 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 26: /* kwclassBegin: kwclassBegin '{' comments oaAttributeArrayDeclaration '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 287 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 288 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-9].kwcValue);
 		KWAttributeBlock* attributeBlock;
@@ -1633,6 +1629,7 @@ yyreduce:
 		KWAttribute* firstAttribute;
 		KWAttribute* lastAttribute;
 		KWDerivationRule* rule = (yyvsp[-3].kwdrValue);
+		ALString sMessage;
 		assert(kwcLoadCurrentClass == (yyvsp[-9].kwcValue));
 		check(oaAttributes);
 
@@ -1648,12 +1645,9 @@ yyreduce:
 		if (oaAttributes->GetSize() > 0)
 		{
 			/* Test de validite du nom de l'attribut */
-			if (!kwcClass->CheckName(sBlockName, kwcClass))
+			if (!kwcClass->CheckNameWithMessage(sBlockName, KWClass::AttributeBlock, sMessage))
 			{
-				yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() +
-							      ": Incorrect sparse variable block name (" + sBlockName +
-							      ")",
-							  -1);
+				yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ", " + sMessage, -1);
 			}
 			/* Test de non existence parmi les attributs */
 			else if (kwcClass->LookupAttribute(sBlockName) != NULL)
@@ -1710,11 +1704,11 @@ yyreduce:
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1741 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1743 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 27: /* kwclassBegin: kwclassBegin '{' comments '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 366 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 368 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-8].kwcValue);
 
@@ -1733,11 +1727,11 @@ yyreduce:
 			delete (yyvsp[0].sValue);
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1764 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1766 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 28: /* kwclassBegin: kwclassBegin error  */
-#line 385 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 387 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* ERRORMGT */
 		/* Attention: cette regle qui permet une gestion des erreurs amelioree */
@@ -1745,15 +1739,16 @@ yyreduce:
 		kwcLoadCurrentClass = NULL;
 		YYABORT;
 	}
-#line 1776 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1778 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 29: /* oaAttributeArrayDeclaration: oaAttributeArrayDeclaration kwattributeDeclaration  */
-#line 396 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 398 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes = (yyvsp[-1].oaAttributes);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
 		KWClass* kwcClass = kwcLoadCurrentClass;
+		ALString sMessage;
 		check(oaAttributes);
 
 		/* Si attribut non valide: on ne fait rien */
@@ -1763,11 +1758,9 @@ yyreduce:
 		else if (kwcClass == NULL)
 			delete attribute;
 		/* Sinon, test de validite du nom de l'attribut */
-		else if (!kwcClass->CheckName(attribute->GetName(), kwcClass))
+		else if (!kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		{
-			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ": Incorrect variable name (" +
-						      attribute->GetName() + ")",
-						  -1);
+			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ", " + sMessage, -1);
 			delete attribute;
 		}
 		/* Test de non existence parmi les attributs */
@@ -1796,15 +1789,16 @@ yyreduce:
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1823 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1826 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 30: /* oaAttributeArrayDeclaration: kwattributeDeclaration  */
-#line 439 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 442 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes;
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
 		KWClass* kwcClass = kwcLoadCurrentClass;
+		ALString sMessage;
 
 		/* Creation d'un tableau */
 		oaAttributes = new ObjectArray;
@@ -1816,11 +1810,9 @@ yyreduce:
 		else if (kwcClass == NULL)
 			delete attribute;
 		/* Sinon, test de validite du nom de l'attribut */
-		else if (!kwcClass->CheckName(attribute->GetName(), kwcClass))
+		else if (!kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		{
-			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ": Incorrect variable name (" +
-						      attribute->GetName() + ")",
-						  -1);
+			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ", " + sMessage, -1);
 			delete attribute;
 		}
 		/* Test de non existence parmi les attributs */
@@ -1849,14 +1841,15 @@ yyreduce:
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1872 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1876 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 31: /* kwclassHeader: comments rootDeclaration CLASS IDENTIFIER keyFields metaData '{'  */
-#line 486 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 490 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass;
 		KWClass* kwcReferencedClass;
+		ALString sMessage;
 
 		/* Test d'existence de la classe */
 		kwcClass = kwcdLoadDomain->LookupClass(*((yyvsp[-3].sValue)));
@@ -1886,14 +1879,14 @@ yyreduce:
 		else
 		{
 			/* Test de nom de classe */
-			if (KWClass::CheckName(*((yyvsp[-3].sValue)), NULL))
+			if (KWClass::CheckNameWithMessage(*((yyvsp[-3].sValue)), KWClass::Class, sMessage))
 			{
 				kwcClass = new KWClass;
 				kwcClass->SetName(*((yyvsp[-3].sValue)));
 				kwcdLoadDomain->InsertClass(kwcClass);
 			}
 			else
-				yyerror("Incorrect dictionary name (" + *((yyvsp[-3].sValue)) + ")");
+				yyerror(sMessage);
 		}
 
 		/* Initialisation si necessaire de la classe */
@@ -1943,41 +1936,41 @@ yyreduce:
 		kwcLoadCurrentClass = kwcClass;
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1965 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1970 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 32: /* keyFields: '(' keyFieldList ')' comments  */
-#line 578 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 583 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore les comemntaires */
 		if ((yyvsp[0].sValue) != NULL)
 			delete (yyvsp[0].sValue);
 		(yyval.svValue) = (yyvsp[-2].svValue);
 	}
-#line 1976 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1981 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 33: /* keyFields: comments  */
-#line 585 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 590 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore les comemntaires */
 		if ((yyvsp[0].sValue) != NULL)
 			delete (yyvsp[0].sValue);
 		(yyval.svValue) = NULL; /* pas de champ cle */
 	}
-#line 1987 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1992 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 34: /* keyFields: %empty  */
-#line 592 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 597 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.svValue) = NULL; /* pas de champ cle */
 	}
-#line 1995 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2000 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 35: /* keyFieldList: keyFieldList ',' IDENTIFIER  */
-#line 599 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 604 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svKeyFields;
 
@@ -1987,11 +1980,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svKeyFields;
 	}
-#line 2009 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2014 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 36: /* keyFieldList: IDENTIFIER  */
-#line 609 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 614 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svKeyFields;
 
@@ -2001,11 +1994,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svKeyFields;
 	}
-#line 2023 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2028 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 37: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' STRINGLITTERAL '>'  */
-#line 622 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 627 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2025,11 +2018,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2047 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2052 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 38: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' CONTINUOUSLITTERAL '>'  */
-#line 642 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 647 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2051,11 +2044,11 @@ yyreduce:
 		delete (yyvsp[-3].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2073 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2078 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 39: /* metaData: metaData '<' SIMPLEIDENTIFIER '>'  */
-#line 664 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 669 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2074,11 +2067,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2096 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2101 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 40: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' IDENTIFIER '>'  */
-#line 683 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 688 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2095,19 +2088,19 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2116 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2121 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 41: /* metaData: %empty  */
-#line 699 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 704 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwmdMetaData) = NULL; /* pas de paires cle valeurs */
 	}
-#line 2124 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2129 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 42: /* kwattributeDeclaration: usedDeclaration typeDeclaration refIdentifier IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 715 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 720 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWAttribute* attribute;
 		KWDerivationRule* rule;
@@ -2163,7 +2156,7 @@ yyreduce:
 			if (kwcReferencedClass == NULL and (yyvsp[-5].sValue) != NULL)
 			{
 				/* Test de nom de classe */
-				if (KWClass::CheckName(*((yyvsp[-5].sValue)), NULL))
+				if (KWClass::CheckName(*((yyvsp[-5].sValue)), KWClass::Class, NULL))
 				{
 					kwcReferencedClass = new KWClass;
 					kwcReferencedClass->SetName(*((yyvsp[-5].sValue)));
@@ -2250,11 +2243,11 @@ yyreduce:
 
 		(yyval.kwaValue) = attribute;
 	}
-#line 2251 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2256 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 43: /* applicationids: applicationids APPLICATIONID  */
-#line 843 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 848 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ne garde que la premiere ligne de chaque identification d'application */
 		if ((yyvsp[-1].sValue) == NULL)
@@ -2265,19 +2258,19 @@ yyreduce:
 			(yyval.sValue) = (yyvsp[-1].sValue);
 		}
 	}
-#line 2266 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2271 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 44: /* applicationids: %empty  */
-#line 854 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 859 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL; /* pas d'identification d'application */
 	}
-#line 2274 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2279 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 45: /* comments: comments LABEL  */
-#line 862 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 867 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ne garde que la premiere ligne de chaque commentaire */
 		if ((yyvsp[-1].sValue) == NULL)
@@ -2288,180 +2281,180 @@ yyreduce:
 			(yyval.sValue) = (yyvsp[-1].sValue);
 		}
 	}
-#line 2289 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2294 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 46: /* comments: %empty  */
-#line 873 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 878 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL; /* pas de commentaire */
 	}
-#line 2297 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2302 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 47: /* rootDeclaration: ROOT  */
-#line 881 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 886 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = true;
 	}
-#line 2305 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2310 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 48: /* rootDeclaration: %empty  */
-#line 885 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 890 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = false; /* valeur par defaut */
 	}
-#line 2313 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2318 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 49: /* usedDeclaration: UNUSED  */
-#line 893 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 898 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = false;
 	}
-#line 2321 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2326 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 50: /* usedDeclaration: %empty  */
-#line 897 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 902 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = true; /* valeur par defaut */
 	}
-#line 2329 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2334 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 51: /* typeDeclaration: CONTINUOUSTYPE  */
-#line 905 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 910 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Continuous;
 	}
-#line 2337 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2342 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 52: /* typeDeclaration: SYMBOLTYPE  */
-#line 909 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 914 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Symbol;
 	}
-#line 2345 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2350 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 53: /* typeDeclaration: DATETYPE  */
-#line 913 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 918 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Date;
 	}
-#line 2353 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2358 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 54: /* typeDeclaration: TIMETYPE  */
-#line 917 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 922 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Time;
 	}
-#line 2361 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2366 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 55: /* typeDeclaration: TIMESTAMPTYPE  */
-#line 921 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 926 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Timestamp;
 	}
-#line 2369 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2374 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 56: /* typeDeclaration: TIMESTAMPTZTYPE  */
-#line 925 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 930 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::TimestampTZ;
 	}
-#line 2377 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2382 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 57: /* typeDeclaration: TEXTTYPE  */
-#line 929 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 934 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Text;
 	}
-#line 2385 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2390 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 58: /* typeDeclaration: TEXTLISTTYPE  */
-#line 933 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 938 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::TextList;
 	}
-#line 2393 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2398 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 59: /* typeDeclaration: OBJECTTYPE  */
-#line 937 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 942 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Object;
 	}
-#line 2401 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2406 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 60: /* typeDeclaration: OBJECTARRAYTYPE  */
-#line 941 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 946 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::ObjectArray;
 	}
-#line 2409 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2414 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 61: /* typeDeclaration: STRUCTURETYPE  */
-#line 945 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 950 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Structure;
 	}
-#line 2417 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2422 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 62: /* refIdentifier: '(' IDENTIFIER ')'  */
-#line 953 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 958 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[-1].sValue);
 	}
-#line 2425 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2430 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 63: /* refIdentifier: %empty  */
-#line 957 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 962 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL;
 	}
-#line 2433 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2438 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 64: /* usedDerivationRule: '=' derivationRule  */
-#line 964 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 969 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2441 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2446 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 65: /* usedDerivationRule: referenceRule  */
-#line 968 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 973 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2449 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2454 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 66: /* usedDerivationRule: '=' derivationRule ')'  */
-#line 972 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 977 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ')'");
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2458 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2463 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 67: /* usedDerivationRule: '(' IDENTIFIER ')'  */
-#line 977 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 982 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ALString sTmp;
 		yyerror(sTmp + "Invalid syntax (" + *(yyvsp[-1].sValue) + ")");
@@ -2469,27 +2462,27 @@ yyreduce:
 			delete (yyvsp[-1].sValue);
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2470 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2475 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 68: /* usedDerivationRule: %empty  */
-#line 985 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 990 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2478 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2483 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 69: /* referenceRule: referenceRuleBody ']'  */
-#line 991 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 996 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2486 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2491 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 70: /* referenceRuleBody: '[' derivationRuleOperand  */
-#line 997 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1002 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule;
 		KWDerivationRuleOperand* operand;
@@ -2509,11 +2502,11 @@ yyreduce:
 		/* On retourner la regle */
 		(yyval.kwdrValue) = rule;
 	}
-#line 2510 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2515 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 71: /* referenceRuleBody: referenceRuleBody ',' derivationRuleOperand  */
-#line 1017 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1022 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand;
@@ -2527,11 +2520,11 @@ yyreduce:
 		/* On retourner la regle */
 		(yyval.kwdrValue) = rule;
 	}
-#line 2528 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2533 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 72: /* derivationRule: derivationRuleBody closeparenthesis  */
-#line 1033 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1038 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* ruleBody = (yyvsp[-1].kwdrValue);
 		KWDerivationRule* rule;
@@ -2713,27 +2706,27 @@ yyreduce:
 
 		(yyval.kwdrValue) = rule;
 	}
-#line 2707 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2712 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 73: /* derivationRuleBody: derivationRuleBegin  */
-#line 1211 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1216 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2715 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2720 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 74: /* derivationRuleBody: derivationRuleHeader  */
-#line 1215 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1220 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2723 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2728 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 75: /* derivationRuleHeader: IDENTIFIER openparenthesis  */
-#line 1222 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1227 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule;
 
@@ -2743,11 +2736,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2737 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2742 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 76: /* derivationRuleBegin: derivationRuleHeader derivationRuleOperand  */
-#line 1235 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1240 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-1].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2758,11 +2751,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2752 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2757 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 77: /* derivationRuleBegin: derivationRuleBegin ',' derivationRuleOperand  */
-#line 1246 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1251 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2773,11 +2766,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2767 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2772 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 78: /* derivationRuleOperand: IDENTIFIER  */
-#line 1260 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1265 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2786,11 +2779,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2780 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2785 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 79: /* derivationRuleOperand: CONTINUOUSLITTERAL  */
-#line 1269 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1274 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2799,11 +2792,11 @@ yyreduce:
 		operand->SetContinuousConstant((yyvsp[0].cValue));
 		(yyval.kwdroValue) = operand;
 	}
-#line 2793 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2798 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 80: /* derivationRuleOperand: bigstring  */
-#line 1278 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1283 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2813,11 +2806,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2807 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2812 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 81: /* derivationRuleOperand: derivationRule  */
-#line 1288 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1293 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2827,22 +2820,22 @@ yyreduce:
 			operand->SetType(operand->GetDerivationRule()->GetType());
 		(yyval.kwdroValue) = operand;
 	}
-#line 2821 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2826 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 82: /* derivationRuleOperand: '.' derivationRuleOperand  */
-#line 1298 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1303 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = (yyvsp[0].kwdroValue);
 		operand->SetScopeLevel(operand->GetScopeLevel() + 1);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2832 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2837 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 83: /* bigstring: bigstring '+' STRINGLITTERAL  */
-#line 1309 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1314 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* Concatenation des deux chaines */
 		(yyval.sValue) = new ALString(*(yyvsp[-2].sValue) + *(yyvsp[0].sValue));
@@ -2851,59 +2844,59 @@ yyreduce:
 		delete (yyvsp[-2].sValue);
 		delete (yyvsp[0].sValue);
 	}
-#line 2845 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2850 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 84: /* bigstring: STRINGLITTERAL  */
-#line 1318 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1323 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 2853 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2858 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 86: /* semicolon: ';' ';'  */
-#line 1326 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1331 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous ';'");
 	}
-#line 2861 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2866 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 87: /* semicolon: ';' ';' ';'  */
-#line 1330 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1335 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ';'");
 	}
-#line 2869 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2874 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 88: /* semicolon: %empty  */
-#line 1334 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1339 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Missing ';'");
 	}
-#line 2877 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2882 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 90: /* openparenthesis: '(' '('  */
-#line 1342 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1347 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous '('");
 	}
-#line 2885 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2890 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 91: /* openparenthesis: '(' '(' '('  */
-#line 1346 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1351 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many '('");
 	}
-#line 2893 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2898 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 92: /* openparenthesis: %empty  */
-#line 1350 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1355 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* ERRORMGT */
 		/* Attention: supprimer cette instruction en cas d'evolution du parser */
@@ -2912,11 +2905,11 @@ yyreduce:
 		/* sa consoeur 3 shift/reduce conflicts et 12 reduce conflicts     */
 		yyerror("Missing '('");
 	}
-#line 2906 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2911 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 94: /* closeparenthesis: %empty  */
-#line 1364 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1369 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* ERRORMGT */
 		/* Attention: supprimer cette instruction en cas d'evolution du parser */
@@ -2925,10 +2918,10 @@ yyreduce:
 		/* sa consoeur 3 shift/reduce conflicts et 12 reduce conflicts     */
 		yyerror("Missing ')'");
 	}
-#line 2919 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2924 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-#line 2923 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2928 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 	default:
 		break;
@@ -3107,7 +3100,7 @@ yyreturnlab:
 	return yyresult;
 }
 
-#line 1375 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1380 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 #include "KWCLex.inc"
 

--- a/src/Learning/KWData/KWCYac.hpp
+++ b/src/Learning/KWData/KWCYac.hpp
@@ -1,7 +1,3 @@
-// Copyright (c) 2024 Orange. All rights reserved.
-// This software is distributed under the BSD 3-Clause-clear License, the text of which is available
-// at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
-
 /* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
@@ -39,8 +35,8 @@
    especially those whose name start with YY_ or yy_.  They are
    private implementation details that can be changed or removed.  */
 
-#ifndef YY_YY_D_USERS_MIIB6422_DOCUMENTS_BOULLEMA_DEVGIT_KHIOPS_SRC_LEARNING_KWDATA_KWCYAC_HPP_INCLUDED
-#define YY_YY_D_USERS_MIIB6422_DOCUMENTS_BOULLEMA_DEVGIT_KHIOPS_SRC_LEARNING_KWDATA_KWCYAC_HPP_INCLUDED
+#ifndef YY_YY_C_APPLICATIONS_BOULLEMA_DEVGIT_KHIOPS_SRC_LEARNING_KWDATA_KWCYAC_HPP_INCLUDED
+#define YY_YY_C_APPLICATIONS_BOULLEMA_DEVGIT_KHIOPS_SRC_LEARNING_KWDATA_KWCYAC_HPP_INCLUDED
 /* Debug traces.  */
 #ifndef YYDEBUG
 #define YYDEBUG 0
@@ -86,7 +82,7 @@ typedef enum yytokentype yytoken_kind_t;
 #if !defined YYSTYPE && !defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 57 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 57 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 	Continuous cValue;
 	ALString* sValue;
@@ -100,7 +96,7 @@ union YYSTYPE
 	KWMetaData* kwmdMetaData;
 	int nValue;
 
-#line 100 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.hpp"
+#line 100 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.hpp"
 };
 typedef union YYSTYPE YYSTYPE;
 #define YYSTYPE_IS_TRIVIAL 1
@@ -111,4 +107,4 @@ extern YYSTYPE yylval;
 
 int yyparse(void);
 
-#endif /* !YY_YY_D_USERS_MIIB6422_DOCUMENTS_BOULLEMA_DEVGIT_KHIOPS_SRC_LEARNING_KWDATA_KWCYAC_HPP_INCLUDED  */
+#endif /* !YY_YY_C_APPLICATIONS_BOULLEMA_DEVGIT_KHIOPS_SRC_LEARNING_KWDATA_KWCYAC_HPP_INCLUDED  */

--- a/src/Learning/KWData/KWCYac.hpp
+++ b/src/Learning/KWData/KWCYac.hpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2024 Orange. All rights reserved.
+// This software is distributed under the BSD 3-Clause-clear License, the text of which is available
+// at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
+
 /* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C

--- a/src/Learning/KWData/KWCYac.yac
+++ b/src/Learning/KWData/KWCYac.yac
@@ -246,6 +246,7 @@ kwclassBegin: kwclassHeader comments
         {
 		  KWClass* kwcClass=$1;
 		  KWAttribute* attribute=$2;
+		  ALString sMessage;
 		  assert(kwcLoadCurrentClass == $1);
 
 		  /* Si attribut non valide: on ne fait rien */
@@ -255,10 +256,10 @@ kwclassBegin: kwclassHeader comments
 		  else if (kwcClass == NULL)
 		    delete attribute;
 	      /* Sinon, test de validite du nom de l'attribut */
-		  else if (! kwcClass->CheckName(attribute->GetName(), kwcClass))
+		  else if (! kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
-			": Incorrect variable name", -1);
+			", " + sMessage, -1);
 			delete attribute;
 		  }
 		  /* Test de non existence parmi les attributs */
@@ -292,6 +293,7 @@ kwclassBegin: kwclassHeader comments
 		  KWAttribute* firstAttribute;
 		  KWAttribute* lastAttribute;
 		  KWDerivationRule* rule = $7;
+		  ALString sMessage;
 		  assert(kwcLoadCurrentClass == $1);
 		  check(oaAttributes);
 
@@ -307,10 +309,10 @@ kwclassBegin: kwclassHeader comments
 		  if (oaAttributes->GetSize() > 0)
 		  {
 	        /* Test de validite du nom de l'attribut */
-		    if (! kwcClass->CheckName(sBlockName, kwcClass))
+		    if (! kwcClass->CheckNameWithMessage(sBlockName, KWClass::AttributeBlock, sMessage))
 		    {
 		      yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
-			  ": Incorrect sparse variable block name (" + sBlockName + ")", -1);
+			  ", " + sMessage, -1);
   		    }
 			/* Test de non existence parmi les attributs */
 		    else if (kwcClass->LookupAttribute(sBlockName) != NULL)
@@ -397,6 +399,7 @@ oaAttributeArrayDeclaration :
 		  ObjectArray* oaAttributes = $1;
 		  KWAttribute* attribute=$2;
 		  KWClass* kwcClass=kwcLoadCurrentClass;
+		  ALString sMessage;
 		  check(oaAttributes);
 
 		  /* Si attribut non valide: on ne fait rien */
@@ -406,10 +409,10 @@ oaAttributeArrayDeclaration :
 		  else if (kwcClass == NULL)
 		    delete attribute;
 	      /* Sinon, test de validite du nom de l'attribut */
-		  else if (! kwcClass->CheckName(attribute->GetName(), kwcClass))
+		  else if (! kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
-			": Incorrect variable name (" + attribute->GetName() + ")", -1);
+			", " + sMessage, -1);
 			delete attribute;
 		  }
 		  /* Test de non existence parmi les attributs */
@@ -440,6 +443,7 @@ oaAttributeArrayDeclaration :
 		  ObjectArray* oaAttributes;
 		  KWAttribute* attribute=$1;
 		  KWClass* kwcClass=kwcLoadCurrentClass;
+		  ALString sMessage;
 
 		  /* Creation d'un tableau */
 		  oaAttributes = new ObjectArray;
@@ -451,10 +455,10 @@ oaAttributeArrayDeclaration :
 		  else if (kwcClass == NULL)
 		    delete attribute;
 	      /* Sinon, test de validite du nom de l'attribut */
-		  else if (! kwcClass->CheckName(attribute->GetName(), kwcClass))
+		  else if (! kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
-			": Incorrect variable name (" + attribute->GetName() + ")", -1);
+			", " + sMessage, -1);
 			delete attribute;
 		  }
 		  /* Test de non existence parmi les attributs */
@@ -486,6 +490,7 @@ kwclassHeader: comments rootDeclaration CLASS IDENTIFIER keyFields metaData '{'
 	   {
           KWClass *kwcClass;
 		  KWClass* kwcReferencedClass;
+		  ALString sMessage;
 
           /* Test d'existence de la classe */
           kwcClass = kwcdLoadDomain->LookupClass(*($4));
@@ -515,14 +520,14 @@ kwclassHeader: comments rootDeclaration CLASS IDENTIFIER keyFields metaData '{'
           else
           {
 		    /* Test de nom de classe */
-		    if (KWClass::CheckName(*($4), NULL))
+		    if (KWClass::CheckNameWithMessage(*($4), KWClass::Class, sMessage))
 		    {
               kwcClass = new KWClass;
               kwcClass->SetName(*($4));
               kwcdLoadDomain->InsertClass(kwcClass);
 		    }
 		    else
-		      yyerror("Incorrect dictionary name (" + *($4) + ")");
+		      yyerror(sMessage);
           }
 
 		  /* Initialisation si necessaire de la classe */
@@ -760,7 +765,7 @@ kwattributeDeclaration:
             if (kwcReferencedClass == NULL and $3 != NULL)
 		    {
 		      /* Test de nom de classe */
-		      if (KWClass::CheckName(*($3), NULL))
+		      if (KWClass::CheckName(*($3), KWClass::Class, NULL))
 		      {
                 kwcReferencedClass = new KWClass;
                 kwcReferencedClass->SetName(*($3));

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -393,14 +393,30 @@ public:
 	// Taille limite des noms de variables
 	static int GetNameMaxLength();
 
+	// Liste des entites disponibles, pour parametrer des messages d'erreur
+	enum
+	{
+		Class,          // Dictionnaire
+		ClassDomain,    // Domaine de dictionnaire
+		Attribute,      // Variable
+		AttributeBlock, // Block de variable sparse
+		Rule,           // Regle de derivation
+		Structure,      // Structure, pour une regle de derivation
+		None,           // Rien de precise
+		Unknown         // Entite inconnue (non valide)
+	};
+
+	// Conversion d'une famille d'entite vers une chaine
+	static const ALString EntityToString(int nEntity);
+
 	// Controles de validite avec emission de message d'erreur
 	// par la classe passee en parametre (pas de message si NULL)
-	static boolean CheckName(const ALString& sValue, const Object* errorSender);
-	static boolean CheckLabel(const ALString& sValue, const Object* errorSender);
+	static boolean CheckName(const ALString& sValue, int nEntity, const Object* errorSender);
+	static boolean CheckLabel(const ALString& sValue, int nEntity, const Object* errorSender);
 
 	// Methode similaire avec message est alimente avec la cause de l'erreur
-	static boolean CheckNameWithMessage(const ALString& sValue, ALString& sMessage);
-	static boolean CheckLabelWithMessage(const ALString& sValue, ALString& sMessage);
+	static boolean CheckNameWithMessage(const ALString& sValue, int nEntity, ALString& sMessage);
+	static boolean CheckLabelWithMessage(const ALString& sValue, int nEntity, ALString& sMessage);
 
 	// Extraction d'une sous-chaine valide pour le format utf8
 	static ALString BuildUTF8SubString(const ALString sValue);
@@ -654,7 +670,7 @@ inline const ALString& KWClass::GetLabel() const
 
 inline void KWClass::SetLabel(const ALString& sValue)
 {
-	require(CheckLabel(sValue, this));
+	require(CheckLabel(sValue, KWClass::Class, this));
 	usLabel.SetValue(sValue);
 }
 

--- a/src/Learning/KWData/KWClassDomain.cpp
+++ b/src/Learning/KWData/KWClassDomain.cpp
@@ -273,7 +273,7 @@ void KWClassDomain::RenameClass(KWClass* refClass, const ALString& sNewName)
 	require(refClass != NULL);
 	require(refClass == cast(KWClass*, odClasses.Lookup(refClass->GetName())));
 	require(refClass->domain == this);
-	require(refClass->CheckName(sNewName, refClass));
+	require(refClass->CheckName(sNewName, KWClass::Class, refClass));
 	require(LookupClass(sNewName) == NULL);
 
 	// Renommage par manipulation dans le dictionnaire

--- a/src/Learning/KWData/KWDataTableDriverTextFile.cpp
+++ b/src/Learning/KWData/KWDataTableDriverTextFile.cpp
@@ -146,7 +146,7 @@ boolean KWDataTableDriverTextFile::BuildDataTableClass(KWClass* kwcDataTableClas
 					break;
 			}
 			// Test de validite du nom de l'attribut
-			else if (not KWClass::CheckName(sAttributeName, this))
+			else if (not KWClass::CheckName(sAttributeName, KWClass::Attribute, this))
 			{
 				bOk = false;
 				AddError(sTmp + "The header line field " + IntToString(nField) + " is not valid");
@@ -1386,7 +1386,7 @@ boolean KWDataTableDriverTextFile::CheckFormat() const
 		{
 			bOk = false;
 			AddError(sTmp + "Field separator '" + CharToString(cFieldSeparator) +
-				 "' must not be end of line");
+				 "' must not be end-of-line");
 		}
 		else if (cFieldSeparator == '\0')
 		{

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -274,7 +274,7 @@ KWClass* KWDatabase::ComputeClass()
 	require(not IsOpenedForRead());
 	require(not IsOpenedForWrite());
 	require(kwcClass == NULL);
-	require(KWClass::CheckName(GetClassName(), this));
+	require(KWClass::CheckName(GetClassName(), KWClass::Class, this));
 	require(KWClassDomain::GetCurrentDomain()->LookupClass(GetClassName()) == NULL);
 
 	// Debut de suivi de tache

--- a/src/Learning/KWData/KWDatabaseFormatDetector.cpp
+++ b/src/Learning/KWData/KWDatabaseFormatDetector.cpp
@@ -1021,7 +1021,8 @@ boolean KWDatabaseFormatDetector::DetectFileFormatWithoutClass(RewindableInputBu
 		{
 			for (i = 0; i < headerLineAnaliser.GetSize(); i++)
 			{
-				bIsHeaderLine = KWClass::CheckName(headerLineAnaliser.GetAt(i), NULL);
+				bIsHeaderLine =
+				    KWClass::CheckName(headerLineAnaliser.GetAt(i), KWClass::Attribute, NULL);
 				if (not bIsHeaderLine)
 					break;
 			}

--- a/src/Learning/KWData/KWDerivationRule.cpp
+++ b/src/Learning/KWData/KWDerivationRule.cpp
@@ -406,21 +406,21 @@ boolean KWDerivationRule::CheckRuleDefinition() const
 	ALString sTmp;
 
 	// Nom de la regle
-	if (not KWClass::CheckName(GetName(), this))
+	if (not KWClass::CheckName(GetName(), KWClass::Rule, this))
 	{
 		AddError("Incorrect name");
 		bResult = false;
 	}
 
 	// Libelle
-	if (not KWClass::CheckLabel(GetLabel(), this))
+	if (not KWClass::CheckLabel(GetLabel(), KWClass::Rule, this))
 	{
 		AddError("Incorrect label");
 		bResult = false;
 	}
 
 	// Nom de classe si renseigne
-	if (GetClassName() != "" and not KWClass::CheckName(GetName(), this))
+	if (GetClassName() != "" and not KWClass::CheckName(GetName(), KWClass::Class, this))
 	{
 		AddError("Incorrect dictionary name");
 		bResult = false;
@@ -435,7 +435,7 @@ boolean KWDerivationRule::CheckRuleDefinition() const
 
 	// Nom de la classe pour un type Object ou ObjectArray si renseigne
 	if (KWType::IsGeneralRelation(GetType()) and GetObjectClassName() != "" and
-	    not KWClass::CheckName(GetObjectClassName(), this))
+	    not KWClass::CheckName(GetObjectClassName(), KWClass::Class, this))
 	{
 		AddError("Incorrect dictionary name for " + KWType::ToString(GetType()) + " type");
 		bResult = false;
@@ -449,7 +449,7 @@ boolean KWDerivationRule::CheckRuleDefinition() const
 			AddError("Missing structure name for Structure type");
 			bResult = false;
 		}
-		else if (not KWClass::CheckName(GetStructureName(), this))
+		else if (not KWClass::CheckName(GetStructureName(), KWClass::Structure, this))
 		{
 			AddError("Incorrect structure name for Structure type");
 			bResult = false;
@@ -2170,7 +2170,7 @@ void KWDerivationRule::RegisterDerivationRule(KWDerivationRule* kwdrRule)
 {
 	require(kwdrRule != NULL);
 	require(kwdrRule->GetName() != "");
-	require(KWClass::CheckName(kwdrRule->GetName(), kwdrRule));
+	require(KWClass::CheckName(kwdrRule->GetName(), KWClass::Rule, kwdrRule));
 	require(odDerivationRules == NULL or odDerivationRules->Lookup(kwdrRule->GetName()) == NULL);
 
 	// Creation si necessaire du dictionnaire de regles

--- a/src/Learning/KWData/KWDerivationRule.h
+++ b/src/Learning/KWData/KWDerivationRule.h
@@ -881,7 +881,7 @@ protected:
 
 inline void KWDerivationRule::SetName(const ALString& sValue)
 {
-	require(KWClass::CheckName(sValue, this));
+	require(KWClass::CheckName(sValue, KWClass::Rule, this));
 	usName.SetValue(sValue);
 	nFreshness++;
 }
@@ -893,7 +893,7 @@ inline const ALString& KWDerivationRule::GetName() const
 
 inline void KWDerivationRule::SetLabel(const ALString& sValue)
 {
-	require(KWClass::CheckLabel(sValue, this));
+	require(KWClass::CheckLabel(sValue, KWClass::Rule, this));
 	usLabel.SetValue(sValue);
 }
 
@@ -904,7 +904,7 @@ inline const ALString& KWDerivationRule::GetLabel() const
 
 inline void KWDerivationRule::SetClassName(const ALString& sValue)
 {
-	require(sValue == "" or KWClass::CheckName(sValue, this));
+	require(sValue == "" or KWClass::CheckName(sValue, KWClass::Class, this));
 	usClassName.SetValue(sValue);
 	nFreshness++;
 }
@@ -936,7 +936,7 @@ inline const ALString& KWDerivationRule::GetObjectClassName() const
 inline void KWDerivationRule::SetObjectClassName(const ALString& sValue)
 {
 	require(KWType::IsGeneralRelation(GetType()));
-	require(sValue == "" or KWClass::CheckName(sValue, this));
+	require(sValue == "" or KWClass::CheckName(sValue, KWClass::Class, this));
 	usSupplementTypeName.SetValue(sValue);
 	nFreshness++;
 }
@@ -956,7 +956,7 @@ inline const ALString& KWDerivationRule::GetStructureName() const
 inline void KWDerivationRule::SetStructureName(const ALString& sValue)
 {
 	require(GetType() == KWType::Structure);
-	require(sValue == "" or KWClass::CheckName(sValue, this));
+	require(sValue == "" or KWClass::CheckName(sValue, KWClass::Structure, this));
 	usSupplementTypeName.SetValue(sValue);
 	nFreshness++;
 }
@@ -1125,7 +1125,7 @@ inline const ALString& KWDerivationRuleOperand::GetObjectClassName() const
 inline void KWDerivationRuleOperand::SetObjectClassName(const ALString& sValue)
 {
 	require(KWType::IsGeneralRelation(GetType()));
-	require(sValue == "" or KWClass::CheckName(sValue, this));
+	require(sValue == "" or KWClass::CheckName(sValue, KWClass::Class, this));
 	usSupplementTypeName.SetValue(sValue);
 	debug(nFreshness++;)
 }
@@ -1139,7 +1139,7 @@ inline const ALString& KWDerivationRuleOperand::GetStructureName() const
 inline void KWDerivationRuleOperand::SetStructureName(const ALString& sValue)
 {
 	require(GetType() == KWType::Structure);
-	require(sValue == "" or KWClass::CheckName(sValue, this));
+	require(sValue == "" or KWClass::CheckName(sValue, KWClass::Structure, this));
 	usSupplementTypeName.SetValue(sValue);
 	debug(nFreshness++;)
 }
@@ -1228,7 +1228,7 @@ inline const ALString KWDerivationRuleOperand::GetStringConstant() const
 
 inline void KWDerivationRuleOperand::SetAttributeName(const ALString& sName)
 {
-	require(sName == "" or KWClass::CheckName(sName, this));
+	require(sName == "" or KWClass::CheckName(sName, KWClass::Attribute, this));
 	usDataItemName.SetValue(sName);
 	debug(nFreshness++;)
 }
@@ -1241,7 +1241,7 @@ inline const ALString& KWDerivationRuleOperand::GetAttributeName() const
 
 inline void KWDerivationRuleOperand::SetAttributeBlockName(const ALString& sName)
 {
-	require(sName == "" or KWClass::CheckName(sName, this));
+	require(sName == "" or KWClass::CheckName(sName, KWClass::AttributeBlock, this));
 	usDataItemName.SetValue(sName);
 	debug(nFreshness++;)
 }
@@ -1254,7 +1254,7 @@ inline const ALString& KWDerivationRuleOperand::GetAttributeBlockName() const
 
 inline void KWDerivationRuleOperand::SetDataItemName(const ALString& sName)
 {
-	require(sName == "" or KWClass::CheckName(sName, this));
+	require(sName == "" or KWClass::CheckName(sName, KWClass::Attribute, this));
 	usDataItemName.SetValue(sName);
 	debug(nFreshness++;)
 }

--- a/src/Learning/KWData/KWDerivationRuleOperand.cpp
+++ b/src/Learning/KWData/KWDerivationRuleOperand.cpp
@@ -106,7 +106,7 @@ boolean KWDerivationRuleOperand::CheckDefinition() const
 
 	// Nom de la classe pour un type Object ou ObjectArray si renseigne
 	if (KWType::IsGeneralRelation(GetType()) and GetObjectClassName() != "" and
-	    not KWClass::CheckName(GetObjectClassName(), this))
+	    not KWClass::CheckName(GetObjectClassName(), KWClass::Class, this))
 	{
 		AddError("Incorrect dictionary name for " + KWType::ToString(GetType()) + " type");
 		bResult = false;
@@ -120,7 +120,7 @@ boolean KWDerivationRuleOperand::CheckDefinition() const
 			AddError("Missing structure name for Structure type");
 			bResult = false;
 		}
-		else if (not KWClass::CheckName(GetStructureName(), this))
+		else if (not KWClass::CheckName(GetStructureName(), KWClass::Structure, this))
 		{
 			AddError("Incorrect structure name for Structure type");
 			bResult = false;
@@ -166,7 +166,7 @@ boolean KWDerivationRuleOperand::CheckDefinition() const
 
 	// Verification eventuelle de l'attribut
 	if (GetOrigin() == OriginAttribute and GetDataItemName() != "" and
-	    not KWClass::CheckName(GetDataItemName(), this))
+	    not KWClass::CheckName(GetDataItemName(), KWClass::Attribute, this))
 	{
 		AddError(GetDataItemLabel() + " name is not correct in the operand");
 		bResult = false;

--- a/src/Learning/KWData/KWMTDatabase.h
+++ b/src/Learning/KWData/KWMTDatabase.h
@@ -164,7 +164,7 @@ protected:
 	// ulterieurement Les mappings crees recursivement sont memorises dans un tableau
 	KWMTDatabaseMapping* CreateMapping(ObjectDictionary* odReferenceClasses, ObjectArray* oaRankedReferenceClasses,
 					   KWClass* mappedClass, boolean bIsExternalTable,
-					   const ALString& sDataPathClassName, const ALString& sDataPathAttributeNames,
+					   const ALString& sOriginClassName, StringVector* svAttributeNames,
 					   ObjectArray* oaCreatedMappings);
 
 	/////////////////////////////////////////////////////////////////////////////////

--- a/src/Learning/KWData/KWMTDatabase.h
+++ b/src/Learning/KWData/KWMTDatabase.h
@@ -163,8 +163,9 @@ protected:
 	// Les classes referencees sont memorisees dans un dictionnaire, pour gerer les mappings externes a creer
 	// ulterieurement Les mappings crees recursivement sont memorises dans un tableau
 	KWMTDatabaseMapping* CreateMapping(ObjectDictionary* odReferenceClasses, ObjectArray* oaRankedReferenceClasses,
-					   KWClass* mappedClass, const ALString& sDataPathClassName,
-					   const ALString& sDataPathAttributeNames, ObjectArray* oaCreatedMappings);
+					   KWClass* mappedClass, boolean bIsExternalTable,
+					   const ALString& sDataPathClassName, const ALString& sDataPathAttributeNames,
+					   ObjectArray* oaCreatedMappings);
 
 	/////////////////////////////////////////////////////////////////////////////////
 	// Gestion des objets natifs references

--- a/src/Learning/KWData/KWMTDatabaseMapping.h
+++ b/src/Learning/KWData/KWMTDatabaseMapping.h
@@ -33,6 +33,13 @@ public:
 	ALString GetDataPath() const;
 
 	// Data root
+	ALString GetDataRoot() const;
+
+	// ExternalTable
+	boolean GetExternalTable() const;
+	void SetExternalTable(boolean bValue);
+
+	// Data path origin dictionary
 	const ALString& GetDataPathClassName() const;
 	void SetDataPathClassName(const ALString& sValue);
 
@@ -51,6 +58,9 @@ public:
 	////////////////////////////////////////////////////////
 	// Divers
 
+	// Separateur utilise dans les data paths
+	static char GetDataPathSeparator();
+
 	// Ecriture
 	void Write(ostream& ost) const override;
 
@@ -59,15 +69,23 @@ public:
 	const ALString GetObjectLabel() const override;
 
 	////////////////////////////////////////////////////////////
-	// Decomposition du DataPath (en DataPathClassName et DataPathAttributeNames)
-	// Un DataPath est constitue d'un nom de classe principale, optionnellement
-	// suivi d'une liste de nom d'attribut separee par des caracteres backquotes
-	// (caractere interdit dans les identifiant de nom de classe et d'attribut)
+	// Decomposition du DataPath
+	//
+	// Dans un schema multi-table, chaque data path fait reference a une variable de type Table ou Entity
+	//  et identifie un fichier de table de donnees.
+	// La table principale a un data path vide.
+	// Dans un schema en etoile,
+	//  les data paths sont les noms de  variable de type Table ou Entity de chaque table secondaire.
+	// Dans un schéma en flocon,
+	//   les data paths  consistent en une liste de noms de variables avec un separateur "/".
+	// Pour les tables externes,
+	//   les data paths commencent par un DataRoot prefixe par "/", qui fait reference a un nom de dictionnaire Root
 	// Exemples de DataPath pour differents types de mapping:
-	//    classe principale: Customer
-	//    sous-objet: Customer.Address
-	//    tableau de sous-objets: Customer.Log
-	//    Sous-objet de second niveau: Customer.Address.City
+	//    classe principale:
+	//    sous-objet: Address
+	//    tableau de sous-objets: Logs
+	//    Sous-objet de second niveau: Address/City
+	//    table externe: /City
 
 	// Attributs du DataPath
 	int GetDataPathAttributeNumber() const;
@@ -93,6 +111,7 @@ protected:
 	friend class PLShared_MTDatabaseTextFile;
 
 	// Attributs de la classe
+	boolean bExternalTable;
 	ALString sDataPathClassName;
 	ALString sDataPathAttributeNames;
 	ALString sClassName;
@@ -149,6 +168,16 @@ protected:
 ////////////////////////////////////////////////////////////
 // Implementations inline
 
+inline boolean KWMTDatabaseMapping::GetExternalTable() const
+{
+	return bExternalTable;
+}
+
+inline void KWMTDatabaseMapping::SetExternalTable(boolean bValue)
+{
+	bExternalTable = bValue;
+}
+
 inline const ALString& KWMTDatabaseMapping::GetDataPathClassName() const
 {
 	return sDataPathClassName;
@@ -187,6 +216,11 @@ inline const ALString& KWMTDatabaseMapping::GetDataTableName() const
 inline void KWMTDatabaseMapping::SetDataTableName(const ALString& sValue)
 {
 	sDataTableName = sValue;
+}
+
+inline char KWMTDatabaseMapping::GetDataPathSeparator()
+{
+	return '/';
 }
 
 inline ObjectArray* KWMTDatabaseMapping::GetComponentTableMappings()

--- a/src/Learning/KWDataPreparation/KWAttributePairsSpec.cpp
+++ b/src/Learning/KWDataPreparation/KWAttributePairsSpec.cpp
@@ -141,7 +141,8 @@ void KWAttributePairsSpec::ImportAttributePairs(const ALString& sFileName)
 				else if (nFieldLength > KWClass::GetNameMaxLength())
 					AddWarning("Name too long, ignored record");
 				// Warning si nom d'attribut present et invalide
-				else if (sField[0] != '\0' and not KWClass::CheckNameWithMessage(sField, sMessage))
+				else if (sField[0] != '\0' and
+					 not KWClass::CheckNameWithMessage(sField, KWClass::Attribute, sMessage))
 					AddWarning(sMessage + ", ignored record");
 				// OK: on memorise le premier attribut de la paire
 				else
@@ -185,8 +186,8 @@ void KWAttributePairsSpec::ImportAttributePairs(const ALString& sFileName)
 					else if (nFieldLength > KWClass::GetNameMaxLength())
 						AddWarning("Name too long, ignored record");
 					// Warning si nom d'attribut present et invalide
-					else if (sField[0] != '\0' and
-						 not KWClass::CheckNameWithMessage(sField, sMessage))
+					else if (sField[0] != '\0' and not KWClass::CheckNameWithMessage(
+									   sField, KWClass::Attribute, sMessage))
 						AddWarning(sMessage + ", ignored record");
 					// OK: on memorise le second attribut de la paire
 					else
@@ -322,7 +323,8 @@ void KWAttributePairsSpec::ExportAllAttributePairs(const ALString& sFileName)
 			// Warning si le nom du premier attribut est present et invalide
 			nContextAttributeIndex = 1;
 			if (bPairOk and attributePairName->GetFirstName() != "" and
-			    not KWClass::CheckNameWithMessage(attributePairName->GetFirstName(), sMessage))
+			    not KWClass::CheckNameWithMessage(attributePairName->GetFirstName(), KWClass::Attribute,
+							      sMessage))
 			{
 				AddWarning(sMessage + ", ignored pair");
 				bPairOk = false;
@@ -330,7 +332,8 @@ void KWAttributePairsSpec::ExportAllAttributePairs(const ALString& sFileName)
 			// Warning si le nom du second attribut est present et invalide
 			nContextAttributeIndex = 2;
 			if (bPairOk and attributePairName->GetSecondName() != "" and
-			    not KWClass::CheckNameWithMessage(attributePairName->GetSecondName(), sMessage))
+			    not KWClass::CheckNameWithMessage(attributePairName->GetSecondName(), KWClass::Attribute,
+							      sMessage))
 			{
 				AddWarning(sMessage + ", ignored pair");
 				bPairOk = false;
@@ -406,9 +409,10 @@ void KWAttributePairsSpec::DeleteDuplicateAttributePairs()
 		// Verification de la validite de la paire, sans warning
 		bPairOk = true;
 		bPairOk = bPairOk and (attributePairName->GetFirstName() == "" or
-				       KWClass::CheckName(attributePairName->GetFirstName(), NULL));
-		bPairOk = bPairOk and (attributePairName->GetSecondName() == "" or
-				       KWClass::CheckName(attributePairName->GetSecondName(), NULL));
+				       KWClass::CheckName(attributePairName->GetFirstName(), KWClass::Attribute, NULL));
+		bPairOk =
+		    bPairOk and (attributePairName->GetSecondName() == "" or
+				 KWClass::CheckName(attributePairName->GetSecondName(), KWClass::Attribute, NULL));
 		bPairOk = bPairOk and attributePairName->GetFirstName() != attributePairName->GetSecondName();
 		bPairOk = bPairOk and slSpecificPairs.Find(attributePairName) == NULL;
 

--- a/src/Learning/KWDataPreparation/KWDataGridStats.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridStats.cpp
@@ -1699,7 +1699,7 @@ boolean KWDataGridStats::ImportVariableNames(const ALString& sValue)
 					bOk = (odVariableNames.Lookup(sVariableName) == NULL);
 				if (bOk)
 				{
-					assert(KWClass::CheckName(sVariableName, NULL));
+					assert(KWClass::CheckName(sVariableName, KWClass::Attribute, NULL));
 					svVariableNames.Add(sVariableName);
 					odVariableNames.SetAt(sVariableName, &odVariableNames);
 				}

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
@@ -1335,8 +1335,8 @@ void PLShared_MTDatabaseTextFile::SerializeObject(PLSerializer* serializer, cons
 
 		// Serialisation des informations de mapping
 		serializer->PutBoolean(mapping->GetExternalTable());
-		serializer->PutString(mapping->GetDataPathClassName());
-		serializer->PutString(mapping->GetDataPathAttributeNames());
+		serializer->PutString(mapping->GetOriginClassName());
+		serializer->PutStringVector(mapping->GetAttributeNames());
 		serializer->PutString(mapping->GetDataTableName());
 	}
 
@@ -1428,8 +1428,8 @@ void PLShared_MTDatabaseTextFile::DeserializeObject(PLSerializer* serializer, Ob
 
 		// Deserialisation du mapping
 		mapping->SetExternalTable(serializer->GetBoolean());
-		mapping->SetDataPathClassName(serializer->GetString());
-		mapping->SetDataPathAttributeNames(serializer->GetString());
+		mapping->SetOriginClassName(serializer->GetString());
+		serializer->GetStringVector(&mapping->svAttributeNames);
 		mapping->SetDataTableName(serializer->GetString());
 	}
 

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
@@ -149,7 +149,7 @@ boolean PLMTDatabaseTextFile::ComputeOpenInformation(boolean bRead, boolean bInc
 		// Memorisation du mapping si driver utilise
 		if (driver != NULL)
 		{
-			assert(mapping->GetDataPath() != "");
+			assert(mapping->GetClassName() != "");
 			ivUsedMappingFlags.SetAt(i, 1);
 		}
 
@@ -1263,8 +1263,8 @@ int PLMTDatabaseTextFile::ComputeMainLocalTableNumber()
 	for (nTable = 0; nTable < GetMainTableNumber(); nTable++)
 	{
 		mapping = cast(KWMTDatabaseMapping*, GetMultiTableMappings()->GetAt(nTable));
-		if (mapping != NULL and mapping->GetDataPath() != "" and
-		    FileService::IsLocalURI(mapping->GetDataPath()))
+		if (mapping != NULL and mapping->GetClassName() != "" and
+		    FileService::IsLocalURI(mapping->GetDataTableName()))
 			nNumber++;
 	}
 	return nNumber;
@@ -1334,6 +1334,7 @@ void PLShared_MTDatabaseTextFile::SerializeObject(PLSerializer* serializer, cons
 		mapping = cast(KWMTDatabaseMapping*, database->GetMultiTableMappings()->GetAt(i));
 
 		// Serialisation des informations de mapping
+		serializer->PutBoolean(mapping->GetExternalTable());
 		serializer->PutString(mapping->GetDataPathClassName());
 		serializer->PutString(mapping->GetDataPathAttributeNames());
 		serializer->PutString(mapping->GetDataTableName());
@@ -1426,6 +1427,7 @@ void PLShared_MTDatabaseTextFile::DeserializeObject(PLSerializer* serializer, Ob
 		}
 
 		// Deserialisation du mapping
+		mapping->SetExternalTable(serializer->GetBoolean());
 		mapping->SetDataPathClassName(serializer->GetString());
 		mapping->SetDataPathAttributeNames(serializer->GetString());
 		mapping->SetDataTableName(serializer->GetString());

--- a/src/Learning/KWLearningProblem/KWLearningProblemView.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblemView.cpp
@@ -204,9 +204,7 @@ void KWLearningProblemView::CheckData()
 {
 	// OK si nom du fichier renseigne et classe correcte
 	if (FileService::CreateApplicationTmpDir() and GetLearningProblem()->CheckTrainDatabaseName() and
-	    GetLearningProblem()->GetTrainDatabase()->CheckSelectionValue(
-		GetLearningProblem()->GetTrainDatabase()->GetSelectionValue()) and
-	    GetLearningProblem()->CheckClass())
+	    GetLearningProblem()->GetTrainDatabase()->Check() and GetLearningProblem()->CheckClass())
 	{
 		GetLearningProblem()->CheckData();
 		AddSimpleMessage("");
@@ -252,11 +250,8 @@ void KWLearningProblemView::BuildConstructedDictionary()
 {
 	// OK si prerequis corrects
 	if (FileService::CreateApplicationTmpDir() and GetLearningProblem()->CheckTrainDatabaseName() and
-	    GetLearningProblem()->GetTrainDatabase()->Check() and
-	    GetLearningProblem()->GetTrainDatabase()->CheckSelectionValue(
-		GetLearningProblem()->GetTrainDatabase()->GetSelectionValue()) and
-	    GetLearningProblem()->CheckClass() and GetLearningProblem()->CheckTargetAttribute() and
-	    GetLearningProblem()->CheckResultFileNames())
+	    GetLearningProblem()->GetTrainDatabase()->Check() and GetLearningProblem()->CheckClass() and
+	    GetLearningProblem()->CheckTargetAttribute() and GetLearningProblem()->CheckResultFileNames())
 	{
 		// Verification supplementaire
 		if (GetLearningProblem()
@@ -288,10 +283,8 @@ void KWLearningProblemView::ComputeStats()
 	// OK si prerequis corrects
 	if (bOk and FileService::CreateApplicationTmpDir() and GetLearningProblem()->CheckTrainDatabaseName() and
 	    GetLearningProblem()->GetTrainDatabase()->Check() and
-	    GetLearningProblem()->GetTrainDatabase()->CheckSelectionValue(
-		GetLearningProblem()->GetTrainDatabase()->GetSelectionValue()) and
-	    GetLearningProblem()->GetTestDatabase()->CheckSelectionValue(
-		GetLearningProblem()->GetTestDatabase()->GetSelectionValue()) and
+	    (GetLearningProblem()->GetTestDatabase()->GetDatabaseName() == "" or
+	     GetLearningProblem()->GetTestDatabase()->Check()) and
 	    GetLearningProblem()->CheckClass() and GetLearningProblem()->CheckTargetAttribute() and
 	    GetLearningProblem()->CheckResultFileNames() and
 	    GetLearningProblem()

--- a/src/Learning/KWModeling/KWTrainedPredictor.cpp
+++ b/src/Learning/KWModeling/KWTrainedPredictor.cpp
@@ -451,7 +451,7 @@ boolean KWTrainedPredictor::Check() const
 				}
 
 				// Test de validite des noms de classe initiaux
-				if (not kwcClass->CheckName(sInitialClassName, kwcClass))
+				if (not kwcClass->CheckName(sInitialClassName, KWClass::Class, kwcClass))
 				{
 					AddError("Bad initial dictionary name (" + sInitialClassName +
 						 ") for predictor dictionary (" + kwcClass->GetName() + ")");

--- a/src/Learning/KWUserInterface/KWClassBuilderView.cpp
+++ b/src/Learning/KWUserInterface/KWClassBuilderView.cpp
@@ -207,7 +207,7 @@ void KWClassBuilderView::BuildClass()
 			// Test si le nom de classe est valide et different du nom par defaut
 			if (bOk and sClassName != kwcClass->GetName())
 			{
-				assert(KWClass::CheckName(sClassName, NULL));
+				assert(KWClass::CheckName(sClassName, KWClass::Class, NULL));
 				bOk = (KWClassDomain::GetCurrentDomain()->LookupClass(sClassName) == NULL);
 				if (not bOk)
 				{

--- a/src/Learning/KWUserInterface/KWDatabaseView.cpp
+++ b/src/Learning/KWUserInterface/KWDatabaseView.cpp
@@ -545,7 +545,7 @@ void KWDatabaseView::RegisterDatabaseTechnologyView(KWDatabaseView* databaseView
 {
 	require(databaseView != NULL);
 	require(databaseView->GetTechnologyName() != "");
-	require(KWClass::CheckName(databaseView->GetTechnologyName(), databaseView));
+	require(KWClass::CheckName(databaseView->GetTechnologyName(), KWClass::None, databaseView));
 	require(odDatabaseTechnologyViews == NULL or
 		odDatabaseTechnologyViews->Lookup(databaseView->GetTechnologyName()) == NULL);
 

--- a/src/Learning/KWUserInterface/KWMTDatabaseMapping.dd
+++ b/src/Learning/KWUserInterface/KWMTDatabaseMapping.dd
@@ -1,6 +1,4 @@
 Rank;Name;Type;Style;Status;Label
 1;DataPath              ;ALString;           ;Derived;Data path
-2;DataPathClassName     ;ALString;           ;       ;Data root
-3;DataPathAttributeNames;ALString;           ;       ;Path
-4;ClassName             ;ALString;           ;       ;Dictionary
-5;DataTableName         ;ALString;FileChooser;       ;Data table file
+2;ClassName             ;ALString;           ;       ;Dictionary
+3;DataTableName         ;ALString;FileChooser;       ;Data table file

--- a/src/Learning/KWUserInterface/KWMTDatabaseMappingArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWMTDatabaseMappingArrayView.cpp
@@ -13,8 +13,6 @@ KWMTDatabaseMappingArrayView::KWMTDatabaseMappingArrayView()
 	SetIdentifier("Array.KWMTDatabaseMapping");
 	SetLabel("Multi-table mappings");
 	AddStringField("DataPath", "Data path", "");
-	AddStringField("DataPathClassName", "Data root", "");
-	AddStringField("DataPathAttributeNames", "Path", "");
 	AddStringField("ClassName", "Dictionary", "");
 	AddStringField("DataTableName", "Data table file", "");
 
@@ -32,9 +30,6 @@ KWMTDatabaseMappingArrayView::KWMTDatabaseMappingArrayView()
 
 	// Champ a utiliser comme identifiant pour les selections
 	SetKeyFieldId("DataPath");
-
-	// Ce champ est invisible: il est decompose en DataPathClass et DataPathAttributes pour l'interface
-	GetFieldAt("DataPath")->SetVisible(false);
 
 	// ##
 }
@@ -58,8 +53,6 @@ void KWMTDatabaseMappingArrayView::EventUpdate(Object* object)
 	require(object != NULL);
 
 	editedObject = cast(KWMTDatabaseMapping*, object);
-	editedObject->SetDataPathClassName(GetStringValueAt("DataPathClassName"));
-	editedObject->SetDataPathAttributeNames(GetStringValueAt("DataPathAttributeNames"));
 	editedObject->SetClassName(GetStringValueAt("ClassName"));
 	editedObject->SetDataTableName(GetStringValueAt("DataTableName"));
 
@@ -76,8 +69,6 @@ void KWMTDatabaseMappingArrayView::EventRefresh(Object* object)
 
 	editedObject = cast(KWMTDatabaseMapping*, object);
 	SetStringValueAt("DataPath", editedObject->GetDataPath());
-	SetStringValueAt("DataPathClassName", editedObject->GetDataPathClassName());
-	SetStringValueAt("DataPathAttributeNames", editedObject->GetDataPathAttributeNames());
 	SetStringValueAt("ClassName", editedObject->GetClassName());
 	SetStringValueAt("DataTableName", editedObject->GetDataTableName());
 

--- a/src/Learning/KWUserInterface/KWMTDatabaseMappingView.cpp
+++ b/src/Learning/KWUserInterface/KWMTDatabaseMappingView.cpp
@@ -13,8 +13,6 @@ KWMTDatabaseMappingView::KWMTDatabaseMappingView()
 	SetIdentifier("KWMTDatabaseMapping");
 	SetLabel("Multi-table mapping");
 	AddStringField("DataPath", "Data path", "");
-	AddStringField("DataPathClassName", "Data root", "");
-	AddStringField("DataPathAttributeNames", "Path", "");
 	AddStringField("ClassName", "Dictionary", "");
 	AddStringField("DataTableName", "Data table file", "");
 
@@ -27,11 +25,18 @@ KWMTDatabaseMappingView::KWMTDatabaseMappingView()
 	GetFieldAt("DataTableName")->SetParameters("Data\ntxt\ncsv");
 
 	// Info-bulles
-	GetFieldAt("DataPath")->SetHelpText("Full data path of the data table.");
-	GetFieldAt("DataPathClassName")->SetHelpText("Name of the dictionary that describes the database.");
-	GetFieldAt("DataPathAttributeNames")
-	    ->SetHelpText("Variable path from the data root."
-			  "\n (multi-tables database only)");
+	GetFieldAt("DataPath")
+	    ->SetHelpText(
+		"Data path of the data table (multi-table database only)."
+		"\n"
+		"\n In a multi-table schema, each data path refers to a Table or Entity variable and identifies a data "
+		"table file."
+		"\n The main table has an empty data path."
+		"\n In a star schema, the data paths are the names of Table or Entity variables for each secondary "
+		"table."
+		"\n In a snowflake schema, data paths consist of a list of variable names with a '/' separator."
+		"\n External tables begin with a data root prefixed with '/', which refers to the name of the "
+		"referenced root dictionary.");
 	GetFieldAt("ClassName")
 	    ->SetHelpText("Name of the dictionary that describes the data table."
 			  "\n (multi-tables database only)");
@@ -60,8 +65,6 @@ void KWMTDatabaseMappingView::EventUpdate(Object* object)
 	require(object != NULL);
 
 	editedObject = cast(KWMTDatabaseMapping*, object);
-	editedObject->SetDataPathClassName(GetStringValueAt("DataPathClassName"));
-	editedObject->SetDataPathAttributeNames(GetStringValueAt("DataPathAttributeNames"));
 	editedObject->SetClassName(GetStringValueAt("ClassName"));
 	editedObject->SetDataTableName(GetStringValueAt("DataTableName"));
 
@@ -78,8 +81,6 @@ void KWMTDatabaseMappingView::EventRefresh(Object* object)
 
 	editedObject = cast(KWMTDatabaseMapping*, object);
 	SetStringValueAt("DataPath", editedObject->GetDataPath());
-	SetStringValueAt("DataPathClassName", editedObject->GetDataPathClassName());
-	SetStringValueAt("DataPathAttributeNames", editedObject->GetDataPathAttributeNames());
 	SetStringValueAt("ClassName", editedObject->GetClassName());
 	SetStringValueAt("DataTableName", editedObject->GetDataTableName());
 

--- a/src/Learning/KWUserInterface/KWPredictorEvaluator.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorEvaluator.cpp
@@ -948,14 +948,14 @@ void KWPredictorEvaluator::RenameDatabaseClasses(KWDatabase* database, KWClassDo
 				// Recherche de la la classe initiale correspondant a la classe en cours
 				sInitialRootClassName = "";
 				kwcClass =
-				    KWClassDomain::GetCurrentDomain()->LookupClass(mapping->GetDataPathClassName());
+				    KWClassDomain::GetCurrentDomain()->LookupClass(mapping->GetOriginClassName());
 				if (kwcClass != NULL)
 					sInitialRootClassName =
 					    KWTrainedPredictor::GetMetaDataInitialClassName(kwcClass);
 
 				// Memorisation de cette classe ainsi de que la classe principale de la base
 				mapping->SetClassName(sInitialClassName);
-				mapping->SetDataPathClassName(sInitialRootClassName);
+				mapping->SetOriginClassName(sInitialRootClassName);
 			}
 		}
 	}

--- a/src/Learning/KWUserInterface/KWPredictorView.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorView.cpp
@@ -60,7 +60,7 @@ void KWPredictorView::RegisterPredictorView(KWPredictorView* predictorView)
 {
 	require(predictorView != NULL);
 	require(predictorView->GetName() != "");
-	require(KWClass::CheckName(predictorView->GetName(), predictorView));
+	require(KWClass::CheckName(predictorView->GetName(), KWClass::None, predictorView));
 	require(odPredictorViews == NULL or odPredictorViews->Lookup(predictorView->GetName()) == NULL);
 
 	// Creation si necessaire du dictionnaire de predictorViews

--- a/src/Learning/KWUtils/KWKhiopsVersion.h
+++ b/src/Learning/KWUtils/KWKhiopsVersion.h
@@ -10,7 +10,7 @@
 // dans le TaskManager de Windows (par exemple)
 
 // Version de Khiops
-#define KHIOPS_VERSION KHIOPS_STR(10.5.3-b.0)
+#define KHIOPS_VERSION KHIOPS_STR(10.5.4-b.0)
 // Les versions release distribuees sont bases sur trois numeros, par exemple KHIOPS_STR(10.2.0)
 // Les versions alpha, beta ou release candidate ont un suffixe supplementaire, par exemple :
 // - KHIOPS_STR(10.5.0-a.1)

--- a/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.cpp
+++ b/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.cpp
@@ -593,8 +593,8 @@ KNI_API int KNIOpenStream(const char* sDictionaryFileName, const char* sDictiona
 			if (i == 0)
 			{
 				assert(mapping->GetDataPath() == "");
-				assert(mapping->GetDataPathClassName() == kniStream->GetInputStream()->GetClassName());
-				mapping->SetDataTableName("Input stream " + mapping->GetDataPathClassName());
+				assert(mapping->GetOriginClassName() == kniStream->GetInputStream()->GetClassName());
+				mapping->SetDataTableName("Input stream " + mapping->GetOriginClassName());
 			}
 			// Sinon, on prend le data path
 			else
@@ -604,7 +604,7 @@ KNI_API int KNIOpenStream(const char* sDictionaryFileName, const char* sDictiona
 		// En sortie, parametrage uniquement de la table principale
 		assert(kniStream->GetOutputStream()->GetTableNumber() > 0);
 		mapping = cast(KWMTDatabaseMapping*, kniStream->GetOutputStream()->GetMultiTableMappings()->GetAt(0));
-		mapping->SetDataTableName("Output stream " + mapping->GetDataPathClassName());
+		mapping->SetDataTableName("Output stream " + mapping->GetOriginClassName());
 
 		// Parametrage de la ligne d'entete des tables principales
 		kniStream->GetInputStream()->SetHeaderLineAt("", sStreamHeaderLine);

--- a/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.h
+++ b/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.h
@@ -217,11 +217,14 @@ extern "C"
 	 *  . declare each external tables
 	 * Secondary tables are identified by a data path (name of the Entity or Table variable of the
 	 * stream main dictionary).
-	 * External tables are identified by a data root (root dictionary of the external table) and
-	 * optionally a data path for secondary external tables.
-	 * Secondary records related to the main record to recode just need a data path to be identified.
-	 * For multi-table schemas beyond the star schema (snowflake schema), the variables names in the
-	 * data path are separated by back-quote characters.
+	 * External tables are identified by a data root (root dictionary of the external table) plus
+	 * if necessary a data path for secondary external tables.
+	 * Secondary records related to the main record to be recoded need only a data path to be identified.
+	 * For multi-table schemas beyond the star schema (snowflake schema), the variable names in the
+	 * data path are separated by a slash '/'.
+	 * If a dictionary or variable in a data path contains back-quote or slash characters,
+	 * it must be enclosed between back-quotes characters, with doubled internal back-quotes characters,
+	 * as for the syntax of dictionary variables.
 	 * For single-table schema, none of the methods dedicated to the multi-table case can be used.
 	 * See Khiops Guide and tutorial for detailed specification of data root and data path.
 	 **********************************************************************************************/

--- a/src/Learning/MODL/MODL.cpp
+++ b/src/Learning/MODL/MODL.cpp
@@ -15,7 +15,7 @@ void SetWindowsDebugDir(const ALString& sDatasetFamily, const ALString& sDataset
 	// A parametrer pour chaque utilisateur
 	// Devra etre fait plus proprement quand tout l'equipe sera sur git, par exemple via une variable
 	// d'environnement et quelques commentaires clairs
-	sUserRootPath = "C:/Applications/boullema/LearningTest.V10.5.2-b.0/TestKhiops/";
+	sUserRootPath = "C:/Applications/boullema/LearningTest.V10.5.3-b.0/TestKhiops/";
 
 	// Pour permettre de continuer a utiliser LearningTest, on ne fait rien s'il y a deja un fichier test.prm
 	// dans le repertoire courante
@@ -38,6 +38,7 @@ int main(int argc, char** argv)
 	// Choix du repertoire de lancement pour le debugage sous Windows (a commenter apres fin du debug)
 	// SetWindowsDebugDir("Standard", "IrisLight");
 	// SetWindowsDebugDir("Standard", "IrisU2D");
+	// SetWindowsDebugDir("MultiTables", "DataPathCheck");
 
 	// Parametrage des logs memoires depuis les variables d'environnement, pris en compte dans KWLearningProject
 	//   KhiopsMemStatsLogFileName, KhiopsMemStatsLogFrequency, KhiopsMemStatsLogToCollect

--- a/src/Learning/samples/sample1/SampleOneLearningProblemView.cpp
+++ b/src/Learning/samples/sample1/SampleOneLearningProblemView.cpp
@@ -59,8 +59,7 @@ SampleOneLearningProblem* SampleOneLearningProblemView::GetSampleOneLearningProb
 boolean SampleOneLearningProblemView::CheckLearningSpec()
 {
 	return GetLearningProblem()->CheckClass() and GetLearningProblem()->CheckTrainDatabaseName() and
-	       GetLearningProblem()->GetTrainDatabase()->CheckSelectionValue(
-		   GetLearningProblem()->GetTrainDatabase()->GetSelectionValue());
+	       GetLearningProblem()->GetTrainDatabase()->Check();
 }
 
 void SampleOneLearningProblemView::ShowClass()

--- a/test/LearningTest/TestCoclustering/Standard/Adult2vars/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Adult2vars/test.prm
@@ -23,7 +23,7 @@ ClassFileName ../../../datasets/Adult/Adult.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Adult               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Adult/Adult.txt     // Database file
 Database.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 Database.DatabaseSpec.Selection.SelectionAttribute native_country   // Selection variable

--- a/test/LearningTest/TestCoclustering/Standard/Adult2varsFrequency/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Adult2varsFrequency/test.prm
@@ -23,7 +23,7 @@ ClassFileName ./OccupationEducationFrequency.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key OccupationEducationFrequency               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ./OccupationEducationFrequency.txt     // Database file
 
 AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter         // Insert variable

--- a/test/LearningTest/TestCoclustering/Standard/Adult2varsTiny/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Adult2varsTiny/test.prm
@@ -23,7 +23,7 @@ ClassFileName ../../../datasets/Adult/Adult.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Adult               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Adult/Adult.txt     // Database file
 Database.DatabaseSpec.Sampling.SampleNumberPercentage 0.5 // Sample percentage
 Database.DatabaseSpec.Selection.SelectionAttribute native_country   // Selection variable

--- a/test/LearningTest/TestCoclustering/Standard/Adult2varsWrongFrequency/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Adult2varsWrongFrequency/test.prm
@@ -23,7 +23,7 @@ ClassFileName ./OccupationEducationFrequency.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key OccupationEducationFrequency               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ./OccupationEducationFrequency.txt     // Database file
 
 AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter         // Insert variable

--- a/test/LearningTest/TestCoclustering/Standard/AdultMissing/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/AdultMissing/test.prm
@@ -23,7 +23,7 @@ ClassFileName ../../../datasets/Adult/Adult.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Adult               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ./AdultMissing10000.txt     // Database file
 
 AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter         // Insert variable

--- a/test/LearningTest/TestCoclustering/Standard/AdultSmall/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/AdultSmall/test.prm
@@ -23,7 +23,7 @@ ClassFileName ../../../datasets/Adult/Adult.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Adult               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ./Adult1000.txt     // Database file
 
 //AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter         // Insert variable

--- a/test/LearningTest/TestCoclustering/Standard/AdultSmall1var/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/AdultSmall1var/test.prm
@@ -23,7 +23,7 @@ ClassFileName ../../../datasets/Adult/Adult.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Adult               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ./Adult1000.txt     // Database file
 
 AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter         // Insert variable

--- a/test/LearningTest/TestCoclustering/Standard/AllCCResultsApiMode/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/AllCCResultsApiMode/test.prm
@@ -27,7 +27,7 @@ ClassFileName ./SubDir/Iris.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ./SubDir/Iris.txt     // Database file
 AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter          // Insert variable
 AnalysisSpec.CoclusteringParameters.Attributes.Name PetalLength          // Name

--- a/test/LearningTest/TestCoclustering/Standard/AllCCResultsStandardMode/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/AllCCResultsStandardMode/test.prm
@@ -27,7 +27,7 @@ ClassFileName ./SubDir/Iris.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ./SubDir/Iris.txt     // Database file
 AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter          // Insert variable
 AnalysisSpec.CoclusteringParameters.Attributes.Name PetalLength          // Name

--- a/test/LearningTest/TestCoclustering/Standard/Iris/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Iris/test.prm
@@ -26,7 +26,7 @@ ClassFileName ../../../datasets/Iris/Iris.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter          // Insert variable
 AnalysisSpec.CoclusteringParameters.Attributes.Name PetalLength          // Name

--- a/test/LearningTest/TestCoclustering/Standard/IrisMissing/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/IrisMissing/test.prm
@@ -23,7 +23,7 @@ ClassFileName ./IrisMissing.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key IrisMissing               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ./IrisMissing.txt     // Database file
 AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter          // Insert variable
 AnalysisSpec.CoclusteringParameters.Attributes.Name PetalLength          // Name

--- a/test/LearningTest/TestCoclustering/Standard/Mushroom/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Mushroom/test.prm
@@ -23,7 +23,7 @@ ClassFileName ../../../datasets/Mushroom/Mushroom.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Mushroom               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Mushroom/Mushroom.txt      // Database file
 
 AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter         // Insert variable

--- a/test/LearningTest/TestCoclustering/Standard/MushroomBasic/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/MushroomBasic/test.prm
@@ -23,7 +23,7 @@ ClassFileName ../../../datasets/Mushroom/Mushroom.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Mushroom               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Mushroom/Mushroom.txt     // Database file
 
 AnalysisSpec.CoclusteringParameters.Attributes.InsertItemAfter         // Insert variable

--- a/test/LearningTest/TestCoclustering/Standard/MushroomNoHeaderLine/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/MushroomNoHeaderLine/test.prm
@@ -23,7 +23,7 @@ ClassFileName ../../../datasets/Mushroom/Mushroom.kdic       // Dictionary file
 OK                             // Open
 // <- Open
 
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Mushroom               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Mushroom/Mushroom.txt     // Database file
 Database.DatabaseSpec.Data.HeaderLineUsed false       // Header line used
 

--- a/test/LearningTest/TestKNI/Standard/Adult/test.prm
+++ b/test/LearningTest/TestKNI/Standard/Adult/test.prm
@@ -23,9 +23,9 @@ TransferDatabase               // Deploy model
 
 // -> Database transfer
 ClassName SNB_Adult             // Deployment dictionary
-SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Adult               // List item selection
+SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 SourceDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Adult/Adult.txt     // Database file
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Adult               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Adult.txt     // Database file
 TransferDatabase               // Deploy model
 

--- a/test/LearningTest/TestKNI/Standard/Iris/test.prm
+++ b/test/LearningTest/TestKNI/Standard/Iris/test.prm
@@ -23,9 +23,9 @@ TransferDatabase               // Deploy model
 
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
-SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 SourceDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 

--- a/test/LearningTest/TestKNI/Standard/Iris2D/test.prm
+++ b/test/LearningTest/TestKNI/Standard/Iris2D/test.prm
@@ -23,9 +23,9 @@ TransferDatabase               // Deploy model
 
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
-SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 SourceDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 

--- a/test/LearningTest/TestKNI/Standard/IrisC/test.prm
+++ b/test/LearningTest/TestKNI/Standard/IrisC/test.prm
@@ -23,9 +23,9 @@ TransferDatabase               // Deploy model
 
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
-SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 SourceDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 

--- a/test/LearningTest/TestKNI/Standard/IrisG/test.prm
+++ b/test/LearningTest/TestKNI/Standard/IrisG/test.prm
@@ -23,9 +23,9 @@ TransferDatabase               // Deploy model
 
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
-SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 SourceDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 

--- a/test/LearningTest/TestKNI/Standard/IrisR/test.prm
+++ b/test/LearningTest/TestKNI/Standard/IrisR/test.prm
@@ -23,9 +23,9 @@ TransferDatabase               // Deploy model
 
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
-SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 SourceDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 

--- a/test/LearningTest/TestKNI/Standard/SpliceJunction/test.prm
+++ b/test/LearningTest/TestKNI/Standard/SpliceJunction/test.prm
@@ -27,11 +27,11 @@ TransferDatabase               // Deploy model...
 
 // -> Database transfer
 ClassName SpliceJunction        // Deployment dictionary
-SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction               // List item selection
+SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 SourceDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunction.txt      // Data table file
-SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction`DNA               // List item selection
+SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key DNA               // List item selection
 SourceDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunctionDNA.txt      // Data table file
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction              // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key               // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_SpliceJunction.txt    // Data table file
 TransferDatabase               // Deploy model
 

--- a/test/LearningTest/TestKhiops/Standard/Adult/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/Adult/test.prm
@@ -25,7 +25,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Adult          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Adult               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Adult/Adult.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 
@@ -54,7 +54,7 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName SNB_Adult             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Adult               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Adult.txt     // Database file
 TransferDatabase               // Deploy model
 Exit                           // Close
@@ -73,7 +73,7 @@ OK                             // Open
 LearningTools.EvaluatePredictors         // Evaluate predictors...
 
 // -> Evaluate predictors
-EvaluationDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Adult               // List item selection
+EvaluationDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 EvaluationDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Adult/Adult.txt     // Database file
 EvaluationDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 EvaluatedPredictors.List.Key SNB_Adult          // List item selection

--- a/test/LearningTest/TestKhiops/Standard/AdultU/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/AdultU/test.prm
@@ -25,7 +25,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Adult          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Adult               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Adult/Adult.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 100  // Sample percentage
 

--- a/test/LearningTest/TestKhiops/Standard/BenchIris/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/BenchIris/test.prm
@@ -67,7 +67,7 @@ BenchmarkSpecs.InsertItemAfter      // Insert after
 BenchmarkClassSpec.ClassFileName ../../../datasets/Iris/Iris.kdic        // Dictionary file
 BenchmarkClassSpec.ClassName Iris              // Dictionary
 BenchmarkClassSpec.TargetAttributeName Class    // Target variable
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 Exit                           // OK
 // <- Benchmark

--- a/test/LearningTest/TestKhiops/Standard/BenchUnivariateIris/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/BenchUnivariateIris/test.prm
@@ -24,7 +24,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 
 TransferDatabase               // Deploy model
@@ -32,7 +32,7 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName Iris             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 100  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/Iris.txt     // Database file
 TransferDatabase               // Deploy model
 Exit                           // Close
@@ -75,7 +75,7 @@ BenchmarkSpecs.InsertItemAfter      // Insert after
 BenchmarkClassSpec.ClassFileName ../../../datasets/Iris/Iris.kdic        // Dictionary file
 BenchmarkClassSpec.ClassName Iris              // Dictionary
 BenchmarkClassSpec.TargetAttributeName Class    // Target variable
-Database.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+Database.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/Iris.txt     // Database file
 Exit                           // OK

--- a/test/LearningTest/TestKhiops/Standard/BugMPIWithErrors/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/BugMPIWithErrors/test.prm
@@ -25,7 +25,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Adult          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Adult               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Adult/Adult.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 

--- a/test/LearningTest/TestKhiops/Standard/Iris/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/Iris/test.prm
@@ -25,7 +25,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 
@@ -55,7 +55,7 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 Exit                           // Close

--- a/test/LearningTest/TestKhiops/Standard/Iris2D/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/Iris2D/test.prm
@@ -26,7 +26,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 
@@ -57,7 +57,7 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 Exit                           // Close

--- a/test/LearningTest/TestKhiops/Standard/IrisC/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisC/test.prm
@@ -26,7 +26,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 
@@ -55,7 +55,7 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 Exit                           // Close

--- a/test/LearningTest/TestKhiops/Standard/IrisG/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisG/test.prm
@@ -26,7 +26,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 
@@ -56,7 +56,7 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 Exit                           // Close

--- a/test/LearningTest/TestKhiops/Standard/IrisLight/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisLight/test.prm
@@ -25,7 +25,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 TrainDatabase.DatabaseSpec.Selection.SelectionAttribute NoSetosa   // Selection variable
@@ -54,7 +54,7 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 Exit                           // Close

--- a/test/LearningTest/TestKhiops/Standard/IrisLight2D/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisLight2D/test.prm
@@ -26,7 +26,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 

--- a/test/LearningTest/TestKhiops/Standard/IrisLightWithTrees/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisLightWithTrees/test.prm
@@ -25,7 +25,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 
@@ -53,7 +53,7 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 Exit                           // Close

--- a/test/LearningTest/TestKhiops/Standard/IrisR/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisR/test.prm
@@ -26,7 +26,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 
@@ -52,7 +52,7 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName SNB_Iris             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SNB_Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_IrisR.txt     // Database file
 TransferDatabase               // Deploy model
 Exit                           // Close

--- a/test/LearningTest/TestKhiops/Standard/IrisTransfer/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisTransfer/test.prm
@@ -25,7 +25,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 
@@ -36,11 +36,11 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName Iris             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 
-SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+SourceDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 SourceDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_Iris.txt     // Database file
 TransferDatabase               // Deploy model
 Exit                           // Close

--- a/test/LearningTest/TestKhiops/Standard/IrisU2D/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisU2D/test.prm
@@ -26,7 +26,7 @@ OK                             // Open
 
 TrainDatabase.ClassName Iris          // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key Iris               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
 

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunction/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunction/test.prm
@@ -23,9 +23,9 @@ OK                             // Open
 
 TrainDatabase.ClassName SpliceJunction        // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunction.txt      // Data table file
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction`DNA               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key DNA               // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunctionDNA.txt      // Data table file
 
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 10  // Sample percentage

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunction2D/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunction2D/test.prm
@@ -23,9 +23,9 @@ OK                             // Open
 
 TrainDatabase.ClassName SpliceJunction        // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunction.txt      // Data table file
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction`DNA               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key DNA               // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunctionDNA.txt      // Data table file
 
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 10  // Sample percentage

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunctionExternal/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunctionExternal/test.prm
@@ -23,11 +23,11 @@ OK                             // Open
 
 TrainDatabase.ClassName SpliceJunctionExternal        // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunctionExternal               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./SpliceJunctionExternal.txt      // Data table file
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key /SpliceJunction               // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunction.txt      // Data table file
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction`DNA               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key /SpliceJunction/DNA               // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunctionDNA.txt      // Data table file
 
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 10  // Sample percentage

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunctionPreparation/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunctionPreparation/test.prm
@@ -23,9 +23,9 @@ OK                             // Open
 
 TrainDatabase.ClassName SpliceJunction        // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunction.txt      // Data table file
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction`DNA               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key DNA               // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunctionDNA.txt      // Data table file
 
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 10  // Sample percentage

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunctionTransfer/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunctionTransfer/test.prm
@@ -23,9 +23,9 @@ OK                             // Open
 
 TrainDatabase.ClassName SpliceJunction        // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunction.txt      // Data table file
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction`DNA               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key DNA               // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunctionDNA.txt      // Data table file
 
 TransferDatabase               // Deploy model
@@ -33,9 +33,9 @@ TransferDatabase               // Deploy model
 // -> Database transfer
 ClassName SpliceJunction             // Deployment dictionary
 SourceDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 70  // Sample percentage
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_SpliceJunction.txt      // Data table file
-TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction`DNA               // List item selection
+TargetDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key DNA               // List item selection
 TargetDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ./results/D_SpliceJunctionDNA.txt      // Data table file
 TransferDatabase               // Deploy model
 Exit                           // Close

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunctionWithTrees/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunctionWithTrees/test.prm
@@ -23,9 +23,9 @@ OK                             // Open
 
 TrainDatabase.ClassName SpliceJunction        // Dictionary
 
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key                // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunction.txt      // Data table file
-TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key SpliceJunction`DNA               // List item selection
+TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key DNA               // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../MTdatasets/SpliceJunction/SpliceJunctionDNA.txt      // Data table file
 
 TrainDatabase.DatabaseSpec.Sampling.SampleNumberPercentage 10  // Sample percentage


### PR DESCRIPTION
Utilisation du caractère '/' dans les data paths, comme dans les paths linux, et dans la norme JSON Patch
- data path relatif au dictionnaire d'analyse en cours, pour l'accès à ses tables internes
  - exemple pour la base Accident
    - Vehicles
    - Vehicles/Users
    - Place
- data path absolu, avec le nom du dictionnaire Root en tete (data root), pour les tables externes et leur composition
  - exemple de paths externes
    - /City
    - /Product
    - /Product/features
- cas des noms comportants des caractères '`' ou '/'
  - a mettre entre back-quotes, comme les noms de variables dans les dictionnaires