### PR TITLE
Use Python 3.8-compatible string suffix removal idiom

### DIFF
--- a/test/LearningTestTool/py/_kht_utils.py
+++ b/test/LearningTestTool/py/_kht_utils.py
@@ -210,7 +210,9 @@ def extract_tool_exe_name(tool_full_exe_name):
         return tool_full_exe_name
     for suffix in kht.TOOL_MPI_SUFFIXES:
         if tool_full_exe_name.endswith(suffix):
-            return tool_full_exe_name.removesuffix(suffix)
+            # TODO: Replace with `return tool_full_exe_name.removesuffix(suffix)`
+            # as soon as Python 3.8 support is dropped
+            return tool_full_exe_name[: tool_full_exe_name.index(suffix)]
 
 
 """


### PR DESCRIPTION
Replace Python >= 3.9 `.removeprefix` with a Python 3.8-compatible idiom.