### PR TITLE
462 improving uniqueness management in multi table schemas

### DIFF
--- a/src/Learning/KDDomainKnowledge/KDMultiTableFeatureConstruction.cpp
+++ b/src/Learning/KDDomainKnowledge/KDMultiTableFeatureConstruction.cpp
@@ -1591,7 +1591,7 @@ void KDMultiTableFeatureConstruction::ComputeAllClassesCompliantRules(
 
 		// On interdit les cles de la classe
 		// De facon generale, il s'agit d'un principe: la cle ne sert qu'a encoder une structure et la
-		// memoriser: il ne s'agit pas d'attributs porteurs d'information. Pour la classe racine, les cle
+		// memoriser: il ne s'agit pas d'attributs porteurs d'information. Pour la classe principale, les cle
 		// apparaissent une seule fois instance, et ne peuvent etre informatives. Pour les classes secondaires
 		// inclues, les cles sont soient unique par instance principale (la cle de l'incluant) sans interet,
 		// soit avec un role d'identifiant dans la table secondaire, sans interet autre que compter le nombre

--- a/src/Learning/KDDomainKnowledge/KDMultiTableFeatureConstruction.h
+++ b/src/Learning/KDDomainKnowledge/KDMultiTableFeatureConstruction.h
@@ -214,7 +214,7 @@ protected:
 	//   . templateDerivationRule: regle de derivation en cours de construction, selon les parametres de
 	//   construction
 	// - controle de la profondeur d'extraction
-	//   . sPriorTreeNodeName: identifiant du noeud de l'arbre de construction a partir de la racine
+	//   . sPriorTreeNodeName: identifiant du noeud de l'arbre de construction a partir de la classe principale
 	//                         Utilise si non vide, pour indiquer qu'une trace de debugging est demandee
 	//   . nDepth: profondeur dans l'arbre de construction, limite par la variable externe nMaxRuleDepth
 	//   . dRuleCost: cout de la regle en cours de construction, limite par la variable externe dMaxRuleCost
@@ -390,7 +390,7 @@ protected:
 	//  . nSelectionSize: taille de selection
 	//  . nMaxSelectionOperandNumber: nombre max d'operandes a constuire
 	//  . dMaxSelectionCost: cout maximum de selection
-	//  . sPriorTreeNodeName: identifiant du noeud de l'arbre de construction a partir de la racine
+	//  . sPriorTreeNodeName: identifiant du noeud de l'arbre de construction a partir de la classe principale
 	//                         Utilise si non vide, pour indiquer qu'une trace de debugging est demandee
 	//  . oaSelectionOperands: tableau des dimensions de partition (KDClassSelectionOperandStats: attribut ou regle)
 	//  utilisables en operandes de selection . oaSelectionOperandIndexedFrequencies: tableau des effectif indexes

--- a/src/Learning/KDDomainKnowledge/KDSelectionOperandDataSampler.cpp
+++ b/src/Learning/KDDomainKnowledge/KDSelectionOperandDataSampler.cpp
@@ -823,7 +823,7 @@ void KDSelectionOperandDataSampler::ExtractAllSelectionReferencedObjects(KWMTDat
 		oaRootObjects.Sort();
 
 		// Analyse des objets
-		// Le tri des classes externes, puis le tri des obejt par classe garantit que l'index attribue a chaque
+		// Le tri des classes externes, puis le tri des objets par classe garantit que l'index attribue a chaque
 		// objet racine externe est unique et reproductible
 		// Note sur l'optimisation:
 		//   . on pourrait eviter le tri des objets en utilisant directement leur CraetionIndex, mais ce serait

--- a/src/Learning/KDDomainKnowledge/KDTextFeatureConstruction.h
+++ b/src/Learning/KDDomainKnowledge/KDTextFeatureConstruction.h
@@ -135,9 +135,9 @@ protected:
 					     ObjectDictionary* odConstructedAttributes) const;
 
 	// Construction d'un attribut de type texte a partir d'un chemin d'attribut dans un schema multi-table
-	// L'attribut construit est insere en unused dans la classe et permet de ramener a la racine l'attribut
-	// texte correspondant au chemin d'attribut, avec le type Text ou TextList selon la nature simple ou multiple du
-	// chemin
+	// L'attribut construit est insere en unused dans la classe et permet de ramener a la classe principale
+	// l'attribut texte correspondant au chemin d'attribut, avec le type Text ou TextList selon la
+	// nature simple ou multiple du chemin
 	KWAttribute* ConstructPathAttribute(KDClassCompliantRules* classCompliantRules, KWClass* kwcClass,
 					    const KDTextAttributePath* textAttributePath) const;
 

--- a/src/Learning/KNITransfer/KNIDatabaseTransferView.cpp
+++ b/src/Learning/KNITransfer/KNIDatabaseTransferView.cpp
@@ -76,7 +76,7 @@ void KNIDatabaseTransferView::KNITransferDatabase()
 		// Recopie des caracteristiques de la table principale ou des tables secondaires
 		else
 		{
-			// Cas du mapping racine (premier des mapping)
+			// Cas du mapping principal (premier des mappings)
 			if (nMapping == 0)
 			{
 				strcpy(recodingOperands.InputFile.DataPath, "");

--- a/src/Learning/KWData/KWAttribute.cpp
+++ b/src/Learning/KWData/KWAttribute.cpp
@@ -551,7 +551,7 @@ void KWAttribute::Write(ostream& ost) const
 	ost << ";";
 
 	// Meta-donnees
-	WriteNotLoadedMetaData(ost);
+	WritePrivateMetaData(ost);
 	if (metaData.GetKeyNumber() > 0)
 	{
 		ost << ' ';
@@ -611,21 +611,21 @@ void KWAttribute::WriteJSONFields(JSONFile* fJSON)
 		metaData.WriteJSONKeyReport(fJSON, "metaData");
 }
 
-void KWAttribute::WriteNotLoadedMetaData(ostream& ost) const
+void KWAttribute::WritePrivateMetaData(ostream& ost) const
 {
-	KWMetaData usedNotLoadedMetaData;
+	KWMetaData privateMetaData;
 
 	// Memorisation dans une meta-data temporaire de l'information d'utilisation d'un attribut non charge en memoire
 	// Permet de transferer cette information "privee", par exemple pour une tache parallele
 	if (GetUsed() and not GetLoaded())
 	{
-		usedNotLoadedMetaData.SetNoValueAt("_NotLoaded");
+		privateMetaData.SetNoValueAt("_NotLoaded");
 		ost << ' ';
-		usedNotLoadedMetaData.Write(ost);
+		privateMetaData.Write(ost);
 	}
 }
 
-void KWAttribute::ReadNotLoadedMetaData()
+void KWAttribute::ReadPrivateMetaData()
 {
 	if (GetMetaData()->GetKeyNumber() > 0 and GetMetaData()->IsMissingTypeAt("_NotLoaded"))
 	{

--- a/src/Learning/KWData/KWAttribute.h
+++ b/src/Learning/KWData/KWAttribute.h
@@ -214,7 +214,7 @@ protected:
 	// Ecriture si necessaire des informations prives dans les meta-data (_NotLoaded)
 	void WritePrivateMetaData(ostream& ost) const;
 
-	// Lecture et prise en compte des l'informations privees depuis les meta-data et nettoyage de ceux-ci
+	// Lecture et prise en compte des informations privees depuis les meta-data et nettoyage de ceux-ci
 	void ReadPrivateMetaData();
 
 	// Bloc d'attribut eventuel auquel l'attribut appartient

--- a/src/Learning/KWData/KWAttribute.h
+++ b/src/Learning/KWData/KWAttribute.h
@@ -208,14 +208,14 @@ protected:
 	void BuildAdvancedTypeSpecification();
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
-	// Gestion des attribut Used mais pas Loaded, pour la lecture/ecriture de dictionnaire dans les fichiers
+	// Gestion des attributs Used mais pas Loaded, pour la lecture/ecriture de dictionnaire dans les fichiers
 	// Permet de transferer cette information "privee", par exemple pour une tache parallele
 
-	// Ecriture si necessaire de l'information NotLoaded dans les meta-data
-	void WriteNotLoadedMetaData(ostream& ost) const;
+	// Ecriture si necessaire des informations prives dans les meta-data (_NotLoaded)
+	void WritePrivateMetaData(ostream& ost) const;
 
-	// Lecture et prise en compte de l'information NotLoaded depuis les meta-data et nettoyage de ceux-ci
-	void ReadNotLoadedMetaData();
+	// Lecture et prise en compte des l'informations privees depuis les meta-data et nettoyage de ceux-ci
+	void ReadPrivateMetaData();
 
 	// Bloc d'attribut eventuel auquel l'attribut appartient
 	KWAttributeBlock* attributeBlock;

--- a/src/Learning/KWData/KWCLex.inc
+++ b/src/Learning/KWData/KWCLex.inc
@@ -560,7 +560,7 @@ char *yytext;
 
 // Desactivation de warnings pour le Visual C++
 #ifdef __MSC__
-#pragma warning(disable : 4505) // C4505: la fonction locale non référencée a été supprimée
+#pragma warning(disable : 4505) // C4505: la fonction locale non referencee a ete supprimee
 #pragma warning(disable : 4996) // C4996: warning for deprecated POSIX names isatty and fileno
 #endif                          // __MSC__
 

--- a/src/Learning/KWData/KWCLex.lex
+++ b/src/Learning/KWData/KWCLex.lex
@@ -3,7 +3,7 @@
 
 // Desactivation de warnings pour le Visual C++
 #ifdef __MSC__
-#pragma warning(disable : 4505) // C4505: la fonction locale non référencée a été supprimée
+#pragma warning(disable : 4505) // C4505: la fonction locale non referencee a ete supprimee
 #pragma warning(disable : 4996) // C4996: warning for deprecated POSIX names isatty and fileno
 #endif                          // __MSC__
 

--- a/src/Learning/KWData/KWCYac.cpp
+++ b/src/Learning/KWData/KWCYac.cpp
@@ -127,7 +127,7 @@ static int nFileParsingErrorNumber = 0;
 extern char   *yyptok(int i);
 */
 
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 #ifndef YY_CAST
 #ifdef __cplusplus
@@ -566,11 +566,11 @@ static const yytype_int8 yytranslate[] = {
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] = {
     0,    143,  143,  147,  154,  158,  162,  166,  170,  174,  178,  182,  186,  190,  194,  198,  202,
-    206,  210,  216,  229,  230,  233,  236,  246,  254,  295,  374,  393,  404,  447,  494,  586,  593,
-    601,  607,  617,  630,  650,  672,  691,  708,  716,  851,  863,  870,  882,  889,  894,  901,  906,
-    913,  917,  921,  925,  929,  933,  937,  941,  945,  949,  953,  961,  966,  972,  976,  980,  985,
-    994,  999,  1005, 1025, 1041, 1149, 1153, 1199, 1206, 1217, 1230, 1243, 1254, 1268, 1277, 1286, 1296,
-    1306, 1317, 1326, 1333, 1334, 1338, 1343, 1349, 1350, 1354, 1359, 1371, 1373};
+    206,  210,  216,  229,  230,  233,  236,  246,  254,  296,  376,  395,  406,  450,  498,  591,  598,
+    606,  612,  622,  635,  655,  677,  696,  713,  721,  856,  868,  875,  887,  894,  899,  906,  911,
+    918,  922,  926,  930,  934,  938,  942,  946,  950,  954,  958,  966,  971,  977,  981,  985,  990,
+    999,  1004, 1010, 1030, 1046, 1154, 1158, 1204, 1211, 1222, 1235, 1248, 1259, 1273, 1282, 1291, 1301,
+    1311, 1322, 1331, 1338, 1339, 1343, 1348, 1354, 1355, 1359, 1364, 1376, 1378};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -923,253 +923,253 @@ static void yydestruct(const char* yymsg, yysymbol_kind_t yykind, YYSTYPE* yyval
 	switch (yykind)
 	{
 	case YYSYMBOL_BASICIDENTIFIER: /* BASICIDENTIFIER  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1046 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1046 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_EXTENDEDIDENTIFIER: /* EXTENDEDIDENTIFIER  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1052 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1052 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_STRINGLITTERAL: /* STRINGLITTERAL  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1058 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1058 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_LABEL: /* LABEL  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1064 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1064 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_APPLICATIONID: /* APPLICATIONID  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1070 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1070 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_IDENTIFIER: /* IDENTIFIER  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1076 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1076 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_SIMPLEIDENTIFIER: /* SIMPLEIDENTIFIER  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1082 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1082 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_oaAttributeArrayDeclaration: /* oaAttributeArrayDeclaration  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).oaAttributes) != NULL)
 			delete ((*yyvaluep).oaAttributes);
 		((*yyvaluep).oaAttributes) = NULL;
 	}
-#line 1088 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1088 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_keyFields: /* keyFields  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).svValue) != NULL)
 			delete ((*yyvaluep).svValue);
 		((*yyvaluep).svValue) = NULL;
 	}
-#line 1094 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1094 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_fieldList: /* fieldList  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).svValue) != NULL)
 			delete ((*yyvaluep).svValue);
 		((*yyvaluep).svValue) = NULL;
 	}
-#line 1100 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1100 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_metaData: /* metaData  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwmdMetaData) != NULL)
 			delete ((*yyvaluep).kwmdMetaData);
 		((*yyvaluep).kwmdMetaData) = NULL;
 	}
-#line 1106 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1106 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_kwattributeDeclaration: /* kwattributeDeclaration  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwaValue) != NULL)
 			delete ((*yyvaluep).kwaValue);
 		((*yyvaluep).kwaValue) = NULL;
 	}
-#line 1112 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1112 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_applicationids: /* applicationids  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1118 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1118 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_comments: /* comments  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1124 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1124 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_refIdentifier: /* refIdentifier  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1130 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1130 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_usedDerivationRule: /* usedDerivationRule  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1136 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1136 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_referenceRule: /* referenceRule  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1142 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1142 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_referenceRuleBody: /* referenceRuleBody  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1148 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1148 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRule: /* derivationRule  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1154 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1154 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleBody: /* derivationRuleBody  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1160 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1160 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_operandList: /* operandList  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).oaOperands) != NULL)
 			delete ((*yyvaluep).oaOperands);
 		((*yyvaluep).oaOperands) = NULL;
 	}
-#line 1166 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1166 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleHeader: /* derivationRuleHeader  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1172 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1172 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleBegin: /* derivationRuleBegin  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1178 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1178 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleOperand: /* derivationRuleOperand  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdroValue) != NULL)
 			delete ((*yyvaluep).kwdroValue);
 		((*yyvaluep).kwdroValue) = NULL;
 	}
-#line 1184 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1184 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_bigstring: /* bigstring  */
-#line 134 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1190 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1190 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	default:
@@ -1419,143 +1419,143 @@ yyreduce:
 	switch (yyn)
 	{
 	case 2: /* IDENTIFIER: SIMPLEIDENTIFIER  */
-#line 144 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 144 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1462 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1462 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 3: /* IDENTIFIER: EXTENDEDIDENTIFIER  */
-#line 148 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 148 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1470 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1470 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 4: /* SIMPLEIDENTIFIER: BASICIDENTIFIER  */
-#line 155 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 155 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1478 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1478 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 5: /* SIMPLEIDENTIFIER: CLASS  */
-#line 159 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 159 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Dictionary");
 	}
-#line 1486 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1486 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 6: /* SIMPLEIDENTIFIER: CONTINUOUSTYPE  */
-#line 163 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 163 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Numerical");
 	}
-#line 1494 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1494 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 7: /* SIMPLEIDENTIFIER: SYMBOLTYPE  */
-#line 167 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 167 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Categorical");
 	}
-#line 1502 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1502 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 8: /* SIMPLEIDENTIFIER: OBJECTTYPE  */
-#line 171 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 171 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Entity");
 	}
-#line 1510 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1510 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 9: /* SIMPLEIDENTIFIER: OBJECTARRAYTYPE  */
-#line 175 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 175 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Table");
 	}
-#line 1518 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1518 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 10: /* SIMPLEIDENTIFIER: ROOT  */
-#line 179 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 179 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Root");
 	}
-#line 1526 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1526 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 11: /* SIMPLEIDENTIFIER: UNUSED  */
-#line 183 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 183 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Unused");
 	}
-#line 1534 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1534 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 12: /* SIMPLEIDENTIFIER: DATETYPE  */
-#line 187 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 187 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Date");
 	}
-#line 1542 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1542 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 13: /* SIMPLEIDENTIFIER: TIMETYPE  */
-#line 191 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 191 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Time");
 	}
-#line 1550 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1550 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 14: /* SIMPLEIDENTIFIER: TIMESTAMPTYPE  */
-#line 195 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 195 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Timestamp");
 	}
-#line 1558 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1558 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 15: /* SIMPLEIDENTIFIER: TIMESTAMPTZTYPE  */
-#line 199 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 199 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("TimestampTZ");
 	}
