### PR TITLE
384 use all processes in the gui

### DIFF
--- a/src/Learning/DTForest/DTDecisionTreeCreationTask.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTask.cpp
@@ -1194,10 +1194,6 @@ boolean DTDecisionTreeCreationTask::ComputeResourceRequirements()
 	// initialisation des parametres permettant les diverses estimations de memoire (esclave, maitre...)
 	InitializeMemoryEstimations();
 
-	// nombre de process esclaves : ne pas en demander plus qu'il n'y a d'arbres a creer, car c'est inutile
-	nMaxSlaveProcessNumber = ComputeMaxSlaveProcessNumber();
-	assert(nMaxSlaveProcessNumber > 0);
-
 	// Estimation de la memoire partagee
 	lSharedMemory = ComputeSharedNecessaryMemory();
 
@@ -1208,7 +1204,7 @@ boolean DTDecisionTreeCreationTask::ComputeResourceRequirements()
 	lBiggestTreeMemory = ComputeBiggestTreeNecessaryMemory();
 
 	// Mise a jour des demandes de resources
-	GetResourceRequirements()->SetMaxSlaveProcessNumber(nMaxSlaveProcessNumber);
+	GetResourceRequirements()->SetMaxSlaveProcessNumber(nMaxCreatedAttributeNumber);
 	GetResourceRequirements()->GetSharedRequirement()->GetMemory()->Set(lSharedMemory);
 	GetResourceRequirements()->GetMasterRequirement()->GetMemory()->Set(lMasterMemory);
 	GetResourceRequirements()->GetSlaveRequirement()->GetMemory()->SetMin(lBiggestTreeMemory);
@@ -1256,16 +1252,6 @@ void DTDecisionTreeCreationTask::BuildForestAttributeSelections(DTForestAttribut
 		    randomForestParameter.GetAttributePercentage());
 
 	nMasterForestMaxAttributesSelectionNumber = forestattributeselection->GetMaxAttributesNumber();
-}
-
-int DTDecisionTreeCreationTask::ComputeMaxSlaveProcessNumber() const
-{
-	int result = RMResourceConstraints::GetMaxCoreNumberOnCluster();
-
-	if (result > nMaxCreatedAttributeNumber)
-		result = nMaxCreatedAttributeNumber;
-
-	return result;
 }
 
 longint DTDecisionTreeCreationTask::ComputeMasterNecessaryMemory()

--- a/src/Learning/DTForest/DTDecisionTreeCreationTask.h
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTask.h
@@ -162,9 +162,6 @@ protected:
 	////////////////////////////////////////////////////////////
 	// Implementation du ComputeResourceRequirements
 
-	// Estimation du nombre optimal de processeurs
-	int ComputeMaxSlaveProcessNumber() const;
-
 	/** Estimation de la memoire partagee */
 	longint ComputeSharedNecessaryMemory();
 

--- a/src/Learning/KWDataUtils/KWDatabaseIndexer.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseIndexer.cpp
@@ -23,6 +23,8 @@ KWDatabaseIndexer::~KWDatabaseIndexer()
 void KWDatabaseIndexer::InitializeFromDatabase(const KWDatabase* database)
 {
 	KWClass* kwcMainClass;
+	RMTaskResourceGrant defaultGrantedResources;
+	RMTaskResourceRequirement defaultRequirements;
 
 	require(database == NULL or database->Check());
 
@@ -70,7 +72,11 @@ void KWDatabaseIndexer::InitializeFromDatabase(const KWDatabase* database)
 	}
 
 	// Memorisation du nombre d'esclaves utilisables au moment de l'indexation
-	nResourceSlaveNumber = RMResourceConstraints::GetMaxCoreNumberOnCluster();
+	// Pour cela, les ressources obtenues pour des exigences par defaut fournissent le nombre total d'esclaves disponibles
+	// (sur un cluster le nombre d'esclave est different du nombre de processus -1)
+
+	RMParallelResourceManager::ComputeGrantedResources(&defaultRequirements, &defaultGrantedResources);
+	nResourceSlaveNumber = defaultGrantedResources.GetSlaveNumber();
 }
 
 boolean KWDatabaseIndexer::IsInitialized() const

--- a/src/Learning/KWLearningProblem/KWSystemParametersView.cpp
+++ b/src/Learning/KWLearningProblem/KWSystemParametersView.cpp
@@ -122,13 +122,12 @@ KWSystemParametersView::KWSystemParametersView()
 	cast(UIIntElement*, GetFieldAt("MaxCoreNumber"))->SetMinValue(1);
 
 	nMaxProcNumber =
-	    min(RMResourceManager::GetPhysicalCoreNumber(), max(1, RMResourceManager::GetLogicalProcessNumber() - 1));
+	    min(RMResourceManager::GetPhysicalCoreNumber(), max(1, RMResourceManager::GetLogicalProcessNumber()));
 	cast(UIIntElement*, GetFieldAt("MaxCoreNumber"))->SetMaxValue(nMaxProcNumber);
 	cast(UIIntElement*, GetFieldAt("MaxCoreNumber"))->SetDefaultValue(nMaxProcNumber);
 
-	// Calcul du nombre effectif de processus qu'on utilise (en general DefaultValue +1)
-	RMResourceConstraints::SetMaxCoreNumberOnCluster(
-	    ComputeCoreNumber(cast(UIIntElement*, GetFieldAt("MaxCoreNumber"))->GetDefaultValue()));
+	// Mise a jour de la contrainte du nombre de processus utilisable sur le systeme
+	RMResourceConstraints::SetMaxCoreNumberOnCluster(nMaxProcNumber);
 
 	// On ne peut pas editer le nombre de process a utiliser le mode parallel n'est pas disponible
 	if (not PLParallelTask::IsParallelModeAvailable())
