### PR TITLE
283 simplify learningtest scenarios in v11

### DIFF
--- a/src/Learning/KWLearningProblem/KWLearningProject.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProject.cpp
@@ -445,6 +445,7 @@ boolean KWLearningProject::ShowSystemInformation(const ALString& sValue)
 	svEnvironmentVariables.Initialize();
 	bEnvVarDefined = false;
 	svEnvironmentVariables.Add("KhiopsExpertMode");
+	svEnvironmentVariables.Add("KhiopsDefaultMemoryLimit");
 	svEnvironmentVariables.Add("KhiopsHardMemoryLimitMode");
 	svEnvironmentVariables.Add("KhiopsCrashTestMode");
 	svEnvironmentVariables.Add("KhiopsFastExitMode");

--- a/src/Learning/KWLearningProblem/KWSystemParametersView.cpp
+++ b/src/Learning/KWLearningProblem/KWSystemParametersView.cpp
@@ -102,6 +102,10 @@ KWSystemParametersView::KWSystemParametersView()
 	else
 		nDefaultMemory = nMaxMemory - nMaxMemory / 10;
 
+	// Modification de la memoire par defaut selon variable d'environnement experte
+	if (GetLearningDefaultMemoryLimit() != 0)
+		nDefaultMemory = min(GetLearningDefaultMemoryLimit(), nMaxMemory);
+
 	cast(UIIntElement*, GetFieldAt("MemoryLimit"))->SetMinValue(nMinMemory);
 	cast(UIIntElement*, GetFieldAt("MemoryLimit"))->SetMaxValue(nMaxMemory);
 	cast(UIIntElement*, GetFieldAt("MemoryLimit"))->SetDefaultValue(nDefaultMemory);

--- a/src/Learning/KWUtils/KWKhiopsVersion.h
+++ b/src/Learning/KWUtils/KWKhiopsVersion.h
@@ -10,7 +10,7 @@
 // dans le TaskManager de Windows (par exemple)
 
 // Version de Khiops
-#define KHIOPS_VERSION KHIOPS_STR(10.5.4-b.0)
+#define KHIOPS_VERSION KHIOPS_STR(10.5.5-b.0)
 // Les versions release distribuees sont bases sur trois numeros, par exemple KHIOPS_STR(10.2.0)
 // Les versions alpha, beta ou release candidate ont un suffixe supplementaire, par exemple :
 // - KHIOPS_STR(10.5.0-a.1)

--- a/src/Learning/KWUtils/KWVersion.cpp
+++ b/src/Learning/KWUtils/KWVersion.cpp
@@ -290,13 +290,12 @@ boolean GetLearningExpertMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bLearningExpertMode = false;
+	ALString sUserName;
+	ALString sLearningExpertMode;
 
 	// Determination du mode expert au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sUserName;
-		ALString sLearningExpertMode;
-
 		// Recherche des variables d'environnement
 		sUserName = p_getenv("USERNAME");
 		sUserName.MakeLower();
@@ -316,17 +315,45 @@ boolean GetLearningExpertMode()
 	return bLearningExpertMode;
 }
 