-#line 1566 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1566 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 16: /* SIMPLEIDENTIFIER: TEXTTYPE  */
-#line 203 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 203 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Text");
 	}
-#line 1574 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1574 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 17: /* SIMPLEIDENTIFIER: TEXTLISTTYPE  */
-#line 207 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 207 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("TextList");
 	}
-#line 1582 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1582 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 18: /* SIMPLEIDENTIFIER: STRUCTURETYPE  */
-#line 211 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 211 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Structure");
 	}
-#line 1590 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1590 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 19: /* kwclassFile: applicationids kwclasses comments  */
-#line 217 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 217 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore l'identification d'application */
 		if ((yyvsp[-2].sValue) != NULL)
@@ -1565,20 +1565,20 @@ yyreduce:
 		if ((yyvsp[0].sValue) != NULL)
 			delete (yyvsp[0].sValue);
 	}
-#line 1604 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1604 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 21: /* kwclasses: kwclasses error  */
-#line 231 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 231 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Error outside the definition of a dictionary");
 		YYABORT;
 	}
-#line 1611 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1611 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 23: /* kwclass: kwclassBegin '}' semicolon  */
-#line 237 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 237 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* La completion des informations de type (CompleteTypeInfo) est centralisee */
 		/* au niveau du domaine en fin de parsing */
@@ -1586,11 +1586,11 @@ yyreduce:
 		/* Reinitialisation de la classe courante */
 		kwcLoadCurrentClass = NULL;
 	}
-#line 1623 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1623 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 24: /* kwclassBegin: kwclassHeader comments  */
-#line 247 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 247 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore les premiers comemntaires */
 		if ((yyvsp[0].sValue) != NULL)
@@ -1598,11 +1598,11 @@ yyreduce:
 		assert(kwcLoadCurrentClass == (yyvsp[-1].kwcValue));
 		(yyval.kwcValue) = (yyvsp[-1].kwcValue);
 	}
-#line 1635 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1635 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 25: /* kwclassBegin: kwclassBegin kwattributeDeclaration  */
-#line 255 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 255 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-1].kwcValue);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
@@ -1646,11 +1646,11 @@ yyreduce:
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1680 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1681 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 26: /* kwclassBegin: kwclassBegin '{' comments oaAttributeArrayDeclaration '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 296 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 297 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-9].kwcValue);
 		KWAttributeBlock* attributeBlock;
@@ -1734,11 +1734,11 @@ yyreduce:
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1763 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1765 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 27: /* kwclassBegin: kwclassBegin '{' comments '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 375 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 377 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-8].kwcValue);
 
@@ -1757,11 +1757,11 @@ yyreduce:
 			delete (yyvsp[0].sValue);
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1786 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1788 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 28: /* kwclassBegin: kwclassBegin error  */
-#line 394 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 396 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* ERRORMGT */
 		/* Attention: cette regle qui permet une gestion des erreurs amelioree */
@@ -1769,11 +1769,11 @@ yyreduce:
 		kwcLoadCurrentClass = NULL;
 		YYABORT;
 	}
-#line 1798 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1800 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 29: /* oaAttributeArrayDeclaration: oaAttributeArrayDeclaration kwattributeDeclaration  */
-#line 405 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 407 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes = (yyvsp[-1].oaAttributes);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
@@ -1819,11 +1819,11 @@ yyreduce:
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1845 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1848 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 30: /* oaAttributeArrayDeclaration: kwattributeDeclaration  */
-#line 448 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 451 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes;
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
@@ -1871,11 +1871,11 @@ yyreduce:
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1894 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1898 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 31: /* kwclassHeader: comments rootDeclaration CLASS IDENTIFIER keyFields metaData '{'  */
-#line 495 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 499 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass;
 		KWClass* kwcReferencedClass;
@@ -1966,41 +1966,41 @@ yyreduce:
 		kwcLoadCurrentClass = kwcClass;
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1987 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1992 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 32: /* keyFields: '(' fieldList ')' comments  */
-#line 587 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 592 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore les comemntaires */
 		if ((yyvsp[0].sValue) != NULL)
 			delete (yyvsp[0].sValue);
 		(yyval.svValue) = (yyvsp[-2].svValue);
 	}
-#line 1998 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2003 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 33: /* keyFields: comments  */
-#line 594 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 599 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore les comemntaires */
 		if ((yyvsp[0].sValue) != NULL)
 			delete (yyvsp[0].sValue);
 		(yyval.svValue) = NULL; /* pas de champ cle */
 	}
-#line 2009 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2014 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 34: /* keyFields: %empty  */
-#line 601 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 606 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.svValue) = NULL; /* pas de champ cle */
 	}
-#line 2017 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2022 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 35: /* fieldList: fieldList ',' IDENTIFIER  */
-#line 608 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 613 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svFields;
 
@@ -2010,11 +2010,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svFields;
 	}
-#line 2031 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2036 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 36: /* fieldList: IDENTIFIER  */
-#line 618 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 623 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svFields;
 
@@ -2024,11 +2024,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svFields;
 	}
-#line 2045 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2050 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 37: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' STRINGLITTERAL '>'  */
-#line 631 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 636 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2048,11 +2048,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2069 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2074 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 38: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' CONTINUOUSLITTERAL '>'  */
-#line 651 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 656 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2074,11 +2074,11 @@ yyreduce:
 		delete (yyvsp[-3].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2095 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2100 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 39: /* metaData: metaData '<' SIMPLEIDENTIFIER '>'  */
-#line 673 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 678 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2097,11 +2097,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2118 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2123 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 40: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' IDENTIFIER '>'  */
-#line 692 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 697 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2118,19 +2118,19 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2138 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2143 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 41: /* metaData: %empty  */
-#line 708 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 713 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwmdMetaData) = NULL; /* pas de paires cle valeurs */
 	}
-#line 2146 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2151 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 42: /* kwattributeDeclaration: usedDeclaration typeDeclaration refIdentifier IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 724 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 729 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWAttribute* attribute;
 		KWDerivationRule* rule;
@@ -2273,11 +2273,11 @@ yyreduce:
 
 		(yyval.kwaValue) = attribute;
 	}
-#line 2273 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2278 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 43: /* applicationids: applicationids APPLICATIONID  */
-#line 852 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 857 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ne garde que la premiere ligne de chaque identification d'application */
 		if ((yyvsp[-1].sValue) == NULL)
@@ -2288,19 +2288,19 @@ yyreduce:
 			(yyval.sValue) = (yyvsp[-1].sValue);
 		}
 	}
-#line 2288 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2293 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 44: /* applicationids: %empty  */
-#line 863 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 868 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL; /* pas d'identification d'application */
 	}
-#line 2296 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2301 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 45: /* comments: comments LABEL  */
-#line 871 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 876 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ne garde que la premiere ligne de chaque commentaire */
 		if ((yyvsp[-1].sValue) == NULL)
@@ -2311,180 +2311,180 @@ yyreduce:
 			(yyval.sValue) = (yyvsp[-1].sValue);
 		}
 	}
-#line 2311 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2316 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 46: /* comments: %empty  */
-#line 882 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 887 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL; /* pas de commentaire */
 	}
-#line 2319 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2324 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 47: /* rootDeclaration: ROOT  */
-#line 890 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 895 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = true;
 	}
-#line 2327 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2332 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 48: /* rootDeclaration: %empty  */
-#line 894 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 899 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = false; /* valeur par defaut */
 	}
-#line 2335 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2340 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 49: /* usedDeclaration: UNUSED  */
-#line 902 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 907 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = false;
 	}
-#line 2343 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2348 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 50: /* usedDeclaration: %empty  */
-#line 906 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 911 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = true; /* valeur par defaut */
 	}
-#line 2351 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2356 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 51: /* typeDeclaration: CONTINUOUSTYPE  */
-#line 914 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 919 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Continuous;
 	}
-#line 2359 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2364 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 52: /* typeDeclaration: SYMBOLTYPE  */
-#line 918 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 923 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Symbol;
 	}
-#line 2367 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2372 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 53: /* typeDeclaration: DATETYPE  */
-#line 922 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 927 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Date;
 	}
-#line 2375 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2380 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 54: /* typeDeclaration: TIMETYPE  */
-#line 926 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 931 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Time;
 	}
-#line 2383 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2388 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 55: /* typeDeclaration: TIMESTAMPTYPE  */
-#line 930 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 935 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Timestamp;
 	}
-#line 2391 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2396 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 56: /* typeDeclaration: TIMESTAMPTZTYPE  */
-#line 934 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 939 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::TimestampTZ;
 	}
-#line 2399 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2404 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 57: /* typeDeclaration: TEXTTYPE  */
-#line 938 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 943 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Text;
 	}
-#line 2407 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2412 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 58: /* typeDeclaration: TEXTLISTTYPE  */
-#line 942 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 947 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::TextList;
 	}
-#line 2415 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2420 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 59: /* typeDeclaration: OBJECTTYPE  */
-#line 946 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 951 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Object;
 	}
-#line 2423 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2428 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 60: /* typeDeclaration: OBJECTARRAYTYPE  */
-#line 950 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 955 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::ObjectArray;
 	}
-#line 2431 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2436 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 61: /* typeDeclaration: STRUCTURETYPE  */
-#line 954 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 959 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Structure;
 	}
-#line 2439 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2444 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 62: /* refIdentifier: '(' IDENTIFIER ')'  */
-#line 962 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 967 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[-1].sValue);
 	}
-#line 2447 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2452 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 63: /* refIdentifier: %empty  */
-#line 966 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 971 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL;
 	}
-#line 2455 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2460 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 64: /* usedDerivationRule: '=' derivationRule  */
-#line 973 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 978 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2463 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2468 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 65: /* usedDerivationRule: referenceRule  */
-#line 977 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 982 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2471 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2476 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 66: /* usedDerivationRule: '=' derivationRule ')'  */
-#line 981 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 986 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ')'");
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2480 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2485 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 67: /* usedDerivationRule: '(' IDENTIFIER ')'  */
-#line 986 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 991 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ALString sTmp;
 		yyerror(sTmp + "Invalid syntax (" + *(yyvsp[-1].sValue) + ")");
@@ -2492,27 +2492,27 @@ yyreduce:
 			delete (yyvsp[-1].sValue);
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2492 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2497 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 68: /* usedDerivationRule: %empty  */
-#line 994 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 999 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2500 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2505 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 69: /* referenceRule: referenceRuleBody ']'  */
-#line 1000 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1005 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2508 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2513 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 70: /* referenceRuleBody: '[' derivationRuleOperand  */
-#line 1006 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1011 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule;
 		KWDerivationRuleOperand* operand;
@@ -2532,11 +2532,11 @@ yyreduce:
 		/* On retourner la regle */
 		(yyval.kwdrValue) = rule;
 	}
-#line 2532 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2537 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 71: /* referenceRuleBody: referenceRuleBody ',' derivationRuleOperand  */
-#line 1026 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1031 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand;
@@ -2550,11 +2550,11 @@ yyreduce:
 		/* On retourner la regle */
 		(yyval.kwdrValue) = rule;
 	}
-#line 2550 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2555 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 72: /* derivationRule: derivationRuleBody closeparenthesis  */
-#line 1042 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1047 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		boolean bOk = true;
 		KWDerivationRule* ruleBody = (yyvsp[-1].kwdrValue);
@@ -2661,19 +2661,19 @@ yyreduce:
 		delete ruleBody;
 		(yyval.kwdrValue) = rule;
 	}
-#line 2659 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2664 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 73: /* derivationRuleBody: derivationRuleBegin  */
-#line 1150 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1155 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2667 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2672 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 74: /* derivationRuleBody: derivationRuleBegin ':' operandList  */
-#line 1154 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1159 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* ruleBody = (yyvsp[-2].kwdrValue);
 		KWDRRelationCreationRule* ruleRelationCreationBody;
@@ -2719,19 +2719,19 @@ yyreduce:
 
 		(yyval.kwdrValue) = ruleRelationCreationBody;
 	}
-#line 2717 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2722 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 75: /* derivationRuleBody: derivationRuleHeader  */
-#line 1200 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1205 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2725 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2730 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 76: /* operandList: operandList ',' derivationRuleOperand  */
-#line 1207 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1212 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaOperandList = (yyvsp[-2].oaOperands);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2742,11 +2742,11 @@ yyreduce:
 		oaOperandList->Add(operand);
 		(yyval.oaOperands) = oaOperandList;
 	}
-#line 2740 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2745 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 77: /* operandList: derivationRuleOperand  */
-#line 1218 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1223 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaOperandList;
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2757,11 +2757,11 @@ yyreduce:
 		oaOperandList->Add(operand);
 		(yyval.oaOperands) = oaOperandList;
 	}
-#line 2755 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2760 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 78: /* derivationRuleHeader: IDENTIFIER openparenthesis  */
-#line 1231 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1236 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule;
 
@@ -2771,11 +2771,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2769 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2774 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 79: /* derivationRuleBegin: derivationRuleHeader derivationRuleOperand  */
-#line 1244 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1249 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-1].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2786,11 +2786,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2784 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2789 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 80: /* derivationRuleBegin: derivationRuleBegin ',' derivationRuleOperand  */
-#line 1255 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1260 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2801,11 +2801,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2799 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2804 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 81: /* derivationRuleOperand: IDENTIFIER  */
-#line 1269 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1274 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2814,11 +2814,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2812 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2817 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 82: /* derivationRuleOperand: CONTINUOUSLITTERAL  */
-#line 1278 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1283 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2827,11 +2827,11 @@ yyreduce:
 		operand->SetContinuousConstant((yyvsp[0].cValue));
 		(yyval.kwdroValue) = operand;
 	}
-#line 2825 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2830 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 83: /* derivationRuleOperand: bigstring  */
-#line 1287 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1292 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2841,11 +2841,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2839 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2844 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 84: /* derivationRuleOperand: derivationRule  */
-#line 1297 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1302 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2855,22 +2855,22 @@ yyreduce:
 			operand->SetType(operand->GetDerivationRule()->GetType());
 		(yyval.kwdroValue) = operand;
 	}
-#line 2853 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2858 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 85: /* derivationRuleOperand: '.' derivationRuleOperand  */
-#line 1307 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1312 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = (yyvsp[0].kwdroValue);
 		operand->SetScopeLevel(operand->GetScopeLevel() + 1);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2864 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2869 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 86: /* bigstring: bigstring '+' STRINGLITTERAL  */
-#line 1318 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1323 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* Concatenation des deux chaines */
 		(yyval.sValue) = new ALString(*(yyvsp[-2].sValue) + *(yyvsp[0].sValue));
@@ -2879,59 +2879,59 @@ yyreduce:
 		delete (yyvsp[-2].sValue);
 		delete (yyvsp[0].sValue);
 	}
-#line 2877 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2882 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 87: /* bigstring: STRINGLITTERAL  */
-#line 1327 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1332 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 2885 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2890 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 89: /* semicolon: ';' ';'  */
-#line 1335 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1340 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous ';'");
 	}
-#line 2893 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2898 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 90: /* semicolon: ';' ';' ';'  */
-#line 1339 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1344 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ';'");
 	}
-#line 2901 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2906 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 91: /* semicolon: %empty  */
-#line 1343 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1348 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Missing ';'");
 	}
-#line 2909 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2914 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 93: /* openparenthesis: '(' '('  */
-#line 1351 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1356 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous '('");
 	}
-#line 2917 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2922 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 94: /* openparenthesis: '(' '(' '('  */
-#line 1355 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1360 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many '('");
 	}
-#line 2925 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2930 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 95: /* openparenthesis: %empty  */
-#line 1359 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1364 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* ERRORMGT */
 		/* Attention: supprimer cette instruction en cas d'evolution du parser */
@@ -2940,11 +2940,11 @@ yyreduce:
 		/* sa consoeur 3 shift/reduce conflicts et 12 reduce conflicts     */
 		yyerror("Missing '('");
 	}
-#line 2938 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2943 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 97: /* closeparenthesis: %empty  */
-#line 1373 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1378 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* ERRORMGT */
 		/* Attention: supprimer cette instruction en cas d'evolution du parser */
@@ -2953,10 +2953,10 @@ yyreduce:
 		/* sa consoeur 3 shift/reduce conflicts et 12 reduce conflicts     */
 		yyerror("Missing ')'");
 	}
-#line 2951 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2956 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-#line 2955 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2960 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 	default:
 		break;
@@ -3135,7 +3135,7 @@ yyreturnlab:
 	return yyresult;
 }
 
-#line 1384 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1389 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 #include "KWCLex.inc"
 
@@ -3450,13 +3450,13 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 		if (nFileParsingErrorNumber == 0)
 			kwcdLoadDomain->CompleteTypeInfo();
 
-		/* Lecture des informations sur les attributs utilises mais non charges en memoire */
+		/* Lecture des informations privees depuis les meta donnees */
 		if (nFileParsingErrorNumber == 0)
 		{
 			for (i = 0; i < kwcdLoadDomain->GetClassNumber(); i++)
 			{
 				kwcClass = kwcdLoadDomain->GetClassAt(i);
-				kwcClass->ReadNotLoadedMetaData();
+				kwcClass->ReadPrivateMetaData();
 			}
 		}
 

