### PR TITLE
Fix fatal error in GUI mode with an incorrect scenario

### DIFF
--- a/src/Norm/base/CommandFile.h
+++ b/src/Norm/base/CommandFile.h
@@ -39,6 +39,11 @@ public:
 	void SetOutputCommandFileName(const ALString& sFileName);
 	const ALString& GetOutputCommandFileName() const;
 
+	// Mode batch, pour creer une erreur fatale en d'erreur de commande (defaut: false)
+	// En mode GUI, on continue dans la GUI apres avoir simplement signale l'erreur
+	void SetBatchMode(boolean bValue);
+	boolean GetBatchMode() const;
+
 	// Indique qu'il faut afficher les sorties dans la console
 	// Determine par le parametrage du fichier de commande en sortie
 	boolean GetPrintOutputInConsole() const;
@@ -320,6 +325,9 @@ protected:
 	// Gestion des chaines des patterns a remplacer par des valeurs dans les fichiers d'input de scenario
 	StringVector svInputCommandSearchValues;
 	StringVector svInputCommandReplaceValues;
+
+	// Mode batch
+	boolean bBatchMode;
 
 	///////////////////////////////////////////////////////////////
 	// Variables de gestion des fichiers et parametres de commandes

--- a/src/Norm/base/CommandLine.cpp
+++ b/src/Norm/base/CommandLine.cpp
@@ -562,6 +562,7 @@ CommandLineOption::CommandLineOption()
 	nPriority = INT_MAX;
 	bIsUsed = false;
 	bIsFinal = false;
+	nIndexUsage = 0;
 }
 
 CommandLineOption::~CommandLineOption()

--- a/src/Norm/base/UIObject.cpp
+++ b/src/Norm/base/UIObject.cpp
@@ -2106,6 +2106,7 @@ boolean UIObject::BatchCommand(const ALString& sParameter)
 	assert(sParameter == "");
 
 	bBatchMode = true;
+	commandFile.SetBatchMode(bBatchMode);
 	return true;
 }
 


### PR DESCRIPTION
En cas d'erreur de scenario, en mode batch, Khiops sort en erreur fatale "Batch mode failure" apres avoir signale la ligne de scenario erronees au moyen d'une erreur standard. En mode GUI, on se contente de signaler l'erreur dans le log, mais la GUI continue d'etre utilisable.

Un bug a ete introduit avec la prise en compte du pilotage par une structure json, en sortant en erreur fatale meme dans le mode GUI.

Correction
- CommandFile
  - Set|GetBatchMode: parametrage du mode batch
  - CloseInputCommandFile: utiliosation du parametre BatchMode pour provoquer ou non une erreur fatale
- UIObject
  - BatchCommand: parametrage du mode batch du commandFile