### PR TITLE
405 cmake issue when building conda on fedora

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -60,14 +60,13 @@ jobs:
         shell: bash
         run: |
           # Put the Khiops package version
-          # The conda version cannot have '-' as a character so we eliminate it
           if [[ "${{ github.ref_type }}" == "tag" ]]
           then
-            KHIOPS_RAW_VERSION="${{ github.ref_name }}"
+            KHIOPS_VERSION="${{ github.ref_name }}"
           else
-            KHIOPS_RAW_VERSION="$(./scripts/khiops-version)"
+            KHIOPS_VERSION="$(./scripts/khiops-version)"
           fi
-          echo "KHIOPS_VERSION=$(echo $KHIOPS_RAW_VERSION | sed 's/-//')" >> "$GITHUB_ENV"
+          echo "KHIOPS_VERSION=$KHIOPS_VERSION" >> "$GITHUB_ENV"
           # On tag and macOS: Set the environment variables to sign the binaries
           if [[ "${{ runner.os }}" == "macOS" && "${{ github.ref_type }}" == "tag" ]]
           then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,24 @@ if(EXISTS "/etc/os-release")
   endif()
 endif()
 
+# Check if it is conda environment
+set(IS_CONDA false)
+if(DEFINED ENV{CONDA_PREFIX})
+  set(IS_CONDA true)
+  message(STATUS "Auto-detected conda environment")
+endif()
+
+if(IS_CONDA AND MPI)
+  if(NOT DEFINED ENV{mpi})
+    message(
+      WARNING "You are building in a conda environment without using `conda build`. find_mpi may not work as expected.")
+  endif()
+endif()
+
 # On Fedora distros, the binaries compiled with mpi must be located under the mpi location furthermore they have to be
 # suffixed by the name of the mpi implementation. These 2 items are given by MPI_BIN and MPI_SUFFIX when the module
 # environment is loaded source /etc/profile.d/modules.sh module load mpi/mpich-x86_64
-if(IS_FEDORA_LIKE)
+if(IS_FEDORA_LIKE AND NOT IS_CONDA)
   if(DEFINED ENV{MPI_BIN})
     set(MPI_BIN $ENV{MPI_BIN})
   else()
@@ -94,21 +108,7 @@ if(IS_FEDORA_LIKE)
         "MPI_SUFFIX is not defined, you have to load the mpi module e.g.:\n source /etc/profile.d/modules.sh && module load mpi/mpich-x86_64"
     )
   endif(DEFINED ENV{MPI_SUFFIX})
-endif(IS_FEDORA_LIKE)
-
-# Check if it is conda environment
-set(IS_CONDA false)
-if(DEFINED ENV{CONDA_PREFIX})
-  set(IS_CONDA true)
-  message(STATUS "Auto-detected conda environment")
-endif()
-
-if(IS_CONDA AND MPI)
-  if(NOT DEFINED ENV{mpi})
-    message(
-      WARNING "You are building in a conda environment without using `conda build`. find_mpi may not work as expected.")
-  endif()
-endif()
+endif(IS_FEDORA_LIKE AND NOT IS_CONDA)
 
 # Set the location of the built artifacts:
 #

--- a/packaging/conda/README.md
+++ b/packaging/conda/README.md
@@ -12,12 +12,7 @@ You'll need `conda-build` installed in your system.
 export KHIOPS_RAW_VERSION=$(scripts/khiops-version)
 export KHIOPS_VERSION=$(echo $KHIOPS_RAW_VERSION | sed 's/-//')
 
-# Windows
 conda build --output-folder ./khiops-conda packaging/conda
-
-# Linux/macOS
-# Note: We need the conda-forge channel to obtain the pinned versions of MPICH
-conda build --channel conda-forge --output-folder ./khiops-conda packaging/conda
 ```
 
 ### Signing the Executables in macOS

--- a/packaging/conda/README.md
+++ b/packaging/conda/README.md
@@ -1,16 +1,33 @@
 # Khiops Conda Packaging Scripts
 
 ## How to Build
-You'll need `conda-build` installed in your system.
+We need `conda-build` installed in the system.
+
+We need to make sure that Conda is configured to use conda-forge as its default channel and that the vanilla default channel (defaults) is removed, e.g. by writing:
+
+```bash
+$ conda config --add channels conda-forge
+$ conda config --remove channels defaults
+```
+
+Or if we want to keep the vanilla defaults channel, we could give the priority to conda-forge:
+
+```bash
+$ conda config --add channels conda-forge
+$ conda config --set channel_priority strict
+```
+
+Thus, the user's $HOME/.condarc file would be updated accordingly and --channel conda-forge would no longer be needed.
+
+In the CI this is ensured by the usage of miniforge-version in the invocation of the setup-miniconda action.
+
+To build `khiops-core` package, we need to run these commands at the root of the repo (it will leave a ready to use conda channel in `./khiops-conda`):
 
 ```bash
 # At the root of the repo