--- a/src/Learning/KWData/KWCYac.hpp
+++ b/src/Learning/KWData/KWCYac.hpp
@@ -86,7 +86,7 @@ typedef enum yytokentype yytoken_kind_t;
 #if !defined YYSTYPE && !defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 64 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 64 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 	Continuous cValue;
 	ALString* sValue;
@@ -101,7 +101,7 @@ union YYSTYPE
 	KWMetaData* kwmdMetaData;
 	int nValue;
 
-#line 101 "D:/Users/miib6422/Documents/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.hpp"
+#line 101 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.hpp"
 };
 typedef union YYSTYPE YYSTYPE;
 #define YYSTYPE_IS_TRIVIAL 1

--- a/src/Learning/KWData/KWCYac.yac
+++ b/src/Learning/KWData/KWCYac.yac
@@ -1705,13 +1705,13 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 	if (nFileParsingErrorNumber == 0)
 	  kwcdLoadDomain->CompleteTypeInfo();
 
-	/* Lecture des informations sur les attributs utilises mais non charges en memoire */
+	/* Lecture des informations privees depuis les meta donnees */
 	if (nFileParsingErrorNumber == 0)
 	{
 		for (i = 0; i < kwcdLoadDomain->GetClassNumber(); i++)
 		{
 			kwcClass = kwcdLoadDomain->GetClassAt(i);
-			kwcClass->ReadNotLoadedMetaData();
+			kwcClass->ReadPrivateMetaData();
 		}
 	}
 

--- a/src/Learning/KWData/KWClass.cpp
+++ b/src/Learning/KWData/KWClass.cpp
@@ -371,7 +371,7 @@ void KWClass::IndexClass()
 	ivUsedDenseAttributeNumbers.Initialize();
 	ivUsedSparseAttributeNumbers.Initialize();
 
-	// Il y a unicite dans le cas d'une classe racine, ou si l'unicite est forcee
+	// A priori, il y a unicite dans le cas d'une classe racine, ou si l'unicite est forcee (cf methode SetForceUnique)
 	bIsUnique = bRoot or bForceUnique;
 
 	// Indexage des tableaux d'attributs par parcours de la liste

