### PR TITLE
Build a minimalist report in case of preparation errors

### DIFF
--- a/src/Learning/KWDataPreparation/KWClassStats.h
+++ b/src/Learning/KWDataPreparation/KWClassStats.h
@@ -256,7 +256,9 @@ public:
 	// Une seule des options doit etre actrive parmi 1D, 2D, Text ou Tree
 
 	// Ecriture d'un rapport
-	// Accessible uniquement si statistiques calculees
+	// Accessible pour un rapport complet uniquement si statistiques calculees
+	// Sinon, seul un rapport minimaliste est produit, avec les specifications d'apprentissage
+	// plus eventuellement les statistiques descriptives cibles si elles sont disponibles, et les erreurs
 	void WriteReport(ostream& ost) override;
 
 	// Parametrage de l'ecriture des rapports des attribut natif ou construits (defaut: false)
@@ -280,7 +282,7 @@ public:
 	void SetWriteOptionStatsTrees(boolean bValue);
 	boolean GetWriteOptionStatsTrees() const;
 
-	// Parametrage de l'ecriture des rapports univarie: native ou constuit, text ou abre
+	// Parametrage de l'ecriture des rapports univarie: native ou construit, text ou arbre
 	boolean GetWriteOptionStats1D() const;
 
 	// Parametrage de l'ecriture des rapports des paires d'attributs (defaut: false)
@@ -292,6 +294,9 @@ public:
 	boolean GetWriteDetailedStats() const;
 
 	// Ecriture du contenu d'un rapport JSON
+	// Accessible pour un rapport complet uniquement si statistiques calculees
+	// Sinon, seul un rapport minimaliste est produit, avec les specifications d'apprentissage
+	// plus eventuellement les statistiques descriptives cibles si elles sont disponibles, et les erreurs
 	void WriteJSONFields(JSONFile* fJSON) override;
 
 	// Verification de la validite des specifications

--- a/src/Learning/KWDataPreparation/KWDataPreparationTask.cpp
+++ b/src/Learning/KWDataPreparation/KWDataPreparationTask.cpp
@@ -239,7 +239,8 @@ int KWDataPreparationTask::ComputeMaxLoadableAttributeNumber(const KWLearningSpe
 		if (nAttributePairNumber > 0)
 			sMessage += "and bivariate ";
 		sMessage += "data processing)";
-		AddError(sMessage + ",\n\t" + grantedResources.GetMissingResourceMessage());
+		AddError(sMessage);
+		AddError(grantedResources.GetMissingResourceMessage());
 	}
 	return nMaxAttributeNumber;
 }

--- a/src/Learning/KWDataPreparation/KWLearningReport.cpp
+++ b/src/Learning/KWDataPreparation/KWLearningReport.cpp
@@ -30,8 +30,6 @@ void KWLearningReport::WriteReportFile(const ALString& sFileName)
 	boolean bOk;
 	ALString sLocalFileName;
 
-	require(IsStatsComputed());
-
 	// Ajout de log memoire
 	MemoryStatsManager::AddLog(GetClassLabel() + " " + GetObjectLabel() + " Write report Begin");
 

--- a/src/Learning/KWLearningProblem/KWLearningProblem.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblem.cpp
@@ -931,12 +931,17 @@ void KWLearningProblem::WritePreparationReports(KWClassStats* classStats)
 	ALString sReportName;
 
 	require(classStats != NULL);
-	require(classStats->IsStatsComputed());
 	require(analysisResults->GetExportAsXls());
 
-	// Ecriture d'un rapport de stats univarie complet
+	// Rapport de preparation minimaliste ne contenant que les specifications d'apprentissage
+	// en cas d'echec de la preparation, pour avoir un rapport avec les erreurs
 	sReportName = analysisResults->BuildOutputFilePathName(analysisResults->GetPreparationFileName());