-# These commands will leave a ready to use conda channel in `./khiops-conda`
 
 # khiops version must be set before launching the build (can be retrieved with the script scripts/khiops-version).
-# The dash must be removed from the version to be compliant with the conda versionning policy
-export KHIOPS_RAW_VERSION=$(scripts/khiops-version)
-export KHIOPS_VERSION=$(echo $KHIOPS_RAW_VERSION | sed 's/-//')
+export KHIOPS_VERSION=$(scripts/khiops-version)
 
 conda build --output-folder ./khiops-conda packaging/conda
 ```

--- a/packaging/conda/build.sh
+++ b/packaging/conda/build.sh
@@ -3,29 +3,21 @@
 # Set-up the shell to behave more like a general-purpose programming language
 set -euo pipefail
 
-# Choose the build preset for macOS/Linux
-if [[ "$(uname)" == "Linux" ]]
-then
-  CMAKE_PRESET="linux-gcc-release"
-else
-  CMAKE_PRESET="macos-clang-release"
-fi
-
 # Configure project
-cmake --fresh --preset $CMAKE_PRESET -DBUILD_JARS=OFF -DTESTING=OFF
+cmake -B build/conda -S . -D BUILD_JARS=OFF -D TESTING=OFF -D CMAKE_BUILD_TYPE=Release -G Ninja
 
 # Build MODL and MODL_Coclustering
-cmake --build --preset $CMAKE_PRESET --parallel \
+cmake --build build/conda --parallel \
   --target MODL MODL_Coclustering KhiopsNativeInterface KNITransfer _khiopsgetprocnumber
 
 # Move the binaries to the Conda PREFIX path
-mv ./build/$CMAKE_PRESET/bin/MODL* "$PREFIX/bin"
-mv ./build/$CMAKE_PRESET/bin/_khiopsgetprocnumber* "$PREFIX/bin"
-mv ./build/$CMAKE_PRESET/bin/KNITransfer* "$PREFIX/bin"
-mv ./build/$CMAKE_PRESET/lib/libKhiopsNativeInterface* "$PREFIX/lib"
+mv ./build/conda/bin/MODL* "$PREFIX/bin"
+mv ./build/conda/bin/_khiopsgetprocnumber* "$PREFIX/bin"
+mv ./build/conda/bin/KNITransfer* "$PREFIX/bin"
+mv ./build/conda/lib/libKhiopsNativeInterface* "$PREFIX/lib"
 
 # Copy the scripts to the Conda PREFIX path
-cp ./build/$CMAKE_PRESET/tmp/khiops_env "$PREFIX/bin"
+cp ./build/conda/tmp/khiops_env "$PREFIX/bin"
 cp ./packaging/linux/common/khiops "$PREFIX/bin"
 cp ./packaging/linux/common/khiops_coclustering "$PREFIX/bin"
 
@@ -56,8 +48,7 @@ cp ./packaging/linux/common/khiops_coclustering "$PREFIX/bin"
 # - KHIOPS_APPLE_TMP_KEYCHAIN_PASSWORD: A temporary password for the a short-lived keychain
 #
 cd ..
-if [[ "$(uname)" == "Darwin" && -n "${KHIOPS_APPLE_CERTIFICATE_COMMON_NAME-}" ]]
-then
+if [[ "$(uname)" == "Darwin" && -n "${KHIOPS_APPLE_CERTIFICATE_COMMON_NAME-}" ]]; then
   # Inform about the signature process
   echo "Signing binaries with the certificate named '${KHIOPS_APPLE_CERTIFICATE_COMMON_NAME}'"
 
@@ -68,14 +59,12 @@ then
   install_name_tool -delete_rpath "$PREFIX/lib" "$PREFIX/bin/MODL_Coclustering"
   install_name_tool -delete_rpath "$PREFIX/lib" "$PREFIX/bin/_khiopsgetprocnumber"
 
-
   # Add the relative rpath as conda build would
   install_name_tool -add_rpath "@loader_path/../lib" "$PREFIX/bin/MODL"
   install_name_tool -add_rpath "@loader_path/../lib" "$PREFIX/bin/MODL_Coclustering"
   install_name_tool -add_rpath "@loader_path/../lib" "$PREFIX/bin/_khiopsgetprocnumber"
 
-  if [[ -n "${KHIOPS_APPLE_CERTIFICATE_BASE64-}" ]]
-  then
+  if [[ -n "${KHIOPS_APPLE_CERTIFICATE_BASE64-}" ]]; then
     # Keychain setup slightly modified from: https://stackoverflow.com/a/68577995
     # Before importing identity
     # - Set the default user login keychain
@@ -91,8 +80,7 @@ then
     sudo security unlock-keychain -p "$KHIOPS_APPLE_TMP_KEYCHAIN_PASSWORD" kh-tmp.keychain
 
     # Add identity (certificate + private key) to the temporary keychain
-    echo "$KHIOPS_APPLE_CERTIFICATE_BASE64" \
-      | base64 --decode -i - -o kh-cert.p12
+    echo "$KHIOPS_APPLE_CERTIFICATE_BASE64" | base64 --decode -i - -o kh-cert.p12
     sudo security import kh-cert.p12 \
       -k kh-tmp.keychain \
       -P "$KHIOPS_APPLE_CERTIFICATE_PASSWORD" \
@@ -126,8 +114,7 @@ then
   $CODESIGN -d -vvv "$KNI_PATH"
 
   # Remove the temporary keychain and restore the login keychain as default if created
-  if [[ -n "${KHIOPS_APPLE_CERTIFICATE_BASE64-}" ]]
-  then
+  if [[ -n "${KHIOPS_APPLE_CERTIFICATE_BASE64-}" ]]; then
     sudo security delete-keychain kh-tmp.keychain
     sudo security list-keychains -d user -s login.keychain
   fi

--- a/packaging/conda/meta.yaml
+++ b/packaging/conda/meta.yaml
@@ -1,6 +1,8 @@
+{% set version = os.environ.get('KHIOPS_VERSION').replace("-", "") %}
+
 package:
   name: khiops-binaries
-  version: {{ os.environ.get('KHIOPS_VERSION') }}
+  version: {{ version }}
 
 source:
   path: ../../
@@ -40,7 +42,7 @@ outputs:
 
   # khiops-core package
   - name: khiops-core
-    version: {{ os.environ.get('KHIOPS_VERSION') }}
+    version: {{ version }}
     requirements:
       build:
         - cmake
@@ -61,13 +63,13 @@ outputs:
       - bin/khiops_coclustering.cmd # [win]
     test:
       commands:
-        - khiops_env --env 
+        - khiops_env --env
         - khiops -s
         - khiops_coclustering -s
 
   # kni package (do not need khiops-core as a runtime dependency)
   - name: kni
-    version: {{ os.environ.get('KHIOPS_VERSION') }}
+    version: {{ version }}
     files:
       - lib/libKhiopsNativeInterface.so* # [linux]
       - lib/libKhiopsNativeInterface*.dylib # [osx]
@@ -81,7 +83,7 @@ outputs:
 
   # kni-transfer package (designed only to test kni)
   - name: kni-transfer
-    version: {{ os.environ.get('KHIOPS_VERSION') }}
+    version: {{ version }}
     requirements:
       build:
         - cmake

--- a/src/Learning/KhiopsNativeInterface/CMakeLists.txt
+++ b/src/Learning/KhiopsNativeInterface/CMakeLists.txt
@@ -6,6 +6,7 @@ set_target_properties(
   KhiopsNativeInterface
   PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/KhiopsNativeInterface.h
              SOVERSION ${PROJECT_VERSION_MAJOR}
-             VERSION ${KHIOPS_VERSION})
+             VERSION ${KHIOPS_VERSION}
+             WINDOWS_EXPORT_ALL_SYMBOLS true)
 
 set_khiops_options(KhiopsNativeInterface)


### PR DESCRIPTION
This PR contains fixes and improvements that I have made to package khiops on conda-forge. 
There is a major fix concerning the use of the compiler of conda instead of the system wide one (commit 2b317f4ba9217a9d2ba92cd51bc6b54e2cce83df)

close #403 
close #405