--- a/src/Learning/KWData/KWClass.cpp
+++ b/src/Learning/KWData/KWClass.cpp
@@ -14,6 +14,8 @@
 KWClass::KWClass()
 {
 	bRoot = false;
+	bForceUnique = false;
+	bIsUnique = false;
 	lClassHashValue = 0;
 	nHashFreshness = 0;
 	nFreshness = 0;
@@ -369,6 +371,9 @@ void KWClass::IndexClass()
 	ivUsedDenseAttributeNumbers.Initialize();
 	ivUsedSparseAttributeNumbers.Initialize();
 
+	// Il y a unicite dans le cas d'une classe racine, ou si l'unicite est forcee
+	bIsUnique = bRoot or bForceUnique;
+
 	// Indexage des tableaux d'attributs par parcours de la liste
 	sAttributeKeyMetaDataKey = KWAttributeBlock::GetAttributeKeyMetaDataKey();
 	nNativeAttributeBlockNumber = 0;
@@ -377,6 +382,10 @@ void KWClass::IndexClass()
 	while (attribute != NULL)
 	{
 		assert(attribute->GetType() != KWType::Unknown);
+
+		// Il y a unicite dans le cas d'utilisation d'attribut relation non calcule
+		if (KWType::IsRelation(attribute->GetType()) and attribute->GetAnyDerivationRule() == NULL)
+			bIsUnique = true;
 
 		// Calcul du nombre d'attributs natifs
 		if (attribute->IsInBlock())
@@ -595,6 +604,9 @@ void KWClass::IndexClass()
 		cout << "Index dictionary\t" << GetName() << "\n";
 		if (GetDomain() != NULL)
 			cout << " Domain\t" << GetDomain()->GetName() << "\n";
+		cout << " Root\t" << BooleanToString(GetRoot()) << "\n";
+		cout << " ForceUnique\t" << BooleanToString(GetForceUnique()) << "\n";
+		cout << " IsUnique\t" << BooleanToString(IsUnique()) << "\n";
 		WriteAttributes("  Used attributes", &oaUsedAttributes, cout);
 		WriteAttributes("  Loaded attributes", &oaLoadedAttributes, cout);
 		WriteAttributes("  Loaded dense attributes", &oaLoadedDenseAttributes, cout);
@@ -1518,6 +1530,8 @@ void KWClass::CopyFrom(const KWClass* aSource)
 	usName = aSource->usName;
 	usLabel = aSource->usLabel;
 	bRoot = aSource->bRoot;
+	bForceUnique = aSource->bForceUnique;
+	bIsUnique = aSource->bIsUnique;
 
 	// Duplication des meta-donnees
 	metaData.CopyFrom(&aSource->metaData);

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -570,12 +570,18 @@ protected:
 	int GetUnloadedOwnedRelationAttributeNumber() const;
 	KWAttribute* GetUnloadedOwnedRelationAttributeAt(int nIndex) const;
 
-	// Prise en compte des attributs utilises non charges en memoire suite a une lecture de dictionnaire (cf.
-	// KWAttribute::ReadNotLoadedMetaData)
-	void ReadNotLoadedMetaData();
-
 	// Affichage d'un tableau d'attributs
 	void WriteAttributes(const ALString& sTitle, const ObjectArray* oaAttributes, ostream& ost) const;
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Gestion du ForceUnique de la classe pour la lecture/ecriture de dictionnaire dans les fichiers
+	// Permet de transferer cette information "privee", par exemple pour une tache parallele
+
+	// Ecriture si necessaire des informations prives dans les meta-data (_ForceUnique, plus celles des attributs)
+	void WritePrivateMetaData(ostream& ost) const;
+
+	// Lecture et prise en compte des l'informations privees depuis les meta-data et nettoyage de ceux-ci
+	void ReadPrivateMetaData();
 
 	// Nom de la classe
 	KWCDUniqueString usName;

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -81,6 +81,17 @@ public:
 	boolean GetRoot() const;
 	void SetRoot(boolean bValue);
 
+	// Unicite des instances de la classe
+	// - soit la classe est racine
+	// - soit elle contient des attributs de type relation non calcules, ce qui implique une unicite
+	//   de ses instances pour que chaque enregistrement de sous-table soit rattache de facon
+	//   unique a son enregistrement parent dans le schema multi-table hierachique
+	// L'unicite est controlee uniquement au moment de la lecture des donnes a partir d'une base
+	// pour des dictionnaire ayant des cles. Cela ne concerne pas les dictionnaires avec ou sans cle
+	// utilise pour la construction de table en memoire
+	// Cette caracteristique est calculee au moment de l'indexation de la classe
+	boolean IsUnique() const;
+
 	/////////////////////////////////////////////////////////////
 	// Specification des attributs de la cle de la classe
 	// Facultatif: utile dans pour les chainage entre classes dans le cas
@@ -478,6 +489,13 @@ protected:
 	// Seule la classe KWDatabase a l'usage des deux listes ci-dessous
 	friend class KWDatabase;
 
+	// Parametrage force du caractere unique d'une classe
+	// Parametrage avance, utilise par exemple pour une classe unique en raison de
+	// ses sous-tables non calculees, mais pour la quelle ces sous tables ont ete
+	// supprimees pour optimiser les lectures de donnees
+	boolean GetForceUnique() const;
+	void SetForceUnique(boolean bValue);
+
 	// Liste des elements de donnees devant etre calcules
 	ObjectArray* GetDatabaseDataItemsToCompute();
 	const ObjectArray* GetConstDatabaseDataItemsToCompute() const;
@@ -570,6 +588,12 @@ protected:
 
 	// Statut racine ou composant
 	boolean bRoot;
+
+	// Statut unique force
+	boolean bForceUnique;
+
+	// Statut unique: racine, ou ayant des attribut relation natifs, imposant l'unicite
+	boolean bIsUnique;
 
 	// Nom des attributs cles (potentiellement specifies avant la specification des attributs de la classe)
 	StringVector svKeyAttributeNames;
@@ -682,6 +706,12 @@ inline void KWClass::SetRoot(boolean bValue)
 {
 	bRoot = bValue;
 	UpdateFreshness();
+}
+
+inline boolean KWClass::IsUnique() const
+{
+	require(IsIndexed());
+	return bIsUnique;
 }
 
 inline int KWClass::GetKeyAttributeNumber() const
@@ -883,6 +913,17 @@ inline KWDataItem* KWClass::GetDataItemAtLoadIndex(KWLoadIndex liIndex) const
 {
 	require(liIndex.IsValid());
 	return cast(KWDataItem*, oaLoadedDataItems.GetAt(liIndex.GetDenseIndex()));
+}
+
+inline boolean KWClass::GetForceUnique() const
+{
+	return bForceUnique;
+}
+
+inline void KWClass::SetForceUnique(boolean bValue)
+{
+	bForceUnique = bValue;
+	UpdateFreshness();
 }
 
 inline ObjectArray* KWClass::GetDatabaseDataItemsToCompute()

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -580,7 +580,7 @@ protected:
 	// Ecriture si necessaire des informations prives dans les meta-data (_ForceUnique, plus celles des attributs)
 	void WritePrivateMetaData(ostream& ost) const;
 
-	// Lecture et prise en compte des l'informations privees depuis les meta-data et nettoyage de ceux-ci
+	// Lecture et prise en compte des informations privees depuis les meta-data et nettoyage de ceux-ci
 	void ReadPrivateMetaData();
 
 	// Nom de la classe
@@ -598,7 +598,10 @@ protected:
 	// Statut unique force
 	boolean bForceUnique;
 
-	// Statut unique: racine, ou ayant des attribut relation natifs, imposant l'unicite
+	// Statut unique:
+	// - racine: unicite necessaire pour les references aux tables externes
+	// - classe ayant des attribut relation natifs: unicite necessaire pour que chaque
+	//   enregistrement secondaire soit rattache de facon unique a son enregistrement parent
 	boolean bIsUnique;
 
 	// Nom des attributs cles (potentiellement specifies avant la specification des attributs de la classe)

--- a/src/Learning/KWData/KWClassDomain.cpp
+++ b/src/Learning/KWData/KWClassDomain.cpp
@@ -94,7 +94,7 @@ boolean KWClassDomain::WriteFile(const ALString& sFileName) const
 	return bOk;
 }
 
-boolean KWClassDomain::WriteFileFromClass(const KWClass* rootClass, const ALString& sFileName) const
+boolean KWClassDomain::WriteFileFromClass(const KWClass* mainClass, const ALString& sFileName) const
 {
 	fstream fst;
 	boolean bOk;
@@ -105,8 +105,8 @@ boolean KWClassDomain::WriteFileFromClass(const KWClass* rootClass, const ALStri
 
 	// Pas de gestion des fichiers cloud, car utilise actuellement uniquement en local
 	require(FileService::GetURIScheme(sFileName) == "");
-	require(rootClass != NULL);
-	require(rootClass->GetDomain() == this);
+	require(mainClass != NULL);
+	require(mainClass->GetDomain() == this);
 
 	// Affichage de stats memoire
 	MemoryStatsManager::AddLog(GetClassLabel() + " " + sFileName + " WriteFileFromClass Begin");
@@ -118,7 +118,7 @@ boolean KWClassDomain::WriteFileFromClass(const KWClass* rootClass, const ALStri
 	if (bOk)
 	{
 		// Calcul des classes dependantes
-		ComputeClassDependence(rootClass, &odDependentClasses);
+		ComputeClassDependence(mainClass, &odDependentClasses);
 
 		// Export dans un tableau ou l'on tri les dictionnaires
 		odDependentClasses.ExportObjectArray(&oaDependentClasses);
@@ -751,7 +751,7 @@ KWClassDomain* KWClassDomain::Clone() const
 	return kwcdClone;
 }
 
-KWClassDomain* KWClassDomain::CloneFromClass(const KWClass* rootClass) const
+KWClassDomain* KWClassDomain::CloneFromClass(const KWClass* mainClass) const
 {
 	KWClassDomain* kwcdClone;
 	ObjectArray oaImpactedClasses;
@@ -761,8 +761,8 @@ KWClassDomain* KWClassDomain::CloneFromClass(const KWClass* rootClass) const
 	KWClass* kwcCloneRef;
 	KWAttribute* attribute;
 
-	require(rootClass != NULL);
-	require(rootClass->GetDomain() == this);
+	require(mainClass != NULL);
+	require(mainClass->GetDomain() == this);
 
 	kwcdClone = new KWClassDomain;
 
@@ -771,7 +771,7 @@ KWClassDomain* KWClassDomain::CloneFromClass(const KWClass* rootClass) const
 	kwcdClone->usLabel = usLabel;
 
 	// Duplication de la classe racine
-	kwcCloneElement = rootClass->Clone();
+	kwcCloneElement = mainClass->Clone();
 	kwcdClone->InsertClass(kwcCloneElement);
 	oaImpactedClasses.Add(kwcCloneElement);
 
@@ -880,7 +880,7 @@ void KWClassDomain::ImportDomain(KWClassDomain* kwcdInputDomain, const ALString&
 	ensure(kwcdInputDomain->GetClassNumber() == 0);
 }
 
-void KWClassDomain::ComputeClassDependence(const KWClass* rootClass, ObjectDictionary* odDependentClasses) const
+void KWClassDomain::ComputeClassDependence(const KWClass* mainClass, ObjectDictionary* odDependentClasses) const
 {
 	ObjectArray oaDependentClasses;
 	int nClass;
@@ -888,15 +888,15 @@ void KWClassDomain::ComputeClassDependence(const KWClass* rootClass, ObjectDicti
 	KWClass* kwcRef;
 	KWAttribute* attribute;
 
-	require(rootClass != NULL);
-	require(rootClass->GetDomain() == this);
+	require(mainClass != NULL);
+	require(mainClass->GetDomain() == this);
 	require(odDependentClasses != NULL);
 
 	// Enregistrement de la classe racine
 	// (en la castant, pour contourner le const du parametre)
 	odDependentClasses->RemoveAll();
-	odDependentClasses->SetAt(rootClass->GetName(), cast(KWClass*, rootClass));
-	oaDependentClasses.Add(cast(KWClass*, rootClass));
+	odDependentClasses->SetAt(mainClass->GetName(), cast(KWClass*, mainClass));
+	oaDependentClasses.Add(cast(KWClass*, mainClass));
 
 	// Parcours des classes dependantes en memorisant les classes
 	// pour lesquelles il faut propager le calcul de dependance
@@ -959,7 +959,7 @@ longint KWClassDomain::GetUsedMemory() const
 	return lUsedMemory;
 }
 
-longint KWClassDomain::GetClassDependanceUsedMemory(const KWClass* rootClass) const
+longint KWClassDomain::GetClassDependanceUsedMemory(const KWClass* mainClass) const
 {
 	longint lUsedMemory;
 	longint lClassUsedMemory;
@@ -968,11 +968,11 @@ longint KWClassDomain::GetClassDependanceUsedMemory(const KWClass* rootClass) co
 	int nClass;
 	KWClass* kwcElement;
 
-	require(rootClass != NULL);
-	require(rootClass->GetDomain() == this);
+	require(mainClass != NULL);
+	require(mainClass->GetDomain() == this);
 
 	// Calcul des classes dependantes
-	ComputeClassDependence(rootClass, &odDependentClasses);
+	ComputeClassDependence(mainClass, &odDependentClasses);
 
 	// Parcours des classes dependantes en memorisant les classes
 	// pour lesquelles il faut propager le calcul de dependance

--- a/src/Learning/KWData/KWClassDomain.cpp
+++ b/src/Learning/KWData/KWClassDomain.cpp
@@ -770,7 +770,7 @@ KWClassDomain* KWClassDomain::CloneFromClass(const KWClass* mainClass) const
 	kwcdClone->usName = usName;
 	kwcdClone->usLabel = usLabel;
 
-	// Duplication de la classe racine
+	// Duplication de la classe principale
 	kwcCloneElement = mainClass->Clone();
 	kwcdClone->InsertClass(kwcCloneElement);
 	oaImpactedClasses.Add(kwcCloneElement);
@@ -892,7 +892,7 @@ void KWClassDomain::ComputeClassDependence(const KWClass* mainClass, ObjectDicti
 	require(mainClass->GetDomain() == this);
 	require(odDependentClasses != NULL);
 
-	// Enregistrement de la classe racine
+	// Enregistrement de la classe principale
 	// (en la castant, pour contourner le const du parametre)
 	odDependentClasses->RemoveAll();
 	odDependentClasses->SetAt(mainClass->GetName(), cast(KWClass*, mainClass));

--- a/src/Learning/KWData/KWClassDomain.h
+++ b/src/Learning/KWData/KWClassDomain.h
@@ -138,7 +138,7 @@ public:
 	// Le domaine source est vide a l'issue de l'import
 	void ImportDomain(KWClassDomain* kwcdInputDomain, const ALString& sClassPrefix, const ALString& sClassSuffix);
 
-	// Calcul de l'ensemble des classes (y compris la racine) dependante d'une classe
+	// Calcul de l'ensemble des classes (y compris la classe principale) dependante d'une classe
 	// Le resultat est un dictionnaire referencant les classes resultats par leur nom
 	void ComputeClassDependence(const KWClass* mainClass, ObjectDictionary* odDependentClasses) const;
 

--- a/src/Learning/KWData/KWClassDomain.h
+++ b/src/Learning/KWData/KWClassDomain.h
@@ -64,7 +64,7 @@ public:
 	boolean WriteFile(const ALString& sFileName) const;
 
 	// Ecriture dans un fichier d'une classe avec toutes ses classes dependantes
-	boolean WriteFileFromClass(const KWClass* rootClass, const ALString& sFileName) const;
+	boolean WriteFileFromClass(const KWClass* mainClass, const ALString& sFileName) const;
 
 	// Ecriture dans un fichier au format JSON
 	boolean WriteJSONFile(const ALString& sJSONFileName) const;
@@ -131,7 +131,7 @@ public:
 
 	// Duplication partielle d'un domaine a partir d'une classe
 	// La classe et ses classes referencees recursivement sont dupliquees de facon coherente
-	KWClassDomain* CloneFromClass(const KWClass* rootClass) const;
+	KWClassDomain* CloneFromClass(const KWClass* mainClass) const;
 
 	// Import de toutes les classes d'un domaine, en y ajoutant un prefixe  et un suffixe
 	// et en les renommant si necessaire
@@ -140,13 +140,13 @@ public:
 
 	// Calcul de l'ensemble des classes (y compris la racine) dependante d'une classe
 	// Le resultat est un dictionnaire referencant les classes resultats par leur nom
-	void ComputeClassDependence(const KWClass* rootClass, ObjectDictionary* odDependentClasses) const;
+	void ComputeClassDependence(const KWClass* mainClass, ObjectDictionary* odDependentClasses) const;
 
 	// Memoire utilisee par le domaine
 	longint GetUsedMemory() const override;
 
 	// Memoire utilisee par la classe et toutes ses classes referencees recursivement
-	longint GetClassDependanceUsedMemory(const KWClass* rootClass) const;
+	longint GetClassDependanceUsedMemory(const KWClass* mainClass) const;
 
 	// Cle de hashage du domaine et de sa composition
 	longint ComputeHashValue() const;

--- a/src/Learning/KWData/KWDataTableDriver.cpp
+++ b/src/Learning/KWData/KWDataTableDriver.cpp
@@ -178,9 +178,9 @@ KWObject* KWDataTableDriver::Read()
 
 void KWDataTableDriver::Skip() {}
 
-const KWObjectKey* KWDataTableDriver::GetLastReadRootKey() const
+const KWObjectKey* KWDataTableDriver::GetLastReadMainKey() const
 {
-	return &lastReadRootKey;
+	return &lastReadMainKey;
 }
 
 void KWDataTableDriver::Write(const KWObject* kwoObject)

--- a/src/Learning/KWData/KWDataTableDriver.h
+++ b/src/Learning/KWData/KWDataTableDriver.h
@@ -164,10 +164,10 @@ public:
 	// Lecture sans production d'un objet physique, pour sauter un enregistrement
 	virtual void Skip();
 
-	// Cle du dernier objet lu physiquement, uniquement dans le cas d'une classe racine
+	// Cle du dernier objet lu physiquement, uniquement dans le cas d'une classe principale d'un schema multi-table
 	// Permet de verifier l'ordre et la duplication des instances dans le fichier
 	// Mise a jour apres toute analyse d'une ligne, soit par Skip ou par Read (meme si la lecture echoue)
-	virtual const KWObjectKey* GetLastReadRootKey() const;
+	virtual const KWObjectKey* GetLastReadMainKey() const;
 
 	// Ecriture d'une instance (de la classe initiale)
 	virtual void Write(const KWObject* kwoObject);
@@ -227,8 +227,8 @@ protected:
 	ALString sDataTableName;
 	const KWClass* kwcClass;
 
-	// Cle correspondant a la derniere ligne lue, dans le cas d'une classe racine
-	KWObjectKey lastReadRootKey;
+	// Cle correspondant a la derniere ligne lue, dans le cas d'une classe principale d'un schema multi-table
+	KWObjectKey lastReadMainKey;
 
 	// Des entiers long sont utilises, pour la gestion de fichiers ayant
 	// potentiellement plus de deux milliards d'enregistrements (limite des int)

--- a/src/Learning/KWData/KWDataTableDriverTextFile.h
+++ b/src/Learning/KWData/KWDataTableDriverTextFile.h
@@ -125,9 +125,9 @@ public:
 	/////////////////////////////////////////////////
 	///// Implementation
 protected:
-	// Implementation specifique du saut de ligne dans le cas d'une classe racine
+	// Implementation specifique du saut de ligne dans le cas d'une classe principale
 	// En effet, dans ce cas, on analyse partiellement la ligne pour en extraire la derniere cle
-	void SkipRootRecord();
+	void SkipMainRecord();
 
 	// Remplissage du buffer si necessaire (fin de buffer et pas fin de fichier)
 	virtual boolean UpdateInputBuffer();
@@ -147,7 +147,7 @@ protected:
 	// Calcul des indexes des data items (attributs ou blocs d'attributs) de la classe logique associee
 	// a chaque champ du fichier en comparant la classe logique comportant les champs necessaires
 	// et une classe representant le header du fichier a analyser (optionnelle si pas de ligne d'entete)
-	// On calcule egalement les index des attributs de la cle dans le cas d'un classe racine
+	// On calcule egalement les index des attributs de la cle dans le cas d'un classe principale
 	virtual boolean ComputeDataItemLoadIndexes(const KWClass* kwcLogicalClass, const KWClass* kwcHeaderLineClass);
 
 	// Ouverture du fichier en lecture ou ecriture: retourne true si OK
@@ -172,14 +172,14 @@ protected:
 	// Index invalide si champ du fichier inutilise ou inexistant dans la classe
 	KWLoadIndexVector livDataItemLoadIndexes;
 
-	// Index des champs de la cle dans le cas d'une classe racine
+	// Index des champs de la cle dans le cas d'une classe principale d'un schema multi-table
 	// A chaque index de champ de fichier, on associe soit -1 si le champ ne fait pas partie de la cle,
 	// soit l'index du champs de la cle
 	// On a en effet besoin de memoriser les champs de la cle dans ce cas, que ce soit lors des
 	// lecture par Read (que l'enregistrement soit errone ou non) ou lors des sauts de ligne
 	// C'est necessaire pour faire le controle des enregistrements dupliques, et de ne garder
 	// que le premier (si valide), et ignorant tous les suivants consideres comme dupliques
-	IntVector ivRootKeyIndexes;
+	IntVector ivMainKeyIndexes;
 
 	// Fichier utilise pour la gestion de la base
 	InputBufferedFile* inputBuffer;

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -1696,6 +1696,11 @@ void KWDatabase::BuildPhysicalClass()
 				nkdLoadedAttributeBlocks.SetAt(attributeBlock, attributeBlock);
 			}
 
+			// On force l'unicite de la clase physique si necessaire
+			// En effet, apres nettoyage, celle-ci ne sera potentiellement plus en mesure de deduire
+			// son unicite de sa composition en attributs relation non calcules, si ceux-ci ont ete detruits
+			kwcCurrentPhysicalClass->SetForceUnique(kwcInitialClass->IsUnique());
+
 			// Si la classe n'est pas necessaire au niveau logique,
 			// ses attributs de base ne sont pas a charger
 			if (nkdNeededUsedClasses.Lookup(kwcCurrentPhysicalClass) == NULL)

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -1481,7 +1481,7 @@ void KWDatabase::BuildPhysicalClass()
 	kwcPhysicalClass = kwcdPhysicalDomain->LookupClass(GetClassName());
 	assert(kwcClass->GetLoadedAttributeNumber() == kwcPhysicalClass->GetLoadedAttributeNumber());
 
-	// Initialisation de l'ensemble des classes physiques necessaires avec la classe physique "racine"
+	// Initialisation de l'ensemble des classes physiques necessaires avec la classe physique principale
 	// Les classes physiques correspondent a tout ce qui doit etre lu physiquement directement ou indirectement
 	// pour le calcul des regles de derivation
 	nkdAllNeededClasses.SetAt(kwcPhysicalClass, kwcPhysicalClass);
@@ -1530,7 +1530,7 @@ void KWDatabase::BuildPhysicalClass()
 			}
 		}
 
-		// Ajout des operandes utilise pour le calcul de l'attribut de selection pour la classe racine
+		// Ajout des operandes utilise pour le calcul de l'attribut de selection pour la classe principale
 		if (kwcCurrentPhysicalClass == kwcPhysicalClass)
 		{
 			attribute = kwcPhysicalClass->LookupAttribute(GetSelectionAttribute());
@@ -1540,7 +1540,7 @@ void KWDatabase::BuildPhysicalClass()
 											  &nkdClassNeededAttributes);
 		}
 
-		// Ajout de l'attribut de selection pour la classe racine
+		// Ajout de l'attribut de selection pour la classe principale
 		if (kwcCurrentPhysicalClass == kwcPhysicalClass)
 		{
 			attribute = kwcPhysicalClass->LookupAttribute(GetSelectionAttribute());
@@ -1548,7 +1548,7 @@ void KWDatabase::BuildPhysicalClass()
 				nkdAllNeededAttributes.SetAt(attribute, attribute);
 		}
 
-		// Ajout de la cle pour toute classe chargeable depuis la classe racine
+		// Ajout de la cle pour toute classe chargeable depuis la classe principale
 		for (i = 0; i < kwcCurrentPhysicalClass->GetKeyAttributeNumber(); i++)
 		{
 			keyAttribute = kwcCurrentPhysicalClass->GetKeyAttributeAt(i);

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -2290,7 +2290,7 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 
 		// Gestion de la coherence pour toute classe principale ayant une cle
 		// Le cas des classes composant est traite plus loin
-		if (mapping == rootMultiTableMapping or kwoObject->GetClass()->GetRoot())
+		if (mapping == rootMultiTableMapping or kwoObject->GetClass()->IsUnique())
 		{
 			// Test a partir du deuxieme enregistrement effectivement lu, pour lequel le LastReadKey est
 			// initialise)
@@ -2300,7 +2300,7 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 
 				// Warning si la cle egale dans le cas d'une classe racine, et supression de
 				// l'enregistrement
-				if (kwoObject->GetClass()->GetRoot() and
+				if (kwoObject->GetClass()->IsUnique() and
 				    objectKey.StrictCompare(mapping->GetLastReadKey()) == 0)
 				{
 					// Warning de lecture
@@ -2336,9 +2336,11 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 			if (kwoObject == NULL)
 				return NULL;
 
-			// Incrementation du compteur d'objet utilise au niveau physique
-			mapping->GetDataTableDriver()->SetUsedRecordNumber(
-			    mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
+			// Incrementation du compteur d'objet utilise au niveau physique pour la classe principale
+			// L'incrementation pour les mapping de la composiitonn est effectuee par la suite
+			if (mapping == mainMultiTableMapping)
+				mapping->GetDataTableDriver()->SetUsedRecordNumber(
+				    mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
 		}
 
 		// Parcours des mappings de la composition  pour completer la lecture de l'objet

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -1317,8 +1317,8 @@ void KWMTDatabase::MutatePhysicalObject(KWObject* kwoPhysicalObject) const
 	assert(KWDRReference::GetObjectReferenceResolver() == NULL);
 	KWDRReference::SetObjectReferenceResolver(&objectReferenceResolver);
 
-	// Referencement du nouvel objet principal lu depuis le resolveur de reference
-	if (not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
+	// Referencement du nouvel objet principal lu depuis le resolveur de reference, s'il est Root
+	if (kwcPhysicalClass->GetRoot() and not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
 		objectReferenceResolver.AddObject(kwcPhysicalClass, mainMultiTableMapping->GetLastReadKey(),
 						  kwoPhysicalObject);
 
@@ -1328,7 +1328,7 @@ void KWMTDatabase::MutatePhysicalObject(KWObject* kwoPhysicalObject) const
 	// Dereferencement du precedent objet principal lu depuis le resolveur de reference
 	// En effet, l'objet precedement lu est potentiellement detruit et inutilisable pour
 	// la resolution des references (intra-objet dans le cas de l'objet principal)
-	if (not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
+	if (kwcPhysicalClass->GetRoot() and not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
 		objectReferenceResolver.RemoveObject(kwcPhysicalClass, mainMultiTableMapping->GetLastReadKey());
 
 	// Remise a NULL du resolveur de reference dans la regle de derivation gerant les references
@@ -1358,7 +1358,7 @@ boolean KWMTDatabase::IsPhysicalObjectSelected(KWObject* kwoPhysicalObject)
 		KWDRReference::SetObjectReferenceResolver(&objectReferenceResolver);
 
 		// Referencement du nouvel objet principal lu depuis le resolveur de reference
-		if (not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
+		if (kwcPhysicalClass->GetRoot() and not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
 			objectReferenceResolver.AddObject(kwcPhysicalClass, mainMultiTableMapping->GetLastReadKey(),
 							  kwoPhysicalObject);
 
@@ -1375,7 +1375,7 @@ boolean KWMTDatabase::IsPhysicalObjectSelected(KWObject* kwoPhysicalObject)
 		// Dereferencement du precedent objet principal lu depuis le resolveur de reference
 		// En effet, l'objet precedement lu est potentiellement detruit et inutilisable pour
 		// la resolution des references (intra-objet dans le cas de l'objet principal)
-		if (not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
+		if (kwcPhysicalClass->GetRoot() and not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
 			objectReferenceResolver.RemoveObject(kwcPhysicalClass, mainMultiTableMapping->GetLastReadKey());
 
 		// Remise a NULL du resolveur de reference dans la regle de derivation gerant les references
@@ -1540,9 +1540,9 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 	// peut potentiellement en declencher un grand nombre
 	Global::ActivateErrorFlowControl();
 
-	// Enregistrement du dictionnaire physique principal dans le resolveur de reference
+	// Enregistrement du dictionnaire physique principal dans le resolveur de reference, s'il est Root
 	// Cela permettra de resoudre les references intra-classe pour la classe principale
-	if (kwcPhysicalClass->GetKeyAttributeNumber() > 0)
+	if (kwcPhysicalClass->GetRoot())
 		objectReferenceResolver.AddClass(kwcPhysicalClass);
 
 	// Ouverture de chaque table secondaire

--- a/src/Learning/KWData/KWMTDatabase.h
+++ b/src/Learning/KWData/KWMTDatabase.h
@@ -218,7 +218,7 @@ protected:
 
 	// Mapping racine pour la table principale
 	// Ce mapping doit toujours etre present et contient le parametrage (nom de base, nom de classe) principal
-	// L'utilisation d'un mapping pour la racine permet d'unifier les traitement entre tables principales
+	// L'utilisation d'un mapping pour la racine permet d'unifier les traitements entre tables principales
 	// et tables secondaires
 	mutable KWMTDatabaseMapping* rootMultiTableMapping;
 

--- a/src/Learning/KWData/KWMTDatabase.h
+++ b/src/Learning/KWData/KWMTDatabase.h
@@ -216,9 +216,9 @@ protected:
 	/////////////////////////////////////////////////
 	// Attributs de l'implementation
 
-	// Mapping racine pour la table principale
+	// Mapping pour la table principale
 	// Ce mapping doit toujours etre present et contient le parametrage (nom de base, nom de classe) principal
-	// L'utilisation d'un mapping pour la racine permet d'unifier les traitements entre tables principales
+	// L'utilisation d'un mapping pour la classe principale permet d'unifier les traitements entre tables principales
 	// et tables secondaires
 	mutable KWMTDatabaseMapping* mainMultiTableMapping;
 
@@ -227,7 +227,7 @@ protected:
 	mutable ObjectArray oaRootRefTableMappings;
 
 	// Mapping multi-tables: tableau exhaustif de tous les mappings (permet une interface d'edition "a plat")
-	// Attention, le mapping racine est toujours integree comme premier element du tableau,
+	// Attention, le mapping de la classe principale est toujours integree comme premier element du tableau,
 	// et ne doit toujours etre synchronise
 	mutable ObjectArray oaMultiTableMappings;
 

--- a/src/Learning/KWData/KWMTDatabase.h
+++ b/src/Learning/KWData/KWMTDatabase.h
@@ -220,9 +220,9 @@ protected:
 	// Ce mapping doit toujours etre present et contient le parametrage (nom de base, nom de classe) principal
 	// L'utilisation d'un mapping pour la racine permet d'unifier les traitements entre tables principales
 	// et tables secondaires
-	mutable KWMTDatabaseMapping* rootMultiTableMapping;
+	mutable KWMTDatabaseMapping* mainMultiTableMapping;
 
-	// Mapping racine des tables secondaires (reference a un sous-ensemble des mapping du tableau
+	// Mapping racine des tables secondaires (reference a un sous-ensemble des mappings du tableau
 	// oaMultiTableMappings)
 	mutable ObjectArray oaRootRefTableMappings;
 

--- a/src/Learning/KWData/KWMTDatabaseMapping.cpp
+++ b/src/Learning/KWData/KWMTDatabaseMapping.cpp
@@ -88,14 +88,6 @@ ALString KWMTDatabaseMapping::GetDataPath() const
 		return GetDataPathAttributeNames();
 }
 
-ALString KWMTDatabaseMapping::GetDataRoot() const
-{
-	if (GetExternalTable())
-		return "";
-	else
-		return GetFormattedName(GetOriginClassName());
-}
-
 ALString KWMTDatabaseMapping::GetDataPathAttributeNames() const
 {
 	ALString sDataPathAttributeNames;
@@ -247,8 +239,7 @@ void KWMTDatabaseMapping::Write(ostream& ost) const
 	int n;
 
 	ost << "Data path\t" << GetDataPath() << "\n";
-	ost << "Data root\t" << GetDataRoot() << "\n";
-	ost << "External table\t" << BooleanToString(GetExternalTable());
+	ost << "External table\t" << BooleanToString(GetExternalTable()) << "\n";
 	ost << "Data path origin dictionary\t" << GetOriginClassName() << "\n";
 	ost << "Data path variables\t" << GetDataPathAttributeNumber() << "\n";
 	for (n = 0; n < GetDataPathAttributeNumber(); n++)

--- a/src/Learning/KWData/KWMTDatabaseMapping.h
+++ b/src/Learning/KWData/KWMTDatabaseMapping.h
@@ -146,7 +146,7 @@ protected:
 	ObjectArray* GetComponentTableMappings();
 
 	// Collecte de tous les mapping de la hierarchie de composition,
-	// y compris le mapping courant (racine de la hierarchie)
+	// y compris le mapping courant (mapping principal de la hierarchie)
 	void CollectFullHierarchyComponentTableMappings(ObjectArray* oaResults);
 
 	// Base de donnees associee au mapping

--- a/src/Learning/KWData/KWMTDatabaseMapping.h
+++ b/src/Learning/KWData/KWMTDatabaseMapping.h
@@ -34,9 +34,6 @@ public:
 	// Data path, calcule d'apres les specifications
 	ALString GetDataPath() const;
 
-	// Data root, qui est le dictionnaire origine dans le cas des tables externes
-	ALString GetDataRoot() const;
-
 	// Partie du data path relative aux attributs, calculee d'apres les specifications
 	ALString GetDataPathAttributeNames() const;
 
@@ -48,6 +45,8 @@ public:
 	void SetExternalTable(boolean bValue);
 
 	// Dictionnaire origine du data path
+	// - dictionnaire Root si on est dans le cas d'une table externe
+	// - dictionnaire principal sinon
 	const ALString& GetOriginClassName() const;
 	void SetOriginClassName(const ALString& sValue);
 
@@ -73,7 +72,7 @@ public:
 	// Dans un schema en flocon,
 	//   les data paths  consistent en une liste de noms de variables avec un separateur "/".
 	// Pour les tables externes,
-	//   les data paths commencent par un DataRoot prefixe par "/", qui fait reference a un nom de dictionnaire Root
+	//   les data paths commencent par un un nom de dictionnaire Root prefixe par "/"
 	// Exemples de DataPath pour differents types de mapping:
 	//    classe principale:
 	//    sous-objet: Address
@@ -99,9 +98,9 @@ public:
 	boolean CheckDataPath() const;
 
 	// Conversion d'un element de data path vers le format externe
-	// Cela concerne les noms de dictionnaire (DataRoot) ou de variable
+	// Cela concerne les noms de dictionnaire ou de variable
 	// S'il contiennent le caractere '`' ou le separateur '/', il doivent
-	// etre mis au format externe defini pour les dictionnaire, enre '`'
+	// etre mis au format externe defini pour les dictionnaires, entre '`'
 	static ALString GetFormattedName(const ALString& sValue);
 
 	// Separateur utilise dans les data paths

--- a/src/Learning/KWData/KWMTDatabaseTextFile.cpp
+++ b/src/Learning/KWData/KWMTDatabaseTextFile.cpp
@@ -30,7 +30,7 @@ void KWMTDatabaseTextFile::AddPrefixToUsedFiles(const ALString& sPrefix)
 	// Renommage si nom existant
 	if (GetDatabaseName() != "")
 	{
-		// Personnalisation des noms de table du mapping (qui comprennent la table racine)
+		// Personnalisation des noms de table du mapping (qui comprennent la table principale)
 		for (nMapping = 0; nMapping < GetMultiTableMappings()->GetSize(); nMapping++)
 		{
 			mapping = cast(KWMTDatabaseMapping*, GetMultiTableMappings()->GetAt(nMapping));
@@ -64,7 +64,7 @@ void KWMTDatabaseTextFile::AddSuffixToUsedFiles(const ALString& sSuffix)
 	// Renommage si nom existant
 	if (GetDatabaseName() != "")
 	{
-		// Personnalisation des noms de table du mapping (qui comprennent la table racine)
+		// Personnalisation des noms de table du mapping (qui comprennent la table principale)
 		for (nMapping = 0; nMapping < GetMultiTableMappings()->GetSize(); nMapping++)
 		{
 			mapping = cast(KWMTDatabaseMapping*, GetMultiTableMappings()->GetAt(nMapping));
@@ -101,7 +101,7 @@ void KWMTDatabaseTextFile::AddPathToUsedFiles(const ALString& sPathName)
 		// avec un fichier bidon en entree pour qu'il extrait correctement la path en entree
 		resultFilePathBuilder.SetInputFilePathName(FileService::BuildFilePathName(sPathName, "dummy.txt"));
 
-		// Personnalisation des noms de table du mapping (qui comprennent la table racine)
+		// Personnalisation des chemins pour les tables du mapping (qui comprennent la table principale)
 		for (nMapping = 0; nMapping < GetMultiTableMappings()->GetSize(); nMapping++)
 		{
 			mapping = cast(KWMTDatabaseMapping*, GetMultiTableMappings()->GetAt(nMapping));
@@ -130,7 +130,7 @@ void KWMTDatabaseTextFile::ExportUsedFileSpecs(ObjectArray* oaUsedFileSpecs) con
 	// Appel de la methode ancetre
 	KWMTDatabase::ExportUsedFileSpecs(oaUsedFileSpecs);
 
-	// Personnalisation des noms de table du mapping (hors table racine, deja traitee)
+	// Personnalisation des noms de table du mapping (hors table principale, deja traitee)
 	for (nMapping = 1; nMapping < oaMultiTableMappings.GetSize(); nMapping++)
 	{
 		mapping = cast(KWMTDatabaseMapping*, oaMultiTableMappings.GetAt(nMapping));
@@ -154,7 +154,7 @@ void KWMTDatabaseTextFile::ExportUsedWriteFileSpecs(ObjectArray* oaUsedFileSpecs
 	// Appel de la methode ancetre
 	KWMTDatabase::ExportUsedFileSpecs(oaUsedFileSpecs);
 
-	// Personnalisation des noms de table du mapping (hors table racine, deja traitee)
+	// Personnalisation des noms de table du mapping (hors table principale, deja traitee)
 	for (nMapping = 1; nMapping < oaMultiTableMappings.GetSize(); nMapping++)
 	{
 		mapping = cast(KWMTDatabaseMapping*, oaMultiTableMappings.GetAt(nMapping));

--- a/src/Learning/KWData/KWRelationCreationRule.cpp
+++ b/src/Learning/KWData/KWRelationCreationRule.cpp
@@ -499,7 +499,7 @@ boolean KWDRRelationCreationRule::CheckOperandsCompleteness(const KWClass* kwcOw
 		kwcTargetClass = kwcOwnerClass->GetDomain()->LookupClass(GetObjectClassName());
 		assert(kwcTargetClass != NULL);
 
-		// La class cible ne doit pas etre Root
+		// La classe cible ne doit pas etre Root
 		if (kwcTargetClass->GetRoot())
 		{
 			AddError(sTmp + "Invalid output dictionary " + kwcTargetClass->GetName() +

--- a/src/Learning/KWDataPreparation/KWDataPreparationTask.cpp
+++ b/src/Learning/KWDataPreparation/KWDataPreparationTask.cpp
@@ -658,6 +658,7 @@ longint KWDataPreparationTask::ComputeNecessaryClassAttributeMemory() const
 	dummyAttribute = new KWAttribute;
 	dummyAttribute->SetType(KWType::Symbol);
 	dummyAttribute->SetName("Dummy");
+	dummyClass.SetName("Dummy");
 	dummyClass.InsertAttribute(dummyAttribute);
 
 	// On rajoute une meta-data comme si l'attribut etait dans un bloc

--- a/src/Learning/KWDataUtils/KWArtificialDataset.cpp
+++ b/src/Learning/KWDataUtils/KWArtificialDataset.cpp
@@ -200,7 +200,7 @@ void KWArtificialDataset::CreateDataset() const
 	int nField;
 	int nLine;
 	int nKey;
-	int nRootBaseKey;
+	int nMainBaseKey;
 	int nBaseKey;
 	StringVector svFieldValues;
 	int nKeyValue;
@@ -253,16 +253,16 @@ void KWArtificialDataset::CreateDataset() const
 
 		// On calcule la valeur de base de la cle, de facon a ce que les cles de poids forts evoluent de facon
 		// monotone
-		nRootBaseKey = 1;
-		nBaseKey = nRootBaseKey;
+		nMainBaseKey = 1;
+		nBaseKey = nMainBaseKey;
 		for (nKey = 0; nKey < ivKeyFieldIndexes.GetSize(); nKey++)
 			nBaseKey *= 10;
 		while (nMaxLineNumberPerKey * nBaseKey / 10 < nLineNumber)
 		{
 			nBaseKey *= 10;
-			nRootBaseKey *= 10;
+			nMainBaseKey *= 10;
 		}
-		assert(nMaxLineNumberPerKey * nRootBaseKey * pow(10.0, 1.0 * ivKeyFieldIndexes.GetSize()) / 10 >=
+		assert(nMaxLineNumberPerKey * nMainBaseKey * pow(10.0, 1.0 * ivKeyFieldIndexes.GetSize()) / 10 >=
 		       nLineNumber);
 
 		// Creation des lignes
@@ -278,7 +278,7 @@ void KWArtificialDataset::CreateDataset() const
 								IntToString(nField + 1));
 
 			// On alimente d'abord les cles de poids faible, par puissance de 10
-			nBaseKey = nRootBaseKey;
+			nBaseKey = nMainBaseKey;
 			for (nKey = ivKeyFieldIndexes.GetSize() - 1; nKey >= 0; nKey--)
 			{
 				// On cree les cle selon l'ordre souhaite
@@ -289,8 +289,8 @@ void KWArtificialDataset::CreateDataset() const
 					nKeyValue = nBaseKey - 1 - ((nLine / nMaxLineNumberPerKey) % nBaseKey);
 
 				// Les cles de poids fort sont incrementees plus lentement que les cle de poids faible
-				nKeyValue /= (nBaseKey / nRootBaseKey);
-				nKeyValue *= (nBaseKey / nRootBaseKey);
+				nKeyValue /= (nBaseKey / nMainBaseKey);
+				nKeyValue *= (nBaseKey / nMainBaseKey);
 
 				// Memorisation de la cle (on maintenant en categoriel son ordre numerique)
 				sKeyValue = sTmp + IntToString(nBaseKey + nKeyValue);

--- a/src/Learning/KWDataUtils/KWDatabaseChunkBuilder.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseChunkBuilder.cpp
@@ -100,17 +100,17 @@ int KWDatabaseChunkBuilder::GetChunkNumber() const
 	return ivChunkBeginIndexes.GetSize();
 }
 
-void KWDatabaseChunkBuilder::GetChunkLastRootKeyAt(int nChunkIndex, KWKey* lastRootKey) const
+void KWDatabaseChunkBuilder::GetChunkLastMainKeyAt(int nChunkIndex, KWKey* lastMainKey) const
 {
 	int nMicroChunkIndex;
 
 	require(databaseIndexer != NULL);
 	require(0 <= nChunkIndex and nChunkIndex < GetChunkNumber());
-	require(lastRootKey != NULL);
+	require(lastMainKey != NULL);
 
 	// On recherche l'information pour le micro-chunk correspondant au chunk
 	nMicroChunkIndex = ivChunkBeginIndexes.GetAt(nChunkIndex);
-	lastRootKey->CopyFrom(databaseIndexer->GetChunkPreviousMainKeyAt(nMicroChunkIndex));
+	lastMainKey->CopyFrom(databaseIndexer->GetChunkPreviousMainKeyAt(nMicroChunkIndex));
 }
 
 void KWDatabaseChunkBuilder::GetChunkPreviousRecordIndexesAt(int nChunkIndex,
@@ -221,7 +221,7 @@ void KWDatabaseChunkBuilder::Write(ostream& ost) const
 	LongintVector lvChunkBeginPositions;
 	LongintVector lvChunkEndPositions;
 	LongintVector lvChunkPreviousRecordIndexes;
-	KWKey lastRootKey;
+	KWKey lastMainKey;
 	longint lChunkSize;
 
 	ost << GetClassLabel() << " " << GetObjectLabel() << "\n";
@@ -247,7 +247,7 @@ void KWDatabaseChunkBuilder::Write(ostream& ost) const
 		for (nChunk = 0; nChunk < GetChunkNumber(); nChunk++)
 		{
 			// Acces aux caracteristique du chunk
-			GetChunkLastRootKeyAt(nChunk, &lastRootKey);
+			GetChunkLastMainKeyAt(nChunk, &lastMainKey);
 			GetChunkPreviousRecordIndexesAt(nChunk, &lvChunkPreviousRecordIndexes);
 			GetChunkBeginPositionsAt(nChunk, &lvChunkBeginPositions);
 			GetChunkEndPositionsAt(nChunk, &lvChunkEndPositions);
@@ -267,7 +267,7 @@ void KWDatabaseChunkBuilder::Write(ostream& ost) const
 				ost << lvChunkEndPositions.GetAt(nTable) << "\t";
 			}
 			ost << lChunkSize << "\t";
-			ost << lastRootKey.GetObjectLabel() << "\n";
+			ost << lastMainKey.GetObjectLabel() << "\n";
 		}
 	}
 }

--- a/src/Learning/KWDataUtils/KWDatabaseChunkBuilder.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseChunkBuilder.cpp
@@ -110,7 +110,7 @@ void KWDatabaseChunkBuilder::GetChunkLastRootKeyAt(int nChunkIndex, KWKey* lastR
 
 	// On recherche l'information pour le micro-chunk correspondant au chunk
 	nMicroChunkIndex = ivChunkBeginIndexes.GetAt(nChunkIndex);
-	lastRootKey->CopyFrom(databaseIndexer->GetChunkPreviousRootKeyAt(nMicroChunkIndex));
+	lastRootKey->CopyFrom(databaseIndexer->GetChunkPreviousMainKeyAt(nMicroChunkIndex));
 }
 
 void KWDatabaseChunkBuilder::GetChunkPreviousRecordIndexesAt(int nChunkIndex,

--- a/src/Learning/KWDataUtils/KWDatabaseChunkBuilder.h
+++ b/src/Learning/KWDataUtils/KWDatabaseChunkBuilder.h
@@ -72,16 +72,16 @@ public:
 	//  . debut de position du chunk par table
 	//  . fin de position du chunk par table
 	//  . index du premier record du chunk par table
-	//  . derniere cle racine du chunk
+	//  . derniere cle principale du chunk
 	// Memoire: les objet retournes appartiennent a l'appelant
 
 	// Nombre total de chunk
 	int GetChunkNumber() const;
 
-	// Derniere cle racine du chunk precedent
+	// Derniere cle principale du chunk precedent
 	// Renvoie une cle vide pour le premier chunk
 	// Renvoie une cle vide systematiquement dans le cas particulier d'une base reduite a une seule table sans cle
-	void GetChunkLastRootKeyAt(int nChunkIndex, KWKey* lastRootKey) const;
+	void GetChunkLastMainKeyAt(int nChunkIndex, KWKey* lastMainKey) const;
 
 	// Vecteur des index du dernier record du chunk precedent, par table
 	// Renvoie un index 0 par table pour le premier chunk

--- a/src/Learning/KWDataUtils/KWDatabaseIndexer.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseIndexer.cpp
@@ -861,7 +861,7 @@ boolean KWDatabaseIndexer::ComputeMainTableIndexation()
 			if (lMaxKeyNumber < 0)
 				lMaxKeyNumber = 0;
 
-			// On limite ce nombre de cle on fonctioRate = 0; de la taille des fichiers a analyser
+			// On limite ce nombre de cle en fonction de la taille des fichiers a analyser
 			// On utilise (lMaxFileSizePerProcess/8) pour la gestion de la fin des taches
 			lMaxSlaveProcessNumber =
 			    1 + GetMTDatabase()->GetTotalFileSize() / (lTotalFileSizePerProcess / 8);

--- a/src/Learning/KWDataUtils/KWDatabaseIndexer.h
+++ b/src/Learning/KWDataUtils/KWDatabaseIndexer.h
@@ -199,7 +199,7 @@ protected:
 	// Initialisation d'un indexeur de champ cle pour un index de table en entree
 	// On n'indexe que les champs cles secondaire correspondant a ceux de la table principale,
 	// Les champs cles secondaire sont potentiellement en positions differentes, de nom different
-	// et en nombre supperieur a ceux de la table principale. On n'indexe que ceux correspond
+	// et en nombre superieur a ceux de la table principale. On n'indexe que ceux qui correspondent
 	// a la table principale (en meme nombre et dans le meme ordre)
 	boolean InitializeKeyFieldIndexer(int nTableIndex, KWKeyFieldsIndexer* keyFieldsIndexer);
 

--- a/src/Learning/KWDataUtils/KWDatabaseIndexer.h
+++ b/src/Learning/KWDataUtils/KWDatabaseIndexer.h
@@ -104,7 +104,7 @@ public:
 	//  . debut de position du chunk par table
 	//  . fin de position du chunk par table
 	//  . index du premier record du chunk par table
-	//  . derniere cle racine du chunk
+	//  . derniere cle principale du chunk
 	//
 	// Ces resultats sont calcules de facon bufferises au fur et a mesure des calcul d'indexation
 	// pour une meme database, uniquement pour la table principale et ses sous-table utilisees.
@@ -117,11 +117,11 @@ public:
 	// Nombre total de chunk
 	int GetChunkNumber() const;
 
-	// Derniere cle racine du chunk precedent
+	// Derniere cle principale du chunk precedent
 	// Renvoie une cle vide pour le premier chunk
 	// Renvoie une cle vide systematiquement dans le cas particulier d'une base reduite a une seule table sans cle
 	// Memoire: appartient a l'appele
-	const KWKey* GetChunkPreviousRootKeyAt(int nChunkIndex) const;
+	const KWKey* GetChunkPreviousMainKeyAt(int nChunkIndex) const;
 
 	// Index du dernier record du chunk precedent, par table
 	// Renvoie 0 pour le premier chunk
@@ -170,14 +170,14 @@ protected:
 	// On calcule d'abord les index de champ de chaque table en entree, ce qui permet de savoir quelle table doit
 	// etre lue. On collecte un echantillon de cles de la table principale, ainsi que leur position pour chaque
 	// table On determine alors un decoupage des tables pour les traitement par esclave En sortie, si OK, on a donc
-	// initialise les tableaux oaAllChunksBeginPos, oaAllChunksBeginRecordIndex, et oaAllChunksLastRootKeys
+	// initialise les tableaux oaAllChunksBeginPos, oaAllChunksBeginRecordIndex, et oaAllChunksLastMainKeys
 
 	// Pilotage du calcul du plan d'indexation global
 	// Erreur possible si pas assez de ressource par exemple
 	boolean ComputeAllDataTableIndexation();
 
 	// Indexation basique avec un seul troncon de la table principale
-	boolean ComputeRootTableBasicIndexation();
+	boolean ComputeMainTableBasicIndexation();
 
 	// Extraction d'un echantillon de cles et de leur position pour la table principale
 	// dans le cas particulier d'une table principale sans cle
@@ -185,7 +185,7 @@ protected:
 
 	// Extraction d'un echantillon de cles et de leur position pour la table principale
 	// dans le cas d'une table princpale avec cle
-	boolean ComputeRootTableIndexation();
+	boolean ComputeMainTableIndexation();
 
 	// Indexation basique avec un seul troncon des tables secondaires non deja traitees
 	boolean ComputeSecondaryTablesBasicIndexation();
@@ -199,18 +199,18 @@ protected:
 	// Initialisation d'un indexeur de champ cle pour un index de table en entree
 	// On n'indexe que les champs cles secondaire correspondant a ceux de la table principale,
 	// Les champs cles secondaire sont potentiellement en positions differentes, de nom different
-	// et en nombre supperieur a ceux de la table racine. On n'indexe que ceux correspond
-	// a la table racine (en meme nombre et dans le meme ordre)
+	// et en nombre supperieur a ceux de la table principale. On n'indexe que ceux correspond
+	// a la table principale (en meme nombre et dans le meme ordre)
 	boolean InitializeKeyFieldIndexer(int nTableIndex, KWKeyFieldsIndexer* keyFieldsIndexer);
 
-	// Evaluation de la taille des cles et du nombre de lignes de la table racine
-	boolean EvaluateKeySize(const KWKeyFieldsIndexer* rootKeyFieldsIndexer, longint& lRootMeanKeySize,
-				longint& lRootLineNumber);
+	// Evaluation de la taille des cles et du nombre de lignes de la table principale
+	boolean EvaluateKeySize(const KWKeyFieldsIndexer* mainKeyFieldsIndexer, longint& lMeanMainKeySize,
+				longint& lMainLineNumber);
 
 	// Extraction d'un echantillon de cles et de leur position pour la table principale en lecture
-	boolean ExtractRootSampleKeyPositions(const KWKeyFieldsIndexer* rootKeyFieldsIndexer, longint lRootMeanKeySize,
-					      longint lRootLineNumber, double dSamplingRate,
-					      ObjectArray* oaRootKeyPositions);
+	boolean ExtractMainSampleKeyPositions(const KWKeyFieldsIndexer* mainKeyFieldsIndexer, longint lMeanMainKeySize,
+					      longint lMainLineNumber, double dSamplingRate,
+					      ObjectArray* oaMainKeyPositions);
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Parametrage de l'indexation

--- a/src/Learning/KWDataUtils/KWDatabaseTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTask.cpp
@@ -512,7 +512,7 @@ boolean KWDatabaseTask::MasterPrepareTaskInput(double& dTaskPercent, boolean& bI
 		if (shared_sourceDatabase.GetDatabase()->IsMultiTableTechnology())
 		{
 			// Recopie de la cle racine
-			databaseChunkBuilder.GetChunkLastRootKeyAt(nChunkCurrentIndex, input_ChunkLastRootKey.GetKey());
+			databaseChunkBuilder.GetChunkLastMainKeyAt(nChunkCurrentIndex, input_ChunkLastRootKey.GetKey());
 
 			// Recopie des vecteurs de position de debut et fin pour l'esclave
 			databaseChunkBuilder.GetChunkPreviousRecordIndexesAt(

--- a/src/Learning/KWDataUtils/KWDatabaseTask.h
+++ b/src/Learning/KWDataUtils/KWDatabaseTask.h
@@ -100,7 +100,7 @@ protected:
 	// On calcule d'abord les index de champ de chaque table en entree, ce qui permet de savoir quelle table doit
 	// etre lue. On collecte un echantillon de cle de la table principale, ainsi que leur position pour chaque table
 	// secondaire On determine alors un decoupage des tables pour les traitement par esclave En sortie, si OK, on a
-	// donc initialise les tableaux oaAllChunksBeginPos, oaAllChunksBeginRecordIndex, et oaAllChunksLastRootKeys
+	// donc initialise les tableaux oaAllChunksBeginPos, oaAllChunksBeginRecordIndex, et oaAllChunksLastMainKeys
 
 	// Calcul du plan d'indexation global des bases pour le pilotage de la parallelisation
 	// Erreur possible si pas assez de ressource par exemple
@@ -224,7 +224,7 @@ protected:
 	//   . un vecteur de position de debut (comprises),
 	//   . un vecteur de position de fin (non comprises),
 	//   . un vecteur d'index de record de debut (en fait, le dernier index du troncon precedent)
-	//   . la derniere cle racine du troncon precedent
+	//   . la derniere cle principale du troncon precedent
 	// La taille des vecteurs et egale au nombre de tables en entree
 	// (les index des table non utilises sont ignores lors de traitements).
 
@@ -240,8 +240,8 @@ protected:
 	// Cf. variable oaAllChunksBeginRecordIndex du maitre
 	PLShared_LongintVector input_lvChunkPreviousRecordIndexes;
 
-	// Cles racine de depart pour le traitement de l'esclave
-	PLShared_Key input_ChunkLastRootKey;
+	// Cles principale de depart pour le traitement de l'esclave
+	PLShared_Key input_ChunkLastMainKey;
 
 	// Position de depart pour le pilotage de la lecture du fichier dans le cas mono-table
 	PLShared_Longint input_lFileBeginPosition;

--- a/src/Learning/KWDataUtils/KWKeyPositionFinderTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeyPositionFinderTask.cpp
@@ -237,23 +237,23 @@ const ALString KWKeyPositionFinderTask::GetObjectLabel() const
 
 void KWKeyPositionFinderTask::Test()
 {
-	TestWithArtificialRootAndSecondaryTables(100000, 1, 1, 1000000, 10, 1, 0);
-	TestWithArtificialRootAndSecondaryTables(10000, 1, 1, 100000, 10, 1, 0);
-	TestWithArtificialRootAndSecondaryTables(100000, 1, 0.01, 1000000, 10, 0.01, 0);
-	TestWithArtificialRootAndSecondaryTables(100000, 1, 0.01, 1000000, 10, 0.01, 1000);
-	TestWithArtificialRootAndSecondaryTables(100000, 10, 0.01, 1000000, 1, 0.01, 1000);
-	TestWithArtificialRootAndSecondaryTables(100000, 1, 0, 1000000, 10, 0.01, 1000);
-	TestWithArtificialRootAndSecondaryTables(100000, 1, 0.01, 1000000, 10, 0, 1000);
-	TestWithArtificialRootAndSecondaryTables(1, 1, 1, 1000000, 10, 0.01, 1000);
+	TestWithArtificialMainAndSecondaryTables(100000, 1, 1, 1000000, 10, 1, 0);
+	TestWithArtificialMainAndSecondaryTables(10000, 1, 1, 100000, 10, 1, 0);
+	TestWithArtificialMainAndSecondaryTables(100000, 1, 0.01, 1000000, 10, 0.01, 0);
+	TestWithArtificialMainAndSecondaryTables(100000, 1, 0.01, 1000000, 10, 0.01, 1000);
+	TestWithArtificialMainAndSecondaryTables(100000, 10, 0.01, 1000000, 1, 0.01, 1000);
+	TestWithArtificialMainAndSecondaryTables(100000, 1, 0, 1000000, 10, 0.01, 1000);
+	TestWithArtificialMainAndSecondaryTables(100000, 1, 0.01, 1000000, 10, 0, 1000);
+	TestWithArtificialMainAndSecondaryTables(1, 1, 1, 1000000, 10, 0.01, 1000);
 }
 
-boolean KWKeyPositionFinderTask::TestWithArtificialRootAndSecondaryTables(
-    int nRootLineNumber, int nRootLineNumberPerKey, double dRootSamplingRate, int nSecondaryLineNumber,
+boolean KWKeyPositionFinderTask::TestWithArtificialMainAndSecondaryTables(
+    int nMainLineNumber, int nMainLineNumberPerKey, double dMainSamplingRate, int nSecondaryLineNumber,
     int nSecondaryLineNumberPerKey, double dSecondarySamplingRate, int nBufferSize)
 {
 	boolean bOk = true;
 	boolean bCreateDatasets = true;
-	KWArtificialDataset rootArtificialDataset;
+	KWArtificialDataset mainArtificialDataset;
 	KWArtificialDataset secondaryArtificialDataset;
 	longint lMeanKeySize;
 	longint lLineNumber;
@@ -262,9 +262,9 @@ boolean KWKeyPositionFinderTask::TestWithArtificialRootAndSecondaryTables(
 	ObjectArray oaFoundKeyPositions;
 	KWKeyPositionFinderTask keyPositionFinder;
 
-	require(nRootLineNumber >= 0);
-	require(nRootLineNumberPerKey >= 0);
-	require(dRootSamplingRate >= 0);
+	require(nMainLineNumber >= 0);
+	require(nMainLineNumberPerKey >= 0);
+	require(dMainSamplingRate >= 0);
 	require(nSecondaryLineNumber >= 0);
 	require(nSecondaryLineNumberPerKey >= 0);
 	require(dSecondarySamplingRate >= 0);
@@ -282,31 +282,31 @@ boolean KWKeyPositionFinderTask::TestWithArtificialRootAndSecondaryTables(
 	cout << endl;
 	cout << "===============================================================================" << endl;
 	cout << keyPositionFinder.GetTaskLabel() << ":"
-	     << " Root(" << nRootLineNumber << ", " << nRootLineNumberPerKey << ", " << dRootSamplingRate << ")"
+	     << " Main(" << nMainLineNumber << ", " << nMainLineNumberPerKey << ", " << dMainSamplingRate << ")"
 	     << " Secondary(" << nSecondaryLineNumber << ", " << nSecondaryLineNumberPerKey << ", "
 	     << dSecondarySamplingRate << ")"
 	     << " Buffer(" << nBufferSize << ")" << endl;
 	cout << "===============================================================================" << endl;
 
 	// Creation d'un fichier racine avec des champs cle
-	rootArtificialDataset.SpecifySortedDataset();
-	rootArtificialDataset.SetLineNumber(nRootLineNumber);
-	rootArtificialDataset.SetMaxLineNumberPerKey(nRootLineNumberPerKey);
-	rootArtificialDataset.SetSamplingRate(dRootSamplingRate);
-	rootArtificialDataset.SetFileName(rootArtificialDataset.BuildFileName());
+	mainArtificialDataset.SpecifySortedDataset();
+	mainArtificialDataset.SetLineNumber(nMainLineNumber);
+	mainArtificialDataset.SetMaxLineNumberPerKey(nMainLineNumberPerKey);
+	mainArtificialDataset.SetSamplingRate(dMainSamplingRate);
+	mainArtificialDataset.SetFileName(mainArtificialDataset.BuildFileName());
 	if (bCreateDatasets)
-		rootArtificialDataset.CreateDataset();
-	rootArtificialDataset.DisplayFirstLines(15);
+		mainArtificialDataset.CreateDataset();
+	mainArtificialDataset.DisplayFirstLines(15);
 
 	// Evaluation de la taille des cles du fichier principal
 	lMeanKeySize = 0;
 	lLineNumber = 0;
 	bOk = bOk and
-	      KWKeySizeEvaluatorTask::TestWithArtificialDataset(&rootArtificialDataset, lMeanKeySize, lLineNumber);
+	      KWKeySizeEvaluatorTask::TestWithArtificialDataset(&mainArtificialDataset, lMeanKeySize, lLineNumber);
 
 	// Extraction des cle du fichier principal
 	bOk = bOk and KWKeyPositionSampleExtractorTask::TestWithArtificialDataset(
-			  &rootArtificialDataset, 0.25, lMeanKeySize, lLineNumber, &oaInputKeyPositions);
+			  &mainArtificialDataset, 0.25, lMeanKeySize, lLineNumber, &oaInputKeyPositions);
 
 	// Creation d'un fichier secondaire avec des champs cle
 	secondaryArtificialDataset.SpecifySortedDataset();
@@ -330,7 +330,7 @@ boolean KWKeyPositionFinderTask::TestWithArtificialRootAndSecondaryTables(
 	// Destruction des fichiers
 	if (bCreateDatasets)
 	{
-		rootArtificialDataset.DeleteDataset();
+		mainArtificialDataset.DeleteDataset();
 		secondaryArtificialDataset.DeleteDataset();
 	}
 

--- a/src/Learning/KWDataUtils/KWKeyPositionFinderTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeyPositionFinderTask.cpp
@@ -288,7 +288,7 @@ boolean KWKeyPositionFinderTask::TestWithArtificialMainAndSecondaryTables(
 	     << " Buffer(" << nBufferSize << ")" << endl;
 	cout << "===============================================================================" << endl;
 
-	// Creation d'un fichier racine avec des champs cle
+	// Creation d'un fichier principal avec des champs cle
 	mainArtificialDataset.SpecifySortedDataset();
 	mainArtificialDataset.SetLineNumber(nMainLineNumber);
 	mainArtificialDataset.SetMaxLineNumberPerKey(nMainLineNumberPerKey);

--- a/src/Learning/KWDataUtils/KWKeyPositionFinderTask.h
+++ b/src/Learning/KWDataUtils/KWKeyPositionFinderTask.h
@@ -89,11 +89,11 @@ public:
 	// Methode de test
 	static void Test();
 
-	// Test en specifiant les caracteristiques d'une table racine et d'une table secondaire
+	// Test en specifiant les caracteristiques d'une table principale et d'une table secondaire
 	// au moyen de jeux de donnees artificiels
 	// La taille de buffer n'est prise en compte que si elle est differente de 0.
-	static boolean TestWithArtificialRootAndSecondaryTables(int nRootLineNumber, int nRootLineNumberPerKey,
-								double dRootSamplingRate, int nSecondaryLineNumber,
+	static boolean TestWithArtificialMainAndSecondaryTables(int nMainLineNumber, int nMainLineNumberPerKey,
+								double dMainSamplingRate, int nSecondaryLineNumber,
 								int nSecondaryLineNumberPerKey,
 								double dSecondarySamplingRate, int nBufferSize);
 

--- a/src/Learning/KWDataUtils/KWTestDatabaseTransfer.cpp
+++ b/src/Learning/KWDataUtils/KWTestDatabaseTransfer.cpp
@@ -742,7 +742,7 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 	if (nTableNumber >= 2)
 	{
 		// Utilisation de deux champs, avec la cle en fin
-		// pour perturber sa position par rapport a la table racine
+		// pour perturber sa position par rapport a la table principale
 		artificialDataset = new KWArtificialDataset;
 		oaArtificialDatasets.SetAt(nSecondary0nIndex, artificialDataset);
 		timer.Reset();

--- a/src/Learning/KWDataUtils/KWTestDatabaseTransfer.cpp
+++ b/src/Learning/KWDataUtils/KWTestDatabaseTransfer.cpp
@@ -588,35 +588,35 @@ void KWTestDatabaseTransfer::MTTest()
 	MTTestWithArtificialDatabase(2, 1, false, 10000, 1, 1, 100000, 10, 1, 0, 100000, "No use of secondary table");
 	MTTestWithArtificialDatabase(2, 2, true, 100000, 1, 0.01, 1000000, 10, 0.01, 10000, 100000,
 				     "Heavily sampled, with orphan records");
-	MTTestWithArtificialDatabase(2, 2, true, 100000, 5, 1, 100000, 1, 1, 10000, 1000000, "Root duplicates");
+	MTTestWithArtificialDatabase(2, 2, true, 100000, 5, 1, 100000, 1, 1, 10000, 1000000, "Main duplicates");
 	MTTestWithArtificialDatabase(2, 1, false, 100, 2, 1, 0, 10, 1, 100, 200,
-				     "Root duplicates with several processes");
+				     "Main duplicates with several processes");
 	MTTestWithArtificialDatabase(2, 2, true, 300, 2, 0.3, 500, 2, 1, 100, 1000,
-				     "Root duplicates and orphans records with several processes");
+				     "Main duplicates and orphans records with several processes");
 	MTTestWithArtificialDatabase(2, 2, true, 300, 3, 1, 10000, 10, 1, 100, 1000,
-				     "Root duplicates and many orphans records with several processes");
-	MTTestWithArtificialDatabase(2, 2, true, 100000, 1, 0, 1000000, 10, 0.01, 10000, 100000, "No root instances");
+				     "Main duplicates and many orphans records with several processes");
+	MTTestWithArtificialDatabase(2, 2, true, 100000, 1, 0, 1000000, 10, 0.01, 10000, 100000, "No main instances");
 	MTTestWithArtificialDatabase(2, 2, true, 100000, 1, 0.01, 1000000, 10, 0, 10000, 100000,
 				     "No secondary records");
 	MTTestWithArtificialDatabase(2, 2, true, 100000, 1, 0.5, 1000000, 10, 0.2, 10000, 1000000,
 				     "Medium sampled with varying record number per instance");
-	MTTestWithArtificialDatabase(2, 2, true, 1, 1, 1, 1000000, 10, 0.01, 10000, 10000, "One single root instance");
+	MTTestWithArtificialDatabase(2, 2, true, 1, 1, 1, 1000000, 10, 0.01, 10000, 10000, "One single main instance");
 	MTTestWithArtificialDatabase(2, 2, true, 100000, 1, 1, 1000000, 10, 1, 0, 0, "Large");
 	MTTestWithArtificialDatabase(3, 3, true, 10000, 1, 1, 100000, 10, 1, 10000, 100000, "Snow-flake schema");
 	MTTestWithArtificialDatabase(3, 0, true, 10000, 1, 1, 100000, 10, 1, 10000, 100000,
-				     "Snow-flake schema with no used sub-table");
+				     "Snowflake schema with no used sub-table");
 	MTTestWithArtificialDatabase(3, 0, false, 10000, 1, 1, 100000, 10, 1, 10000, 100000,
-				     "Snow-flake schema using only root table");
+				     "Snowflake schema using only main table");
 	MTTestWithArtificialDatabase(4, 4, true, 10000, 1, 1, 100000, 10, 1, 10000, 100000, "Full schema");
 	MTTestWithArtificialDatabase(4, 0, true, 10000, 1, 1, 100000, 10, 1, 10000, 100000,
 				     "Full schema with no used sub-table");
 	MTTestWithArtificialDatabase(4, 0, false, 10000, 1, 1, 100000, 10, 1, 10000, 100000,
-				     "Full schema using only root table");
+				     "Full schema using only main table");
 }
 
 void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int nUsedTableNumber,
-							  boolean bUseBuildRules, int nRootLineNumber,
-							  int nRootLineNumberPerKey, double dRootSamplingRate,
+							  boolean bUseBuildRules, int nMainLineNumber,
+							  int nMainLineNumberPerKey, double dMainSamplingRate,
 							  int nSecondaryLineNumber, int nSecondaryLineNumberPerKey,
 							  double dSecondarySamplingRate, int nBufferSize,
 							  int lMaxFileSizePerProcess, const ALString& sTestLabel)
@@ -624,7 +624,7 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 	boolean bShowTime = false;
 	KWDatabaseTransferTask databaseTransfer;
 	boolean bOk;
-	const int nRootIndex = 0;
+	const int nMainIndex = 0;
 	const int nSecondary01Index = 1;
 	const int nSecondary0nIndex = 2;
 	const int nExternalIndex = 3;
@@ -651,9 +651,9 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 	require(nTableNumber >= 0);
 	require(nUsedTableNumber >= 0);
 	require(nUsedTableNumber <= nTableNumber);
-	require(nRootLineNumber >= 0);
-	require(nRootLineNumberPerKey >= 0);
-	require(dRootSamplingRate >= 0);
+	require(nMainLineNumber >= 0);
+	require(nMainLineNumberPerKey >= 0);
+	require(dMainSamplingRate >= 0);
 	require(nSecondaryLineNumber >= 0);
 	require(nSecondaryLineNumberPerKey >= 0);
 	require(dSecondarySamplingRate >= 0);
@@ -672,7 +672,7 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 	cout << endl;
 	cout << "=============================================================================" << endl;
 	cout << databaseTransfer.GetTaskLabel() << ":"
-	     << " Root(" << nRootLineNumber << ", " << nRootLineNumberPerKey << ", " << dRootSamplingRate << ")";
+	     << " Main(" << nMainLineNumber << ", " << nMainLineNumberPerKey << ", " << dMainSamplingRate << ")";
 	if (nTableNumber >= 2)
 		cout << " Secondary(" << nSecondaryLineNumber << ", " << nSecondaryLineNumberPerKey << ", "
 		     << dSecondarySamplingRate << ")";
@@ -692,15 +692,15 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 
 	// Creation du fichier principal
 	artificialDataset = new KWArtificialDataset;
-	oaArtificialDatasets.SetAt(nRootIndex, artificialDataset);
+	oaArtificialDatasets.SetAt(nMainIndex, artificialDataset);
 	timer.Reset();
 	timer.Start();
 	if (nTableNumber == 0)
 		artificialDataset->GetKeyFieldIndexes()->SetSize(0);
-	artificialDataset->SetLineNumber(nRootLineNumber);
-	artificialDataset->SetMaxLineNumberPerKey(nRootLineNumberPerKey);
-	artificialDataset->SetSamplingRate(dRootSamplingRate);
-	artificialDataset->SetFileName(FileService::BuildFilePathName(FileService::GetTmpDir(), "Root.txt"));
+	artificialDataset->SetLineNumber(nMainLineNumber);
+	artificialDataset->SetMaxLineNumberPerKey(nMainLineNumberPerKey);
+	artificialDataset->SetSamplingRate(dMainSamplingRate);
+	artificialDataset->SetFileName(FileService::BuildFilePathName(FileService::GetTmpDir(), "Main.txt"));
 	artificialDataset->CreateDataset();
 	artificialDataset->DisplayFirstLines(15);
 	timer.Stop();
@@ -709,7 +709,7 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 
 	// Creation de son dictionnaire
 	kwcClass = ComputeArtificialClass(artificialDataset);
-	oaArtificialClasses.SetAt(nRootIndex, kwcClass);
+	oaArtificialClasses.SetAt(nMainIndex, kwcClass);
 	if (nTableNumber >= 1)
 		kwcClass->SetRoot(true);
 	KWClassDomain::GetCurrentDomain()->InsertClass(kwcClass);
@@ -718,7 +718,7 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 	if (nTableNumber >= 3)
 	{
 		// Utilisation d'une copie du fichier principal
-		artificialDataset = cast(KWArtificialDataset*, oaArtificialDatasets.GetAt(nRootIndex))->Clone();
+		artificialDataset = cast(KWArtificialDataset*, oaArtificialDatasets.GetAt(nMainIndex))->Clone();
 		oaArtificialDatasets.SetAt(nSecondary01Index, artificialDataset);
 		timer.Reset();
 		timer.Start();
@@ -747,7 +747,7 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 		oaArtificialDatasets.SetAt(nSecondary0nIndex, artificialDataset);
 		timer.Reset();
 		timer.Start();
-		artificialDataset->CopyFrom(cast(KWArtificialDataset*, oaArtificialDatasets.GetAt(nRootIndex)));
+		artificialDataset->CopyFrom(cast(KWArtificialDataset*, oaArtificialDatasets.GetAt(nMainIndex)));
 		artificialDataset->SetFieldNumber(2);
 		artificialDataset->GetKeyFieldIndexes()->SetAt(0, 1);
 		artificialDataset->SetLineNumber(nSecondaryLineNumber);
@@ -771,7 +771,7 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 	if (nTableNumber >= 4)
 	{
 		// Utilisation d'une copie du fichier principal
-		artificialDataset = cast(KWArtificialDataset*, oaArtificialDatasets.GetAt(nRootIndex))->Clone();
+		artificialDataset = cast(KWArtificialDataset*, oaArtificialDatasets.GetAt(nMainIndex))->Clone();
 		oaArtificialDatasets.SetAt(nExternalIndex, artificialDataset);
 		timer.Reset();
 		timer.Start();
@@ -797,7 +797,7 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 	{
 		// Acces aux tables a lier
 		if (nTableNumber == 2)
-			kwcClass = cast(KWClass*, oaArtificialClasses.GetAt(nRootIndex));
+			kwcClass = cast(KWClass*, oaArtificialClasses.GetAt(nMainIndex));
 		else
 			kwcClass = cast(KWClass*, oaArtificialClasses.GetAt(nSecondary01Index));
 		kwcSubClass = cast(KWClass*, oaArtificialClasses.GetAt(nSecondary0nIndex));
@@ -831,7 +831,7 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 	if (nTableNumber >= 3)
 	{
 		// Acces aux tables a lier
-		kwcClass = cast(KWClass*, oaArtificialClasses.GetAt(nRootIndex));
+		kwcClass = cast(KWClass*, oaArtificialClasses.GetAt(nMainIndex));
 		kwcSubClass = cast(KWClass*, oaArtificialClasses.GetAt(nSecondary01Index));
 
 		// Preparation du schema multi-tables avec un attribut de lien vers la table secondaire
@@ -862,7 +862,7 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 	if (nTableNumber >= 4)
 	{
 		// Acces aux tables a lier
-		kwcClass = cast(KWClass*, oaArtificialClasses.GetAt(nRootIndex));
+		kwcClass = cast(KWClass*, oaArtificialClasses.GetAt(nMainIndex));
 		kwcSubClass = cast(KWClass*, oaArtificialClasses.GetAt(nExternalIndex));
 		assert(kwcSubClass->GetKeyAttributeNumber() == 1);
 
@@ -900,8 +900,8 @@ void KWTestDatabaseTransfer::MTTestWithArtificialDatabase(int nTableNumber, int 
 	KWClassDomain::GetCurrentDomain()->Compile();
 
 	// Initialisation de la base source
-	kwcClass = cast(KWClass*, oaArtificialClasses.GetAt(nRootIndex));
-	artificialDataset = cast(KWArtificialDataset*, oaArtificialDatasets.GetAt(nRootIndex));
+	kwcClass = cast(KWClass*, oaArtificialClasses.GetAt(nMainIndex));
+	artificialDataset = cast(KWArtificialDataset*, oaArtificialDatasets.GetAt(nMainIndex));
 	databaseSource.SetClassName(kwcClass->GetName());
 	databaseSource.SetHeaderLineUsed(artificialDataset->GetHeaderLineUsed());
 	databaseSource.SetFieldSeparator(artificialDataset->GetFieldSeparator());
@@ -1011,9 +1011,9 @@ void KWTestDatabaseTransfer::MTMainTestReadWrite(int argc, char** argv)
 		cout << "TestReadWrite "
 		     << "<ClassFileName> "
 		     << "<ClassName> "
-		     << "<RootReadFileName> "
+		     << "<MainReadFileName> "
 		     << "<SecondaryReadFileName> "
-		     << "<RootWriteFileName> "
+		     << "<MainWriteFileName> "
 		     << "<SecondaryWriteFileName>" << endl;
 	}
 	else
@@ -1021,8 +1021,8 @@ void KWTestDatabaseTransfer::MTMainTestReadWrite(int argc, char** argv)
 }
 
 void KWTestDatabaseTransfer::MTTestReadWrite(const ALString& sClassFileName, const ALString& sClassName,
-					     const ALString& sRootReadFileName, const ALString& sSecondaryReadFileName,
-					     const ALString& sRootWriteFileName,
+					     const ALString& sMainReadFileName, const ALString& sSecondaryReadFileName,
+					     const ALString& sMainWriteFileName,
 					     const ALString& sSecondaryWriteFileName)
 {
 	boolean bOk = true;
@@ -1053,7 +1053,7 @@ void KWTestDatabaseTransfer::MTTestReadWrite(const ALString& sClassFileName, con
 	{
 		// Initialisation de la base source
 		readDatabase.SetClassName(sClassName);
-		readDatabase.SetDatabaseName(sRootReadFileName);
+		readDatabase.SetDatabaseName(sMainReadFileName);
 		readDatabase.UpdateMultiTableMappings();
 
 		// Initialisation de la table secondaire
@@ -1066,7 +1066,7 @@ void KWTestDatabaseTransfer::MTTestReadWrite(const ALString& sClassFileName, con
 	if (bOk)
 	{
 		writeDatabase.SetClassName(sClassName);
-		writeDatabase.SetDatabaseName(sRootWriteFileName);
+		writeDatabase.SetDatabaseName(sMainWriteFileName);
 		writeDatabase.UpdateMultiTableMappings();
 
 		// Initialisation de la table secondaire

--- a/src/Learning/KWDataUtils/KWTestDatabaseTransfer.h
+++ b/src/Learning/KWDataUtils/KWTestDatabaseTransfer.h
@@ -45,31 +45,31 @@ public:
 	// Test en specifiant les caracteristiques d'une base multi-tables au moyen de jeux de donnees artificiels
 	// TableNumber:
 	//   . 0: cas mono-table, sans identifiants
-	//   . 1: une table racine avec identifiants
-	//   . 2: une table racine avec une table secondaire en relation 0-n
-	//   . 3: une table racine avec une table secondaire en relation 0-1 (identique a table principale), et
+	//   . 1: une table principale avec identifiants
+	//   . 2: une table principale avec une table secondaire en relation 0-n
+	//   . 3: une table principale avec une table secondaire en relation 0-1 (identique a table principale), et
 	//        une autre table secondaire en relation 0-n avec la seconde table
 	//   . 4: comme la cas (3), avec en plus une table externe (identique a la table principale)
 	// UsedTableNumber: pour mettre en Unused tout ou partie des tables et des regles de calcul
 	// UseBuildRules: utilisation des regles de calcul liant les tables
-	// RootLineNumber, RootLineNumberPerKey, RootSamplingRate: caracteristique de la table principale
+	// MainLineNumber, MainLineNumberPerKey, MainSamplingRate: caracteristique de la table principale
 	//    (et de la table en relation 0-1, et de la table externe)
 	// SecondaryLineNumber, SecondaryLineNumberPerKey, SecondarySamplingRate: caracteristique de la table en
 	// relation 0-n La taille de buffer ou des fichier par process n'est prise en compte que si elle est differente
 	// de 0.
 	static void MTTestWithArtificialDatabase(int nTableNumber, int nUsedTableNumber, boolean bUseBuildRules,
-						 int nRootLineNumber, int nRootLineNumberPerKey,
-						 double dRootSamplingRate, int nSecondaryLineNumber,
+						 int nMainLineNumber, int nMainLineNumberPerKey,
+						 double dMainSamplingRate, int nSecondaryLineNumber,
 						 int nSecondaryLineNumberPerKey, double dSecondarySamplingRate,
 						 int nBufferSize, int lMaxFileSizePerProcess,
 						 const ALString& sTestLabel);
 
 	// Test de transfert de fichier
-	//   Si RootWriteFileName est absent: pas d'ecriture
+	//   Si MainWriteFileName est absent: pas d'ecriture
 	static void MTMainTestReadWrite(int argc, char** argv);
 	static void MTTestReadWrite(const ALString& sClassFileName, const ALString& sClassName,
-				    const ALString& sRootReadFileName, const ALString& sSecondaryReadFileName,
-				    const ALString& sRootWriteFileName, const ALString& sSecondaryWriteFileName);
+				    const ALString& sMainReadFileName, const ALString& sSecondaryReadFileName,
+				    const ALString& sMainWriteFileName, const ALString& sSecondaryWriteFileName);
 
 	///////////////////////////////////////////////////////////////////////////////
 	///// Implementation

--- a/src/Learning/KWDataUtils/PLDataTableDriverTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLDataTableDriverTextFile.cpp
@@ -226,19 +226,19 @@ KWLoadIndexVector* PLDataTableDriverTextFile::GetDataItemLoadIndexes()
 	return &livDataItemLoadIndexes;
 }
 
-const IntVector* PLDataTableDriverTextFile::GetConstRootKeyIndexes() const
+const IntVector* PLDataTableDriverTextFile::GetConstMainKeyIndexes() const
 {
-	return &ivRootKeyIndexes;
+	return &ivMainKeyIndexes;
 }
 
-IntVector* PLDataTableDriverTextFile::GetRootKeyIndexes()
+IntVector* PLDataTableDriverTextFile::GetMainKeyIndexes()
 {
-	return &ivRootKeyIndexes;
+	return &ivMainKeyIndexes;
 }
 
 void PLDataTableDriverTextFile::InitializeLastReadKeySize(int nValue)
 {
 	require(nValue >= 0);
-	lastReadRootKey.SetSize(nValue);
-	lastReadRootKey.Initialize();
+	lastReadMainKey.SetSize(nValue);
+	lastReadMainKey.Initialize();
 }

--- a/src/Learning/KWDataUtils/PLDataTableDriverTextFile.h
+++ b/src/Learning/KWDataUtils/PLDataTableDriverTextFile.h
@@ -17,8 +17,8 @@
 //  La methode ComputeDataItemLoadIndexes permet de calculer les index (a faire dans le Master)
 //  Les methodes GetConstDataItemLoadIndexes et GetDataItemLoadIndexes permettent de transmettre
 //  l'index entre le maitre et les esclaves
-//  Dans le cas multi-table, les methodes GetConstRootKeyIndexes et GetRootKeyIndexes permettent
-//  de transmettre les index des attributs de la cle en cas de classe racine
+//  Dans le cas multi-table, les methodes GetConstMainKeyIndexes et GetMainKeyIndexes permettent
+//  de transmettre les index des attributs de la cle en cas de classe principale
 //  Enfin, chaque process gere une portion de fichier comprise entre une position de debut et de fin,
 //  qui peut potentiellement necessiter la lecture de plusieurs buffers pour etre traitee.
 class PLDataTableDriverTextFile : public KWDataTableDriverTextFile
@@ -88,9 +88,9 @@ protected:
 	const KWLoadIndexVector* GetConstDataItemLoadIndexes() const;
 	KWLoadIndexVector* GetDataItemLoadIndexes();
 
-	// Acces en lecture et ecriture aux index des attributs de la cle en cas de classe racine
-	const IntVector* GetConstRootKeyIndexes() const;
-	IntVector* GetRootKeyIndexes();
+	// Acces en lecture et ecriture aux index des attributs de la cle en cas de classe principale
+	const IntVector* GetConstMainKeyIndexes() const;
+	IntVector* GetMainKeyIndexes();
 
 	// Initialisation de la taille de la derniere cle lu
 	void InitializeLastReadKeySize(int nValue);

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
@@ -106,16 +106,16 @@ boolean PLMTDatabaseTextFile::ComputeOpenInformation(boolean bRead, boolean bInc
 	lMaxOpenNecessaryMemory = lEmptyOpenNecessaryMemory * 5;
 
 	// Initialisation recursive du mapping a partir de la racine pour avoir des driver initialises
-	DMTMPhysicalTerminateMapping(rootMultiTableMapping);
+	DMTMPhysicalTerminateMapping(mainMultiTableMapping);
 	if (bRead)
 	{
 		// En lecture, on utilise la classe physique
-		DMTMPhysicalInitializeMapping(rootMultiTableMapping, kwcPhysicalClass, true);
+		DMTMPhysicalInitializeMapping(mainMultiTableMapping, kwcPhysicalClass, true);
 	}
 	else
 	{
 		// En ecriture, on utile la classe logique
-		DMTMPhysicalInitializeMapping(rootMultiTableMapping, kwcClass, false);
+		DMTMPhysicalInitializeMapping(mainMultiTableMapping, kwcClass, false);
 	}
 
 	// Nettoyage prealable
@@ -350,7 +350,7 @@ boolean PLMTDatabaseTextFile::ComputeOpenInformation(boolean bRead, boolean bInc
 	}
 
 	// Nettoyage
-	DMTMPhysicalTerminateMapping(rootMultiTableMapping);
+	DMTMPhysicalTerminateMapping(mainMultiTableMapping);
 	if (bRead)
 		DeletePhysicalClass();
 	kwcClass = NULL;
@@ -1418,7 +1418,7 @@ void PLShared_MTDatabaseTextFile::DeserializeObject(PLSerializer* serializer, Ob
 	{
 		// Le premier mapping est pre-existant (table racine)
 		if (i == 0)
-			mapping = database->rootMultiTableMapping;
+			mapping = database->mainMultiTableMapping;
 		// Les autre sont a creer
 		else
 		{

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.h
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.h
@@ -161,7 +161,7 @@ public:
 	boolean IsMappingInitialized(KWMTDatabaseMapping* mapping);
 
 	// Parametrage de la derniere cle lue dans la table principale
-	void SetLastReadRootKey(const KWObjectKey* objectKey);
+	void SetLastReadMainKey(const KWObjectKey* objectKey);
 
 	// Nettoyage d'un mapping de ses informations de contexte (last key ou last object)
 	void CleanMapping(KWMTDatabaseMapping* mapping);
@@ -220,11 +220,12 @@ protected:
 
 	// Memorisation des index des attributs pour les mappings pour la serialisation
 	// Un vecteur d'index est memorise pour chaque mapping
-	// ainsi qu'un vecteur des index des attributs de cle dans le cas de classes racines
+	// ainsi qu'un vecteur des index des attributs de cle dans le cas de classes principales,
+	// plus precisement de toute classe "unique" d'un schema multi-table
 	// Utile pour la serialisation des bases destinees a etre ouverte en lecture,
 	// pour transferer aux esclaves les index calcules une fois pour toutes par le maitre
 	ObjectArray oaIndexedMappingsDataItemLoadIndexes;
-	ObjectArray oaIndexedMappingsRootKeyIndexes;
+	ObjectArray oaIndexedMappingsMainKeyIndexes;
 };
 
 ///////////////////////////////////////////////////

--- a/src/Learning/KWLearningProblem/KWLearningProblemActionView.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProblemActionView.cpp
@@ -54,7 +54,7 @@ KWLearningProblemActionView::KWLearningProblemActionView()
 	GetActionAt("ExtractKeysFromDataTable")
 	    ->SetHelpText("Extract keys from a sorted input data table."
 			  "\n It is dedicated to the preparation of multi-table databases,"
-			  "\n where a root entity has to be extracted from a detailed 0-n entity."
+			  "\n where a main entity has to be extracted from a detailed 0-n entity."
 			  "\n For example, in case of a web log file with cookies, page, timestamp in each log,"
 			  "\n extracting keys allow to build a table with unique cookies from the table of logs.");
 	GetActionAt("EvaluatePredictors")

--- a/src/Learning/KWUserInterface/KWDataTableKeyExtractorView.cpp
+++ b/src/Learning/KWUserInterface/KWDataTableKeyExtractorView.cpp
@@ -43,11 +43,11 @@ KWDataTableKeyExtractorView::KWDataTableKeyExtractorView()
 	GetActionAt("ExtractKeysFromDataTable")
 	    ->SetHelpText("Extract keys from a sorted input data table."
 			  "\n It is dedicated to the preparation of multi-table databases, where a"
-			  "\n root entity has to be extracted from a detailed 0-n entity."
+			  "\n main entity has to be extracted from a detailed 0-n entity."
 			  "\n For example, in case of a web log file with cookies, page, timestamp in each log,"
 			  "\n extracting keys allow to build a table with unique cookies from the table of logs.");
 	GetActionAt("BuildMultiTableClass")
-	    ->SetHelpText("Build a root dictionary with a Table variable based on"
+	    ->SetHelpText("Build a main dictionary with a Table variable based on"
 			  "\n the input dictionary, then save the dictionary file.");
 
 	// Short cuts

--- a/src/Learning/KWUserInterface/KWMTClassBuilderView.cpp
+++ b/src/Learning/KWUserInterface/KWMTClassBuilderView.cpp
@@ -37,7 +37,7 @@ KWMTClassBuilderView::KWMTClassBuilderView()
 	GetFieldAt("SecondaryClassName")
 	    ->SetHelpText("Name of secondary dictionary used as a Table in the multi-table dictionary.");
 	classNameList->GetFieldAt("Name")->SetHelpText("Name of dictionary.");
-	GetActionAt("OK")->SetHelpText("Build a root dictionary with a Table variable based on"
+	GetActionAt("OK")->SetHelpText("Build a main dictionary with a Table variable based on"
 				       "\n the input dictionary, then save the dictionary file.");
 
 	// Short cuts
@@ -66,7 +66,7 @@ void KWMTClassBuilderView::InitDefaultParameters()
 	if (sSecondaryDictionaryName != "")
 	{
 		// Nom par defaut du dictionnaire multi-classes a construire
-		sDefaultMultiTableClassName = "Root" + sSecondaryDictionaryName;
+		sDefaultMultiTableClassName = "Main" + sSecondaryDictionaryName;
 		sDefaultMultiTableClassName =
 		    KWClassDomain::GetCurrentDomain()->BuildClassName(sDefaultMultiTableClassName);
 

--- a/src/Learning/KWUserInterface/KWPredictorEvaluator.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorEvaluator.cpp
@@ -909,7 +909,7 @@ void KWPredictorEvaluator::RenameDatabaseClasses(KWDatabase* database, KWClassDo
 	KWMTDatabase* mtDatabase;
 	KWMTDatabaseMapping* mapping;
 	KWClass* kwcClass;
-	ALString sInitialRootClassName;
+	ALString sInitialMainClassName;
 	ALString sInitialClassName;
 	int i;
 
@@ -922,13 +922,13 @@ void KWPredictorEvaluator::RenameDatabaseClasses(KWDatabase* database, KWClassDo
 	else
 	{
 		// Recherche de la la classe initiale correspondant a la classe en cours de la base
-		sInitialRootClassName = "";
+		sInitialMainClassName = "";
 		kwcClass = KWClassDomain::GetCurrentDomain()->LookupClass(database->GetClassName());
 		if (kwcClass != NULL)
-			sInitialRootClassName = KWTrainedPredictor::GetMetaDataInitialClassName(kwcClass);
+			sInitialMainClassName = KWTrainedPredictor::GetMetaDataInitialClassName(kwcClass);
 
 		// Memorisation de cette classe
-		database->SetClassName(sInitialRootClassName);
+		database->SetClassName(sInitialMainClassName);
 
 		// Cas multi-table
 		if (database->IsMultiTableTechnology())
@@ -946,16 +946,16 @@ void KWPredictorEvaluator::RenameDatabaseClasses(KWDatabase* database, KWClassDo
 					sInitialClassName = KWTrainedPredictor::GetMetaDataInitialClassName(kwcClass);
 
 				// Recherche de la la classe initiale correspondant a la classe en cours
-				sInitialRootClassName = "";
+				sInitialMainClassName = "";
 				kwcClass =
 				    KWClassDomain::GetCurrentDomain()->LookupClass(mapping->GetOriginClassName());
 				if (kwcClass != NULL)
-					sInitialRootClassName =
+					sInitialMainClassName =
 					    KWTrainedPredictor::GetMetaDataInitialClassName(kwcClass);
 
 				// Memorisation de cette classe ainsi de que la classe principale de la base
 				mapping->SetClassName(sInitialClassName);
-				mapping->SetOriginClassName(sInitialRootClassName);
+				mapping->SetOriginClassName(sInitialMainClassName);
 			}
 		}
 	}

--- a/src/Learning/KhiopsNativeInterface/KWMTDatabaseStream.cpp
+++ b/src/Learning/KhiopsNativeInterface/KWMTDatabaseStream.cpp
@@ -136,14 +136,14 @@ KWObject* KWMTDatabaseStream::ReadFromBuffer(const char* sBuffer)
 	int i;
 
 	require(sBuffer != NULL);
-	require(rootMultiTableMapping->GetDataTableDriver() != NULL);
+	require(mainMultiTableMapping->GetDataTableDriver() != NULL);
 
 	// On repositionne le flag d'erreur a false, pour permettre des lectures sucessives
 	bIsError = false;
 	bSecondaryRecordError = false;
 
 	// Alimentation du buffer en entree
-	cast(KWDataTableDriverStream*, rootMultiTableMapping->GetDataTableDriver())->FillBufferWithRecord(sBuffer);
+	cast(KWDataTableDriverStream*, mainMultiTableMapping->GetDataTableDriver())->FillBufferWithRecord(sBuffer);
 
 	// Lecture de l'objet
 	kwoObject = Read();
@@ -173,13 +173,13 @@ boolean KWMTDatabaseStream::WriteToBuffer(KWObject* kwoObject, char* sBuffer, in
 {
 	boolean bOk;
 
-	require(rootMultiTableMapping->GetDataTableDriver() != NULL);
+	require(mainMultiTableMapping->GetDataTableDriver() != NULL);
 
 	// On repositionne le flag d'erreur a false, pour permettre des ecritures sucessives
 	bIsError = false;
 
 	// Vidage du buffer en sortie
-	cast(KWDataTableDriverStream*, rootMultiTableMapping->GetDataTableDriver())->ResetOutputBuffer();
+	cast(KWDataTableDriverStream*, mainMultiTableMapping->GetDataTableDriver())->ResetOutputBuffer();
 
 	// Ecriture de l'objet dans le buffer du stream
 	Write(kwoObject);
@@ -187,7 +187,7 @@ boolean KWMTDatabaseStream::WriteToBuffer(KWObject* kwoObject, char* sBuffer, in
 	// On recupere le resultat
 	bOk = not IsError();
 	if (bOk)
-		bOk = cast(KWDataTableDriverStream*, rootMultiTableMapping->GetDataTableDriver())
+		bOk = cast(KWDataTableDriverStream*, mainMultiTableMapping->GetDataTableDriver())
 			  ->FillRecordWithBuffer(sBuffer, nMaxBufferLength);
 	return bOk;
 }

--- a/src/Norm/base/Ermgt.cpp
+++ b/src/Norm/base/Ermgt.cpp
@@ -78,8 +78,8 @@ void Global::SignalHandler(int nSigNum)
 	else
 		cout << "Interrupt signal " << nSigNum << " : Unknown error" << endl;
 
-	// Sortie du programe (on n'utilise pas les signaux comme valeurs de retour car on renvoie 1 en cas d'erreur
-	// fatale et 2 en cas d'erreurs)
+	// Sortie du programe
+	// (on n'utilise pas les signaux comme valeurs de retour car on renvoie 1 en cas d'erreur fatale)
 	exit(EXIT_FAILURE);
 }
 

--- a/src/Norm/base/Standard.cpp
+++ b/src/Norm/base/Standard.cpp
@@ -681,7 +681,7 @@ void GlobalExit()
 		fflush(NULL);
 #endif
 
-		// Sortie fatale (seul exit de toutes)
+		// Sortie fatale (seul exit de tout le code)
 		// les librairies NORM)
 		exit(nExitCode);
 	}


### PR DESCRIPTION
Gestion des clés uniques dans les drivers de fichier et les base
- conditionné par la méthode IsUnique de KWClass (auraravant GetRoot)
- uniformisation de la terminologie, en passant de root a main, principalement pour la gestion des clés
  - dans les noms de méthodes (rappelé dans les notes de commit)
  - dans les noms d'attributs,  de paramètres ou de variables locales
  - dans les commentaires (racine -> principal)

Les commits de type "Improve terminology between root and main in..." ne concernent que du renommage,
sans aucun impact sur le code:
- ils peuvent être survolés lors du review
- ils pourraient être fusionnés en un seul commit

Noveau test dédié sur LearningTest\TestKhiops\MultiTables\NoRootSnowflakeDuplicates
Tests complet sur tout LearningTest

Création d'un issue à discuter: https://github.com/KhiopsML/khiops/issues/483