### PR TITLE
Let CMake choose the compiler in Conda on Windows as well (#425)

### DIFF
--- a/packaging/conda/bld.bat
+++ b/packaging/conda/bld.bat
@@ -2,30 +2,26 @@ REM Echo all output
 @echo on
 
 REM Build the Khiops binaries
-REM Specify empty target platform and generator toolset for CMake with Ninja on
-REM Windows
-REM Ninja does not expect target platform and generator toolset.
-REM However, CMake Windows presets set these, which results in Ninja failure.
-cmake --preset windows-msvc-release -DBUILD_JARS=OFF -DTESTING=OFF -A "" -T ""
-cmake --build --preset windows-msvc-release --parallel --target MODL MODL_Coclustering KhiopsNativeInterface KNITransfer _khiopsgetprocnumber
+cmake -B build\conda -S . -D BUILD_JARS=OFF -D TESTING=OFF -D CMAKE_BUILD_TYPE=Release -G Ninja
+cmake --build build\conda --parallel --target MODL MODL_Coclustering KhiopsNativeInterface KNITransfer _khiopsgetprocnumber
 
 mkdir %PREFIX%\bin
 
 REM Copy the khiops-core binaries to the Conda PREFIX path: MODL, MODL_Cocluetsring and _khiopsgetprocnumber.
 REM This last one is used by khiops_env to get the physical cores number 
-copy build\windows-msvc-release\bin\MODL.exe %PREFIX%\bin
-copy build\windows-msvc-release\bin\MODL_Coclustering.exe %PREFIX%\bin
-copy build\windows-msvc-release\bin\_khiopsgetprocnumber.exe %PREFIX%\bin
+copy build\conda\bin\MODL.exe %PREFIX%\bin
+copy build\conda\bin\MODL_Coclustering.exe %PREFIX%\bin
+copy build\conda\bin\_khiopsgetprocnumber.exe %PREFIX%\bin
 
 REM Copy the KNITransfer for the kni-transfer package (a test package for kni)
-copy build\windows-msvc-release\bin\KNITransfer.exe %PREFIX%\bin
+copy build\conda\bin\KNITransfer.exe %PREFIX%\bin
 
 REM Copy the KhiopsNativeInterface libs for the kni package
-copy build\windows-msvc-release\bin\KhiopsNativeInterface.dll %PREFIX%\bin
-copy build\windows-msvc-release\lib\KhiopsNativeInterface.lib %PREFIX%\lib
+copy build\conda\bin\KhiopsNativeInterface.dll %PREFIX%\bin
+copy build\conda\lib\KhiopsNativeInterface.lib %PREFIX%\lib
 
 REM Copy the scripts to the Conda PREFIX path
-copy build\windows-msvc-release\tmp\khiops_env.cmd %PREFIX%\bin
+copy build\conda\tmp\khiops_env.cmd %PREFIX%\bin
 copy packaging\windows\khiops_coclustering.cmd %PREFIX%\bin
 copy packaging\windows\khiops.cmd %PREFIX%\bin
 


### PR DESCRIPTION
Backport of PR #425 (approved and merged) on `dev-v10`