-boolean GetLearningHardMemoryLimitMode()
+int GetLearningDefaultMemoryLimit()
 {
 	static boolean bIsInitialized = false;
-	static boolean bLearningHardMemoryLimitMode = false;
+	static int nLearningDefaultMemoryLimit = 0;
+	ALString sLearningDefaultMemoryLimit;
 
 	// Determination du mode HardMemoryLimit au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sUserName;
-		ALString sLearningHardMemoryLimitMode;
+		// Recherche des variables d'environnement
+		sLearningDefaultMemoryLimit = p_getenv("KhiopsDefaultMemoryLimit");
 
+		// Conversion au mieux en un entier positif
+		if (sLearningDefaultMemoryLimit == "")
+			nLearningDefaultMemoryLimit = 0;
+		else
+			nLearningDefaultMemoryLimit = StringToInt(sLearningDefaultMemoryLimit);
+		if (nLearningDefaultMemoryLimit < 0)
+			nLearningDefaultMemoryLimit = 0;
+
+		// Utilisable uniquement en mode expert
+		if (GetLearningExpertMode())
+			nLearningDefaultMemoryLimit = 0;
+
+		// Memorisation du flag d'initialisation
+		bIsInitialized = true;
+	}
+	return nLearningDefaultMemoryLimit;
+}
+
+boolean GetLearningHardMemoryLimitMode()
+{
+	static boolean bIsInitialized = false;
+	static boolean bLearningHardMemoryLimitMode = false;
+	ALString sLearningHardMemoryLimitMode;
+
+	// Determination du mode HardMemoryLimit au premier appel
+	if (not bIsInitialized)
+	{
 		// Recherche des variables d'environnement
 		sLearningHardMemoryLimitMode = p_getenv("KhiopsHardMemoryLimitMode");
 		sLearningHardMemoryLimitMode.MakeLower();
@@ -347,13 +374,11 @@ boolean GetLearningCrashTestMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bLearningCrashTestMode = false;
+	ALString sLearningCrashTestMode;
 
 	// Determination du mode CrashTest au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sUserName;
-		ALString sLearningCrashTestMode;
-
 		// Recherche des variables d'environnement
 		sLearningCrashTestMode = p_getenv("KhiopsCrashTestMode");
 		sLearningCrashTestMode.MakeLower();
@@ -374,13 +399,11 @@ boolean GetLearningFastExitMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bLearningFastExitMode = true;
+	ALString sLearningFastExitMode;
 
 	// Determination du mode FastExit au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sUserName;
-		ALString sLearningFastExitMode;
-
 		// Recherche des variables d'environnement
 		sLearningFastExitMode = p_getenv("KhiopsFastExitMode");
 		sLearningFastExitMode.MakeLower();
@@ -401,12 +424,11 @@ boolean GetPreparationTraceMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bPreparationTraceMode = false;
+	ALString sPreparationTraceMode;
 
 	// Determination du mode au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sPreparationTraceMode;
-
 		// Recherche des variables d'environnement
 		sPreparationTraceMode = p_getenv("KhiopsPreparationTraceMode");
 		sPreparationTraceMode.MakeLower();
@@ -427,12 +449,11 @@ boolean GetIOTraceMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bIOTraceMode = false;
+	ALString sIOTraceMode;
 
 	// Determination du mode expert au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sIOTraceMode;
-
 		// Recherche des variables d'environnement
 		sIOTraceMode = p_getenv("KhiopsIOTraceMode");
 		sIOTraceMode.MakeLower();
@@ -453,12 +474,11 @@ boolean GetForestExpertMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bForestExpertMode = false;
+	ALString sForestExpertMode;
 
 	// Determination du mode expert au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sForestExpertMode;
-
 		// Recherche des variables d'environnement
 		sForestExpertMode = p_getenv("KhiopsForestExpertMode");
 		sForestExpertMode.MakeLower();
@@ -479,12 +499,11 @@ boolean GetLearningCoclusteringExpertMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bLearningCoclusteringExpertMode = false;
+	ALString sLearningCoclusteringExpertMode;
 
 	// Determination du mode expert au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sLearningCoclusteringExpertMode;
-
 		// Recherche des variables d'environnement
 		sLearningCoclusteringExpertMode = p_getenv("KhiopsCoclusteringExpertMode");
 		sLearningCoclusteringExpertMode.MakeLower();
@@ -506,13 +525,12 @@ boolean GetLearningCoclusteringIVExpertMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bLearningCoclusteringIVExpertMode = false;
+	ALString sUserName;
+	ALString sLearningCoclusteringIVExpertMode;
 
 	// Determination du mode expert au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sUserName;
-		ALString sLearningCoclusteringIVExpertMode;
-
 		// Recherche des variables d'environnement
 		sUserName = p_getenv("USERNAME");
 		sUserName.MakeLower();
@@ -540,12 +558,11 @@ boolean GetParallelExpertMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bParallelExpertMode = false;
+	ALString sExpertParallelMode;
 
 	// Determination du mode parallele au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sExpertParallelMode;
-
 		// Recherche des variables d'environnement
 		sExpertParallelMode = p_getenv("KhiopsExpertParallelMode");
 		sExpertParallelMode.MakeLower();
@@ -566,13 +583,12 @@ int GetParallelTraceMode()
 {
 	static boolean bIsInitialized = false;
 	static int nParallelTraceMode = 0;
+	ALString sParallelTraceMode;
 	int nValue;
 
 	// Determination du mode parallele au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sParallelTraceMode;
-
 		// Recherche des variables d'environnement
 		sParallelTraceMode = p_getenv("KhiopsParallelTrace");
 
@@ -600,12 +616,11 @@ boolean GetFileServerActivated()
 {
 	static boolean bIsInitialized = false;
 	static boolean bFileServerActivated = false;
+	ALString sFileServerActivated;
 
 	// Determination du mode parallele au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sFileServerActivated;
-
 		// Recherche de la variable d'environnement
 		sFileServerActivated = p_getenv("KhiopsFileServerActivated");
 		sFileServerActivated.MakeLower();
@@ -626,12 +641,11 @@ boolean GetLearningPriorStudyMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bLearningPriorStudyMode = false;
+	ALString sLearningPriorStudyMode;
 
 	// Determination du mode etude des prior au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sLearningPriorStudyMode;
-
 		// Recherche des variables d'environnement
 		sLearningPriorStudyMode = p_getenv("KhiopsPriorStudyMode");
 		sLearningPriorStudyMode.MakeLower();
@@ -652,12 +666,11 @@ boolean GetDistanceStudyMode()
 {
 	static boolean bIsInitialized = false;
 	static boolean bDistanceStudyMode = false;
+	ALString sDistanceStudyMode;
 
 	// Determination du mode parallele au premier appel
 	if (not bIsInitialized)
 	{
-		ALString sDistanceStudyMode;
-
 		// Recherche des variables d'environnement
 		sDistanceStudyMode = p_getenv("KhiopsDistanceStudyMode");
 		sDistanceStudyMode.MakeLower();

--- a/src/Learning/KWUtils/KWVersion.h
+++ b/src/Learning/KWUtils/KWVersion.h
@@ -116,7 +116,14 @@ boolean GetLearningRawGuiModeMode();
 // Ce mode expert est controlable par la variable d'environnement KhiopsExpertMode a true ou false
 boolean GetLearningExpertMode();
 
-// Indicateur du mode de l'outil avec gestion d'un controle stricte des limites memoire (defaut: false)
+// Memoire par defaut a utiliser
+// Est equivalent a un choix par utilisateur de la memoire maximum a utiliser en utilisant le parametrage
+// de l'onglet des parametres systemes
+// Ce mode expert est controlable par la variable d'environnement KhiopsDefaultMemoryLimit
+// Renvoie 0 si non specifie ou invalide
+int GetLearningDefaultMemoryLimit();
+
+// Indicateur du mode de l'outil avec gestion d'un controle strict des limites memoire (defaut: false)
 // Quand il est a true, tout depassement d'une limite memoire specifie par l'utilisateur provoque
 // un crash memoire, gere par un parametrage de l'allocateur
 // Ce mode expert est controlable par la variable d'environnement KhiopsHardMemoryLimitMode a true ou false

--- a/test/LearningTest/TestCoclustering/Standard/Adult2vars/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Adult2vars/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/Adult2varsFrequency/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Adult2varsFrequency/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/Adult2varsTiny/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Adult2varsTiny/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/Adult2varsWrongFrequency/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Adult2varsWrongFrequency/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/AdultMissing/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/AdultMissing/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/AdultSmall/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/AdultSmall/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/AdultSmall1var/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/AdultSmall1var/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/AllCCResultsApiMode/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/AllCCResultsApiMode/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // Build coclustering

--- a/test/LearningTest/TestCoclustering/Standard/AllCCResultsStandardMode/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/AllCCResultsStandardMode/test.prm
@@ -15,7 +15,6 @@
 
 // -> Khiops Coclustering
 AnalysisSpec.SystemParameters.APIMode false        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // Build coclustering

--- a/test/LearningTest/TestCoclustering/Standard/DeployDistributionAdult/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/DeployDistributionAdult/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/DeployDistributionAdult2vars/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/DeployDistributionAdult2vars/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/DeployDistributionAdult2varsFrequency/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/DeployDistributionAdult2varsFrequency/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/DeployDistributionAdultSmall/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/DeployDistributionAdultSmall/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/DeployDistributionAnnotatedMushroom/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/DeployDistributionAnnotatedMushroom/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/ExtractClustersAdult/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/ExtractClustersAdult/test.prm
@@ -14,8 +14,6 @@
 //
 
 
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 
 LearningTools.ExtractClusters  // Extract clusters...
 

--- a/test/LearningTest/TestCoclustering/Standard/Iris/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Iris/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 
 //AnalysisSpec.DataGridOptimizerParameters.DisplayDetails true // Display details
 

--- a/test/LearningTest/TestCoclustering/Standard/IrisFastPath/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/IrisFastPath/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 Database.DatabaseSpec.Data.DatabaseFiles.List.Key  // List item selection
 Database.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 

--- a/test/LearningTest/TestCoclustering/Standard/IrisMissing/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/IrisMissing/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/JSONDeployDistributionAnnotatedMushroom/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/JSONDeployDistributionAnnotatedMushroom/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/JSONSimplifyAdultMissing/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/JSONSimplifyAdultMissing/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 LearningTools.PostProcessCoclustering    // Simplify coclustering...
 
 // -> Coclustering post-processing

--- a/test/LearningTest/TestCoclustering/Standard/JSONSimplifyIris/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/JSONSimplifyIris/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 LearningTools.PostProcessCoclustering    // Simplify coclustering...
 
 // -> Coclustering post-processing

--- a/test/LearningTest/TestCoclustering/Standard/Mushroom/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/Mushroom/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/MushroomBasic/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/MushroomBasic/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/MushroomNoHeaderLine/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/MushroomNoHeaderLine/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/PreparePowerCurveDeployment/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/PreparePowerCurveDeployment/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestCoclustering/Standard/PrepareSpliceJunctionDeployment/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/PrepareSpliceJunctionDeployment/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 
 ClassManagement.OpenFile       // Open...
 

--- a/test/LearningTest/TestCoclustering/Standard/SimplifyAdult/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/SimplifyAdult/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 LearningTools.PostProcessCoclustering    // Simplify coclustering...
 
 // -> Coclustering post-processing

--- a/test/LearningTest/TestCoclustering/Standard/SimplifyAdultV75/test.prm
+++ b/test/LearningTest/TestCoclustering/Standard/SimplifyAdultV75/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Coclustering
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 LearningTools.PostProcessCoclustering    // Simplify coclustering...
 
 // -> Coclustering post-processing

--- a/test/LearningTest/TestKNI/Standard/Adult/test.prm
+++ b/test/LearningTest/TestKNI/Standard/Adult/test.prm
@@ -13,8 +13,6 @@
 //
 //
 
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 ClassFileName ./AdultModeling.kdic       // Dictionary file
 OK                             // Open

--- a/test/LearningTest/TestKNI/Standard/Iris/test.prm
+++ b/test/LearningTest/TestKNI/Standard/Iris/test.prm
@@ -13,8 +13,6 @@
 //
 //
 
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 ClassFileName ./IrisModeling.kdic       // Dictionary file
 OK                             // Open

--- a/test/LearningTest/TestKNI/Standard/Iris2D/test.prm
+++ b/test/LearningTest/TestKNI/Standard/Iris2D/test.prm
@@ -13,8 +13,6 @@
 //
 //
 
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 ClassFileName ./IrisModeling.kdic       // Dictionary file
 OK                             // Open

--- a/test/LearningTest/TestKNI/Standard/IrisC/test.prm
+++ b/test/LearningTest/TestKNI/Standard/IrisC/test.prm
@@ -13,8 +13,6 @@
 //
 //
 
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 ClassFileName ./IrisModeling.kdic       // Dictionary file
 OK                             // Open

--- a/test/LearningTest/TestKNI/Standard/IrisG/test.prm
+++ b/test/LearningTest/TestKNI/Standard/IrisG/test.prm
@@ -13,8 +13,6 @@
 //
 //
 
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 ClassFileName ./IrisModeling.kdic       // Dictionary file
 OK                             // Open

--- a/test/LearningTest/TestKNI/Standard/IrisR/test.prm
+++ b/test/LearningTest/TestKNI/Standard/IrisR/test.prm
@@ -13,8 +13,6 @@
 //
 //
 
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 ClassFileName ./IrisModeling.kdic       // Dictionary file
 OK                             // Open

--- a/test/LearningTest/TestKNI/Standard/SpliceJunction/test.prm
+++ b/test/LearningTest/TestKNI/Standard/SpliceJunction/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Khiops Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/Adult/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/Adult/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/AdultU/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/AdultU/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/BenchIris/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/BenchIris/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 LearningProblemStudy.ClassifierBenchmark   // Evaluate classifiers...
 
 // -> Learning benchmark

--- a/test/LearningTest/TestKhiops/Standard/BenchUnivariateIris/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/BenchUnivariateIris/test.prm
@@ -13,8 +13,6 @@
 //
 //
 
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/BugMPIWithErrors/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/BugMPIWithErrors/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/Iris/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/Iris/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/Iris2D/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/Iris2D/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/IrisC/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisC/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/IrisFastPath/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisFastPath/test.prm
@@ -13,8 +13,6 @@
 //
 //
 
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.List.Key     // List item selection
 TrainDatabase.DatabaseSpec.Data.DatabaseFiles.DataTableName ../../../datasets/Iris/Iris.txt     // Database file
 

--- a/test/LearningTest/TestKhiops/Standard/IrisG/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisG/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/IrisLight/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisLight/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/IrisLight2D/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisLight2D/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/IrisLightWithTrees/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisLightWithTrees/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/IrisR/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisR/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/IrisTransfer/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisTransfer/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/IrisU2D/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/IrisU2D/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 
 // -> Open

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunction/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunction/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 // -> Open
 ClassFileName ../../../MTdatasets/SpliceJunction/SpliceJunction.kdic  // Dictionary file

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunction2D/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunction2D/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 // -> Open
 ClassFileName ../../../MTdatasets/SpliceJunction/SpliceJunction.kdic  // Dictionary file

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunctionExternal/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunctionExternal/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 // -> Open
 ClassFileName ./SpliceJunctionExternal.kdic  // Dictionary file

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunctionPreparation/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunctionPreparation/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 // -> Open
 ClassFileName ../../../MTdatasets/SpliceJunction/SpliceJunction.kdic  // Dictionary file

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunctionTransfer/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunctionTransfer/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 // -> Open
 ClassFileName ../../../MTdatasets/SpliceJunction/SpliceJunction.kdic  // Dictionary file

--- a/test/LearningTest/TestKhiops/Standard/SpliceJunctionWithTrees/test.prm
+++ b/test/LearningTest/TestKhiops/Standard/SpliceJunctionWithTrees/test.prm
@@ -14,8 +14,6 @@
 //
 
 // -> Data preparation and scoring
-AnalysisSpec.SystemParameters.APIMode true        // API mode
-AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
 ClassManagement.OpenFile       // Open...
 // -> Open
 ClassFileName ../../../MTdatasets/SpliceJunction/SpliceJunction.kdic  // Dictionary file

--- a/test/LearningTestTool/py/_kht_constants.py
+++ b/test/LearningTestTool/py/_kht_constants.py
@@ -137,11 +137,13 @@ KHIOPS_MEM_STATS_LOG_FREQUENCY = "KhiopsMemStatsLogFrequency"
 KHIOPS_MEM_STATS_LOG_TO_COLLECT = "KhiopsMemStatsLogToCollect"
 KHIOPS_IO_TRACE_MODE = "KhiopsIOTraceMode"
 
-# Variables non documentee documentees, utilisee systematiquement pour les tests
+# Variables non documentee, utilisees systematiquement pour les tests
 KHIOPS_EXPERT_MODE = "KhiopsExpertMode"
 KHIOPS_CRASH_TEST_MODE = "KhiopsCrashTestMode"
 KHIOPS_FAST_EXIT_MODE = "KhiopsFastExitMode"
+KHIOPS_DEFAULT_MEMORY_LIMIT = "KhiopsDefaultMemoryLimit"
 KHIOPS_HARD_MEMORY_LIMIT_MODE = "KhiopsHardMemoryLimitMode"
+KHIOPS_API_MODE = "KHIOPS_API_MODE"
 
 """
 Gestion du timeout pour un jeu de test

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -326,12 +326,19 @@ def evaluate_tool_on_test_dir(
         # pour executer des scenarios testant plusieurs cas d'erreur
         os.environ[kht.KHIOPS_FAST_EXIT_MODE] = "false"
 
+        # khiops avec choix de la memoire par defaut a 2000 Mb, pour detecter au plus vite les problemes memoire,
+        # comme on avait auparavent en compilation 32 bits avec limite physique a 2 Gb
+        os.environ[kht.KHIOPS_DEFAULT_MEMORY_LIMIT] = "2000"
+
         # khiops en mode HardMemoryLimit via une variable d'environnement pour provoquer
         # un plantage physique de l'allocateur en cas de depassement des contraintes memoires des scenarios
         os.environ[kht.KHIOPS_HARD_MEMORY_LIMIT_MODE] = "true"
 
         # khiops en mode crash test via une variable d'environnement
         os.environ[kht.KHIOPS_CRASH_TEST_MODE] = "true"
+
+        # khiops par defaut en mode en mode API via une variable d'environnement
+        os.environ[kht.KHIOPS_API_MODE] = "true"
 
         # Ajout de variables d'environements propres a OpenMPI, elles remplacent les parametres
         # on peut ansi lancer indiferemment mpich ou openmpi


### PR DESCRIPTION
### Simplify LearningTest scenarios in V11

Actuellement, pour LearningTest en V11, tout scénario commence par les deux lignes suivantes:
- AnalysisSpec.SystemParameters.APIMode true        // API mode
- AnalysisSpec.SystemParameters.MemoryLimit 2000     // Memory limit in MB
Ce parametrage necessaire est en fait le cas par defaut: il est plus pertinent d'avoir ce comportement par defaut systematiquement,
et ne n'avoir ces lignes specifiees que pour les rares jeux de test concernes

Evolution:
- KhiopsDefaultMemoryLimit:
  - nouvelle variable d'environnement en mode expert, pour la valeur max par defaut dans les parametres systemes
- dans les script de LearningTestTool
  - KHIOPS_API_MODE=true
  - KhiopsDefaultMemoryLimit=2000
- dans les scenarios de LearningTest
  - supression des deux lignes de base dans tous les scenarios
  - on ne garde que les lignes specifiques si besoin

## Attention
A reviewer et merger apres la PR https://github.com/KhiopsML/khiops/pull/380
- les premiers commits proviennent de la PR en prérequis
- seuls les trois derniers commits sont concernés par cette PR