### PR TITLE
Rename "Visualize results" to "Visualize report"

### DIFF
--- a/src/Learning/KWLearningProblem/KWAnalysisResultsView.cpp
+++ b/src/Learning/KWLearningProblem/KWAnalysisResultsView.cpp
@@ -22,8 +22,8 @@ KWAnalysisResultsView::KWAnalysisResultsView()
 	// ## Custom constructor
 
 	// Action de visualisation des resultats
-	AddAction("VisualizeResults", "Visualize results", (ActionMethod)(&KWAnalysisResultsView::VisualizeResults));
-	GetActionAt("VisualizeResults")->SetStyle("Button");
+	AddAction("VisualizeReport", "Visualize report", (ActionMethod)(&KWAnalysisResultsView::VisualizeReport));
+	GetActionAt("VisualizeReport")->SetStyle("Button");
 
 	// Info-bulles
 	GetFieldAt("ReportFileName")
@@ -49,11 +49,10 @@ KWAnalysisResultsView::KWAnalysisResultsView()
 			  "predictors on the train database."
 			  "\n - TestEvaluationReport.xls: evaluation report produced after the evaluation of the "
 			  "predictors on the train database.");
-	GetActionAt("VisualizeResults")
-	    ->SetHelpText("Visualize result report if available, using Khiops visualization tool.");
+	GetActionAt("VisualizeReport")->SetHelpText("Visualize report if available, using Khiops visualization tool.");
 
 	// Short cuts
-	GetActionAt("VisualizeResults")->SetShortCut('V');
+	GetActionAt("VisualizeReport")->SetShortCut('V');
 
 	// ##
 }
@@ -110,7 +109,7 @@ const ALString KWAnalysisResultsView::GetClassLabel() const
 
 // ## Method implementation
 
-void KWAnalysisResultsView::VisualizeResults()
+void KWAnalysisResultsView::VisualizeReport()
 {
 	KWAnalysisResults* analysisResults;
 	ALString sAnalysisReportFileName;

--- a/src/Learning/KWLearningProblem/KWAnalysisResultsView.h
+++ b/src/Learning/KWLearningProblem/KWAnalysisResultsView.h
@@ -47,7 +47,7 @@ public:
 	// ## Custom declarations
 
 	// Actions de menu
-	void VisualizeResults();
+	void VisualizeReport();
 
 	// Libelles de l'objet
 	const ALString GetObjectLabel() const override;

--- a/src/Learning/MODL_Coclustering/CCAnalysisResultsView.cpp
+++ b/src/Learning/MODL_Coclustering/CCAnalysisResultsView.cpp
@@ -22,8 +22,8 @@ CCAnalysisResultsView::CCAnalysisResultsView()
 	// ## Custom constructor
 
 	// Action de visualisation des resultats
-	AddAction("VisualizeResults", "Visualize results", (ActionMethod)(&CCAnalysisResultsView::VisualizeResults));
-	GetActionAt("VisualizeResults")->SetStyle("Button");
+	AddAction("VisualizeReport", "Visualize report", (ActionMethod)(&CCAnalysisResultsView::VisualizeReport));
+	GetActionAt("VisualizeReport")->SetStyle("Button");
 
 	// Le format khc est DEPRECATED et amene a disparaitre des que possible
 	GetFieldAt("ExportAsKhc")->SetVisible(false);
@@ -38,7 +38,7 @@ CCAnalysisResultsView::CCAnalysisResultsView()
 	    ->SetHelpText(
 		"Brief description to summarize the current analysis, which will be included in the reports.");
 	GetFieldAt("ExportAsKhc")->SetHelpText("Export the coclustering report under the khc format.");
-	GetActionAt("VisualizeResults")
+	GetActionAt("VisualizeReport")
 	    ->SetHelpText("Visualize coclustering report if available, using Khiops covisualization tool.");
 
 	// ##
@@ -96,7 +96,7 @@ const ALString CCAnalysisResultsView::GetClassLabel() const
 
 // ## Method implementation
 
-void CCAnalysisResultsView::VisualizeResults()
+void CCAnalysisResultsView::VisualizeReport()
 {
 	CCAnalysisResults* analysisResults;
 	ALString sAnalysisReportFileName;

--- a/src/Learning/MODL_Coclustering/CCAnalysisResultsView.h
+++ b/src/Learning/MODL_Coclustering/CCAnalysisResultsView.h
@@ -47,7 +47,7 @@ public:
 	// ## Custom declarations
 
 	// Actions de menu
-	void VisualizeResults();
+	void VisualizeReport();
 
 	// Libelles de l'objet
 	const ALString GetObjectLabel() const override;


### PR DESCRIPTION
Au dela du renommage du libelle des deux boutons concernes, renommage des identifiant des actions et methodes concernees, pour homogenisation entre terminologie interne et externe