-	if (sReportName != "")
+	if (not classStats->IsStatsComputed() and sReportName != "")
+	{
+		classStats->WriteReportFile(sReportName);
+	}
+	// Ecriture d'un rapport de stats univarie complet sinon
+	else if (classStats->IsStatsComputed() and sReportName != "")
 	{
 		classStats->SetWriteOptionStatsNativeOrConstructed(true);
 		classStats->WriteReportFile(sReportName);
@@ -945,7 +950,7 @@ void KWLearningProblem::WritePreparationReports(KWClassStats* classStats)
 
 	// Ecriture d'un rapport de stats univarie dans le cas des textes
 	sReportName = analysisResults->BuildOutputFilePathName(analysisResults->GetTextPreparationFileName());
-	if (sReportName != "" and
+	if (classStats->IsStatsComputed() and sReportName != "" and
 	    analysisSpec->GetModelingSpec()->GetAttributeConstructionSpec()->GetMaxTextFeatureNumber() > 0 and
 	    classStats->GetTextAttributeStats()->GetSize() > 0)
 	{
@@ -956,7 +961,7 @@ void KWLearningProblem::WritePreparationReports(KWClassStats* classStats)
 
 	// Ecriture d'un rapport de stats univarie dans le cas des arbres
 	sReportName = analysisResults->BuildOutputFilePathName(analysisResults->GetTreePreparationFileName());
-	if (sReportName != "" and
+	if (classStats->IsStatsComputed() and sReportName != "" and
 	    analysisSpec->GetModelingSpec()->GetAttributeConstructionSpec()->GetMaxTreeNumber() > 0 and
 	    classStats->GetTreeAttributeStats()->GetSize() > 0)
 	{
@@ -967,7 +972,7 @@ void KWLearningProblem::WritePreparationReports(KWClassStats* classStats)
 
 	// Ecriture d'un rapport de stats bivarie complet
 	sReportName = analysisResults->BuildOutputFilePathName(analysisResults->GetPreparation2DFileName());
-	if (sReportName != "" and
+	if (classStats->IsStatsComputed() and sReportName != "" and
 	    analysisSpec->GetModelingSpec()->GetAttributeConstructionSpec()->GetMaxAttributePairNumber() > 0 and
 	    classStats->GetAttributePairStats()->GetSize() > 0 and
 	    classStats->GetTargetAttributeType() != KWType::Continuous)
@@ -986,7 +991,6 @@ void KWLearningProblem::WriteJSONAnalysisReport(KWClassStats* classStats, Object
 	JSONFile fJSON;
 
 	require(classStats != NULL);
-	require(classStats->IsStatsComputed());
 	require(oaTrainedPredictorReports != NULL);
 	require(oaTrainPredictorEvaluations != NULL);
 	require(oaTestPredictorEvaluations != NULL);
@@ -1047,8 +1051,14 @@ void KWLearningProblem::WriteJSONAnalysisReport(KWClassStats* classStats, Object
 				fJSON.EndObject();
 			}
 
-			// Rapport de preparation
-			if (analysisResults->GetPreparationFileName() != "")
+			// Rapport de preparation minimaliste ne contenant que les specifications d'apprentissage
+			// en cas d'echec de la preparation, pour avoir un rapport avec les erreurs
+			if (not classStats->IsStatsComputed() and analysisResults->GetPreparationFileName() != "")
+			{
+				classStats->WriteJSONKeyReport(&fJSON, "preparationReport");
+			}
+			// Rapport de preparation complet sinon
+			else if (classStats->IsStatsComputed() and analysisResults->GetPreparationFileName() != "")
 			{
 				classStats->SetWriteOptionStatsNativeOrConstructed(true);
 				classStats->WriteJSONKeyReport(&fJSON, "preparationReport");
@@ -1056,7 +1066,7 @@ void KWLearningProblem::WriteJSONAnalysisReport(KWClassStats* classStats, Object
 			}
 
 			// Rapport de preparation pour les variables de type texte
-			if (analysisResults->GetPreparationFileName() != "" and
+			if (classStats->IsStatsComputed() and analysisResults->GetPreparationFileName() != "" and
 			    classStats->GetTextAttributeStats()->GetSize() > 0)
 			{
 				classStats->SetWriteOptionStatsText(true);
@@ -1065,7 +1075,7 @@ void KWLearningProblem::WriteJSONAnalysisReport(KWClassStats* classStats, Object
 			}
 
 			// Rapport de preparation pour les variables de type arbre
-			if (analysisResults->GetPreparationFileName() != "" and
+			if (classStats->IsStatsComputed() and analysisResults->GetPreparationFileName() != "" and
 			    classStats->IsTreeConstructionRequired() and
 			    classStats->GetTreeAttributeStats()->GetSize() > 0)
 			{
@@ -1080,7 +1090,7 @@ void KWLearningProblem::WriteJSONAnalysisReport(KWClassStats* classStats, Object
 			classStats->DeleteAttributeTreeConstructionTask();
 
 			// Rapport de preparation bivarie
-			if (analysisResults->GetPreparation2DFileName() != "" and
+			if (classStats->IsStatsComputed() and analysisResults->GetPreparation2DFileName() != "" and
 			    analysisSpec->GetModelingSpec()
 				    ->GetAttributeConstructionSpec()
 				    ->GetMaxAttributePairNumber() > 0 and

--- a/src/Learning/KWLearningProblem/KWLearningProblemComputeStats.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblemComputeStats.cpp
@@ -115,10 +115,10 @@ void KWLearningProblem::ComputeStats()
 	// Demarrage de la tache de preparation
 	KWLearningErrorManager::AddTask("Data preparation");
 
-	// Initialisation des objets de calculs des statistiques
-	bPreparationOk = bPreparationOk and not TaskProgression::IsInterruptionRequested();
-	if (bPreparationOk)
-		InitializeClassStats(classStats, &learningSpec);
+	// Initialisation des specifications de calculs des statistiques dans tous les cas,
+	// meme en cas d'erreur ou d'interruption utilisateur
+	// On en a besoin car on va creer un rapport d'analyse meme en cas d'erreur (minimaliste dans ce cas)
+	InitializeClassStats(classStats, &learningSpec);
 
 	// Calcul des statistiques
 	bPreparationOk = bPreparationOk and not TaskProgression::IsInterruptionRequested();
@@ -288,8 +288,8 @@ void KWLearningProblem::ComputeStats()
 
 	// Ecriture des rapports de preparation, maintenant que la modelisation a ete effectuee
 	// pour permettre de parametrer les ClassStats par les variables selectionnees par les predicteurs
-	bPreparationOk = bPreparationOk and not TaskProgression::IsInterruptionRequested();
-	if (bPreparationOk and analysisResults->GetExportAsXls())
+	// Dans le pire des cas, on peut avoir un rapport vide ne contenant que des messages d'erreur
+	if (not TaskProgression::IsInterruptionRequested() and analysisResults->GetExportAsXls())
 		WritePreparationReports(classStats);
 
 	// Ecriture du rapport de modelisation au format tabulaire xls
@@ -384,9 +384,9 @@ void KWLearningProblem::ComputeStats()
 	}
 
 	// Ecriture du rapport JSON
-	// Il faut au moins que la preparation soit correcte
-	// La modelisation et l'evaluation seront ecrite si elles ont pu etre calculee
-	if (bPreparationOk and not TaskProgression::IsInterruptionRequested())
+	// La preparation, la modelisation et l'evaluation seront ecrites si elles ont pu etre calculees
+	// Dans le pire des cas, on peut avoir un rapport vide ne contenant que des messages d'erreur
+	if (not TaskProgression::IsInterruptionRequested())
 		WriteJSONAnalysisReport(classStats, &oaTrainedPredictorReports, &oaTrainPredictorEvaluations,
 					&oaTestPredictorEvaluations);
 	// Sinon, nettoyage de tous les rapports, dont certains ont peut-etre ete ecrits avant l'interruption

--- a/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
@@ -649,10 +649,16 @@ boolean CCLearningProblem::CheckCoclusteringSpecifications() const
 	// Cas d'un coclustering standard : coclustering de variables
 	if (not analysisSpec->GetVarPartCoclustering())
 	{
-		// Il doit y avoir au moins deux variables dans un co-clustering
-		if (analysisSpec->GetCoclusteringSpec()->GetAttributeNames()->GetSize() < 2)
+		// Il doit y avoir des variables specifiees pour un co-clustering
+		if (analysisSpec->GetCoclusteringSpec()->GetAttributeNames()->GetSize() == 0)
 		{
-			AddError("Less than two coclustering variables are specified");
+			AddError("No coclustering variable specified");
+			bOk = false;
+		}
+		// Il doit y avoir au moins deux variables specifiee pour un co-clustering
+		else if (analysisSpec->GetCoclusteringSpec()->GetAttributeNames()->GetSize() < 2)
+		{
+			AddError("At least two coclustering variables must be specified");
 			bOk = false;
 		}
 		// Il y a une limite au nombre de variables

--- a/src/Learning/MODL_Coclustering/CCLearningProblemView.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemView.cpp
@@ -188,14 +188,17 @@ void CCLearningProblemView::EventRefresh(Object* object)
 
 void CCLearningProblemView::BuildCoclustering()
 {
-	boolean bOk = true;
+	boolean bOk;
+
+	// On verifie a minima qu'une base est specifiee
+	bOk = GetLearningProblem()->CheckDatabaseName();
 
 	// Test si on a pas specifie de dictionnaire d'analyse, pour le construire automatiquement a la volee
-	if (GetLearningProblem()->CheckDatabaseName() and GetLearningProblem()->GetDatabase()->GetClassName() == "")
+	if (bOk and GetLearningProblem()->GetDatabase()->GetClassName() == "")
 		bOk = BuildClassFromDataTable();
 
 	// OK si nom du fichier renseigne et classe correcte
-	if (GetLearningProblem()->CheckClass() and GetLearningProblem()->CheckDatabaseName() and
+	if (bOk and GetLearningProblem()->CheckClass() and GetLearningProblem()->CheckDatabaseName() and
 	    GetLearningProblem()->GetDatabase()->Check() and
 	    GetLearningProblem()->GetDatabase()->CheckSelectionValue(
 		GetLearningProblem()->GetDatabase()->GetSelectionValue()) and


### PR DESCRIPTION
En cas d'erreur des la preparation (par exemple du a un manque de memoire), on produit desormais un rapport de preparation minimaliste contenant les specifications d'apprentissage, plus si elles sont disponibles les stattistiques sur la variable cible.

Cela permet ainsi d'avoir systematiquement un rapport de modelisation dans tous les cas, en permettant de voir les erreurs avec une interface uniforme, en evitant de revenir au fichier texte du log de Khiops.

Impacts:
- KWClassStats
  - WriteReport: on accepte maintenant d'ecrire un rapport (minimaliste) meme si les stats n'ont pas pu etre calculee
  - WriteJSONFields: idem avec le rapport json
- KWLearningReport
  - WriteReportFile: supression du require pour permettre l'ecriture d'un rapport, meme si les stats ne sont pas calculees
- KWLearningProblem
  - WritePreparationReports: prise en compte du cas ou les stats ne sont pas calculees
  - WriteJSONAnalysisReport: idem avec le rappot json
- KWLearningProblem
  - ComputeStats: appel systematique des methodes d'ecriture des rapports dans tous les cas

Nouveau jeu de test dans LearningTest\TestKhiops\SideEffects\MinimalistReport