@@ -194,9 +193,6 @@ KWSystemParametersView::~KWSystemParametersView() {}
 
 void KWSystemParametersView::EventUpdate(Object* object)
 {
-	int nRequestedCore;
-	ALString sTestFunctionality;
-
 	// On parametre directement les variables statiques correspondantes
 	// en ignorant l'objet passe en parametres
 	KWResultFilePathBuilder::SetLearningApiMode(GetBooleanValueAt("APIMode"));
@@ -210,8 +206,7 @@ void KWSystemParametersView::EventUpdate(Object* object)
 		MemSetMaxHeapSize(RMResourceConstraints::GetMemoryLimit() * lMB);
 
 	// Calcul du nombre de processus utilises
-	nRequestedCore = GetIntValueAt("MaxCoreNumber");
-	RMResourceConstraints::SetMaxCoreNumberOnCluster(ComputeCoreNumber(nRequestedCore));
+	RMResourceConstraints::SetMaxCoreNumberOnCluster(GetIntValueAt("MaxCoreNumber"));
 	PLParallelTask::SetParallelSimulated(GetBooleanValueAt("ParallelSimulated"));
 	PLParallelTask::SetParallelLogFileName(GetStringValueAt("ParallelLogFileName"));
 	FileService::SetUserTmpDir(GetStringValueAt("TemporaryDirectoryName"));
@@ -226,7 +221,7 @@ void KWSystemParametersView::EventRefresh(Object* object)
 	SetIntValueAt("OptimizationTime", RMResourceConstraints::GetOptimizationTime());
 	SetIntValueAt("MemoryLimit", RMResourceConstraints::GetMemoryLimit());
 	SetBooleanValueAt("IgnoreMemoryLimit", RMResourceConstraints::GetIgnoreMemoryLimit());
-	SetIntValueAt("MaxCoreNumber", ComputeRequestedCoreNumber(RMResourceConstraints::GetMaxCoreNumberOnCluster()));
+	SetIntValueAt("MaxCoreNumber", RMResourceConstraints::GetMaxCoreNumberOnCluster());
 	SetBooleanValueAt("ParallelSimulated", PLParallelTask::GetParallelSimulated());
 	SetStringValueAt("ParallelLogFileName", PLParallelTask::GetParallelLogFileName());
 	SetStringValueAt("TemporaryDirectoryName", FileService::GetUserTmpDir());
@@ -235,44 +230,4 @@ void KWSystemParametersView::EventRefresh(Object* object)
 const ALString KWSystemParametersView::GetClassLabel() const
 {
 	return "System parameters";
-}
-
-int KWSystemParametersView::ComputeCoreNumber(int nRequestedCoreNumber) const
-{
-	int nMPIProcessNumber;
-	int nProcessNumber;
-
-	require(nRequestedCoreNumber > 0);
-
-	nMPIProcessNumber = RMResourceManager::GetLogicalProcessNumber();
-
-	// Evaluation du nombre de processus a lancer
-	if (nRequestedCoreNumber == 1)
-	{
-		// Lancement en sequentiel si l'utilisateur ne demande qu'un seul coeur
-		nProcessNumber = 1;
-	}
-	else
-	{
-		// En parallele, on utilise 1 processus de plus que ce que demande l'utilisateur.
-		// Et on n'utilise pas plus de processus qu'il n'y a de processus MPI (d'ou le min)
-		// Il est donc recommande de lancer Khiops avec 1 processus MPI de plus que le nombre
-		// de coeurs physiques
-		nProcessNumber = min(nRequestedCoreNumber + 1, nMPIProcessNumber);
-	}
-	ensure(nProcessNumber > 0);
-	return nProcessNumber;
-}
-
-int KWSystemParametersView::ComputeRequestedCoreNumber(int nCoreNumber) const
-{
-	int nRequestedCore;
-
-	require(nCoreNumber > 0);
-
-	if (nCoreNumber == 1)
-		nRequestedCore = 1;
-	else
-		nRequestedCore = nCoreNumber - 1;
-	return nRequestedCore;
 }

--- a/src/Learning/KWLearningProblem/KWSystemParametersView.h
+++ b/src/Learning/KWLearningProblem/KWSystemParametersView.h
@@ -39,17 +39,4 @@ public:
 
 	// Libelles utilisateur
 	const ALString GetClassLabel() const override;
-
-	////////////////////////////////////////////////////////
-	//// Implementation
-protected:
-	// Calcul du nombre de processus utilise a partir de ce que l'utilisateur indique dans l'IHM
-	// Si nRequestedCoreNumber == 1 , c'est du sequentiel, on n'utilise qu'un seul processus
-	// Sinon on utilise un processus de plus que ce qui est demande sauf si il n'y a pas assez de
-	// processus MPI lances
-	int ComputeCoreNumber(int nRequestedCoreNumber) const;
-
-	// Pendant de la methode ComputeCoreNumber, renvoie le nombre de coeurs affiche a l'IHM a partir
-	// du nombre de processus utilises
-	int ComputeRequestedCoreNumber(int nCoreNumber) const;
 };


### PR DESCRIPTION
 Fix "Max number of processor cores" in the GUI

- In the Khiops GUI, the "Max number of processor cores" is now bounded by the number of physical cores (not minus one).
2 now useless methods are removed from `KWSystemParametersView`:
    - ComputeCoreNumber
    - ComputeRequestedCoreNumber
- 2 methods used RMResourceConstraints::GetMaxCoreNumberOnCluster() wrongly. It returns the number of cores on the system without regard to the user constraints and resource requirements.