### PR TITLE
496 extend comment syntax in khiops dictionaries

### DIFF
--- a/src/Learning/KWData/KWAttribute.cpp
+++ b/src/Learning/KWData/KWAttribute.cpp
@@ -561,7 +561,8 @@ void KWAttribute::WriteJSONFields(JSONFile* fJSON)
 	if (GetLabel() != "")
 		fJSON->WriteKeyString("label", GetLabel());
 
-	// Commentaires
+	// Commentaires, ecrits uniquement si presents, comme pour les autres champs facultatifs,
+	// ce qui facilite la compatibilite ascendante, et diminue la volumetrie
 	if (GetComments()->GetSize() > 0)
 	{
 		fJSON->BeginKeyArray("comments");
@@ -570,7 +571,7 @@ void KWAttribute::WriteJSONFields(JSONFile* fJSON)
 		fJSON->EndArray();
 	}
 
-	// Attribute a ne pas utiliser
+	// Attribut a ne pas utiliser
 	if (not GetUsed())
 		fJSON->WriteKeyBoolean("used", false);
 

--- a/src/Learning/KWData/KWAttribute.h
+++ b/src/Learning/KWData/KWAttribute.h
@@ -82,8 +82,14 @@ public:
 	const KWTimestampTZFormat* GetTimestampTZFormat() const;
 
 	// Libelle
+	// Fin de ligne prefixee par '//' suivant la declaration de l'attribut dans le fichier dictionnaire
 	const ALString& GetLabel() const;
 	void SetLabel(const ALString& sValue);
+
+	// Commentaires
+	// Lignes prefixees par '//' precedent la declaration de l'attribut dans le fichier dictionnaire
+	const StringVector* GetComments() const;
+	void SetComments(const StringVector* svValue);
 
 	// Attribut effectivement utilise, chargeable en memoire
 	// Un attribut non utilise devient non charge
@@ -241,6 +247,7 @@ protected:
 	// Specifications de l'attribut
 	KWCDUniqueString usName;
 	KWCDUniqueString usLabel;
+	StringVector svComments;
 	KWMetaData metaData;
 	KWClass* attributeClass;
 	KWCDUniqueString usStructureName;
@@ -399,6 +406,16 @@ inline const ALString& KWAttribute::GetLabel() const
 inline void KWAttribute::SetLabel(const ALString& sValue)
 {
 	usLabel.SetValue(sValue);
+}
+
+inline const StringVector* KWAttribute::GetComments() const
+{
+	return &svComments;
+}
+
+inline void KWAttribute::SetComments(const StringVector* svValue)
+{
+	svComments.CopyFrom(svValue);
 }
 
 inline boolean KWAttribute::GetUsed() const

--- a/src/Learning/KWData/KWAttributeBlock.cpp
+++ b/src/Learning/KWData/KWAttributeBlock.cpp
@@ -796,7 +796,7 @@ void KWAttributeBlock::Write(ostream& ost) const
 	KWAttribute* attribute;
 	int i;
 
-	// Commentaires prededents le debut du bloc
+	// Commentaires precedant le debut du bloc
 	for (i = 0; i < GetComments()->GetSize(); i++)
 		ost << "\t// " << GetComments()->GetAt(i) << "\n";
 	ost << "\t{\n";
@@ -865,7 +865,8 @@ void KWAttributeBlock::WriteJSONFields(JSONFile* fJSON)
 	if (GetLabel() != "")
 		fJSON->WriteKeyString("label", GetLabel());
 
-	// Commentaire
+	// Commentaires, ecrits uniquement si presents, comme pour les autres champs facultatifs,
+	// ce qui facilite la compatibilite ascendante, et diminue la volumetrie
 	if (GetComments()->GetSize() > 0)
 	{
 		fJSON->BeginKeyArray("comments");
@@ -903,7 +904,7 @@ void KWAttributeBlock::WriteJSONFields(JSONFile* fJSON)
 	}
 	fJSON->EndArray();
 
-	// Commentaires internes
+	// Commentaires internes, uniquement si presents, comme pour les commentaires
 	if (GetInternalComments()->GetSize() > 0)
 	{
 		fJSON->BeginKeyArray("internalComments");

--- a/src/Learning/KWData/KWAttributeBlock.cpp
+++ b/src/Learning/KWData/KWAttributeBlock.cpp
@@ -130,6 +130,18 @@ boolean KWAttributeBlock::Check() const
 	if (not KWClass::CheckName(GetName(), KWClass::AttributeBlock, this))
 		bOk = false;
 
+	// Verification du Label
+	if (not KWClass::CheckLabel(GetLabel(), KWClass::AttributeBlock, this))
+		bOk = false;
+
+	// Verification des commentaires
+	if (not KWClass::CheckComments(GetComments(), KWClass::AttributeBlock, this))
+		bOk = false;
+
+	// Verification des commentaires internes
+	if (not KWClass::CheckComments(GetInternalComments(), KWClass::AttributeBlock, this))
+		bOk = false;
+
 	// Tests de base sur la specification du block
 	if (bOk and firstAttribute == NULL)
 	{
@@ -746,6 +758,8 @@ longint KWAttributeBlock::GetUsedMemory() const
 	lUsedMemory = sizeof(KWAttributeBlock);
 	lUsedMemory += usName.GetUsedMemory();
 	lUsedMemory += usLabel.GetUsedMemory();
+	lUsedMemory += svComments.GetUsedMemory();
+	lUsedMemory += svInternalComments.GetUsedMemory();
 	lUsedMemory += metaData.GetUsedMemory() - sizeof(KWMetaData);
 
 	// Prise en compte de la regle de derivation
@@ -778,27 +792,63 @@ longint KWAttributeBlock::ComputeHashValue() const
 
 void KWAttributeBlock::Write(ostream& ost) const
 {
-	KWAttribute* secondAttribute;
+	KWClass* parentClass;
+	KWAttribute* attribute;
+	int i;
 
-	ost << '{';
-	if (firstAttribute != NULL)
+	// Commentaires prededents le debut du bloc
+	for (i = 0; i < GetComments()->GetSize(); i++)
+		ost << "\t// " << GetComments()->GetAt(i) << "\n";
+	ost << "\t{\n";
+
+	// Attributs du bloc
+	parentClass = GetParentClass();
+	attribute = firstAttribute;
+	while (attribute != NULL)
 	{
-		ost << firstAttribute->GetName();
+		// Ecriture de l'attribut
+		ost << *attribute << "\n";
 
-		// Acces au deuxieme attribut
-		secondAttribute = firstAttribute;
-		if (GetParentClass() != NULL)
-			GetParentClass()->GetNextAttribute(secondAttribute);
+		// Arret si derniere variable du bloc trouvee
+		if (attribute == lastAttribute)
+			break;
 
-		// Si au moins trois attributs
-		if (lastAttribute != NULL and secondAttribute != NULL and lastAttribute != secondAttribute)
-			ost << ",..., ";
-
-		// Dernier attribut si au moins deux attributs
-		if (lastAttribute != NULL and lastAttribute != firstAttribute)
-			ost << ", " + lastAttribute->GetName();
+		// Passage a l'attribut suivant
+		parentClass->GetNextAttribute(attribute);
 	}
-	ost << "}\t" << GetName() << endl;
+
+	// Commentaires internes precedents la fin du bloc
+	for (i = 0; i < GetInternalComments()->GetSize(); i++)
+		ost << "\t// " << GetInternalComments()->GetAt(i) << "\n";
+	ost << "\t}";
+
+	// Nom du bloc
+	ost << "\t" << KWClass::GetExternalName(GetName());
+	ost << "\t";
+
+	// Regle de derivation
+	if (GetDerivationRule() != NULL)
+	{
+		// Dans le cas de la regle predefinie de Reference, on n'utilise pas le signe '='
+		if (GetDerivationRule()->GetName() != KWDerivationRule::GetReferenceRuleName())
+			ost << " = ";
+		GetDerivationRule()->WriteUsedRule(ost);
+	}
+
+	// Fin de declaration
+	ost << "\t;";
+
+	// Meta-donnees
+	if (GetConstMetaData()->GetKeyNumber() > 0)
+	{
+		ost << ' ';
+		GetConstMetaData()->Write(ost);
+	}
+	ost << "\t";
+
+	// Libelle
+	if (GetLabel() != "")
+		ost << "// " << GetLabel();
 }
 
 void KWAttributeBlock::WriteJSONFields(JSONFile* fJSON)
@@ -806,13 +856,23 @@ void KWAttributeBlock::WriteJSONFields(JSONFile* fJSON)
 	KWClass* parentClass;
 	KWAttribute* attribute;
 	ALString sOutputString;
+	int i;
 
 	// Nom
 	fJSON->WriteKeyString("blockName", GetName());
 
-	// Commentaire
+	// Libelle
 	if (GetLabel() != "")
 		fJSON->WriteKeyString("label", GetLabel());
+
+	// Commentaire
+	if (GetComments()->GetSize() > 0)
+	{
+		fJSON->BeginKeyArray("comments");
+		for (i = 0; i < GetComments()->GetSize(); i++)
+			fJSON->WriteString(GetComments()->GetAt(i));
+		fJSON->EndArray();
+	}
 
 	// Regle de derivation
 	if (kwdrRule != NULL)
@@ -842,6 +902,15 @@ void KWAttributeBlock::WriteJSONFields(JSONFile* fJSON)
 		parentClass->GetNextAttribute(attribute);
 	}
 	fJSON->EndArray();
+
+	// Commentaires internes
+	if (GetInternalComments()->GetSize() > 0)
+	{
+		fJSON->BeginKeyArray("internalComments");
+		for (i = 0; i < GetInternalComments()->GetSize(); i++)
+			fJSON->WriteString(GetInternalComments()->GetAt(i));
+		fJSON->EndArray();
+	}
 }
 
 const ALString KWAttributeBlock::GetClassLabel() const

--- a/src/Learning/KWData/KWAttributeBlock.h
+++ b/src/Learning/KWData/KWAttributeBlock.h
@@ -75,12 +75,12 @@ public:
 	void SetLabel(const ALString& sValue);
 
 	// Commentaires
-	// Ensemble des lignes prefixees par '//' precedent le debut du bloc d'attributs '{' dans le fichier dictionnaire
+	// Ensemble des lignes prefixees par '//' precedant le debut du bloc d'attributs '{' dans le fichier dictionnaire
 	const StringVector* GetComments() const;
 	void SetComments(const StringVector* svValue);
 
 	// Commentaires internes
-	// Ensemble des lignes prefixees par '//' precedent la fin du bloc d'attributs '}' dans le fichier dictionnaire
+	// Ensemble des lignes prefixees par '//' precedant la fin du bloc d'attributs '}' dans le fichier dictionnaire
 	const StringVector* GetInternalComments() const;
 	void SetInternalComments(const StringVector* svValue);
 

--- a/src/Learning/KWData/KWAttributeBlock.h
+++ b/src/Learning/KWData/KWAttributeBlock.h
@@ -70,8 +70,19 @@ public:
 	void ImportMetaDataFrom(const KWAttributeBlock* sourceAttributeBlock);
 
 	// Libelle
+	// Fin de ligne prefixee par '//' suivant la declaration du bloc d'attributs dans le fichier dictionnaire
 	const ALString& GetLabel() const;
 	void SetLabel(const ALString& sValue);
+
+	// Commentaires
+	// Ensemble des lignes prefixees par '//' precedent le debut du bloc d'attributs '{' dans le fichier dictionnaire
+	const StringVector* GetComments() const;
+	void SetComments(const StringVector* svValue);
+
+	// Commentaires internes
+	// Ensemble des lignes prefixees par '//' precedent la fin du bloc d'attributs '}' dans le fichier dictionnaire
+	const StringVector* GetInternalComments() const;
+	void SetInternalComments(const StringVector* svValue);
 
 	/////////////////////////////////////////////////////////
 	// Informations de specification du bloc, suite a sa
@@ -259,6 +270,8 @@ protected:
 	// Specifications du bloc
 	KWCDUniqueString usName;
 	KWCDUniqueString usLabel;
+	StringVector svComments;
+	StringVector svInternalComments;
 	KWDerivationRule* kwdrRule;
 	KWMetaData metaData;
 
@@ -371,6 +384,26 @@ inline const ALString& KWAttributeBlock::GetLabel() const
 inline void KWAttributeBlock::SetLabel(const ALString& sValue)
 {
 	usLabel.SetValue(sValue);
+}
+
+inline const StringVector* KWAttributeBlock::GetComments() const
+{
+	return &svComments;
+}
+
+inline void KWAttributeBlock::SetComments(const StringVector* svValue)
+{
+	svComments.CopyFrom(svValue);
+}
+
+inline const StringVector* KWAttributeBlock::GetInternalComments() const
+{
+	return &svInternalComments;
+}
+
+inline void KWAttributeBlock::SetInternalComments(const StringVector* svValue)
+{
+	svInternalComments.CopyFrom(svValue);
 }
 
 inline KWAttribute* KWAttributeBlock::GetFirstAttribute() const

--- a/src/Learning/KWData/KWCLex.inc
+++ b/src/Learning/KWData/KWCLex.inc
@@ -566,14 +566,14 @@ char *yytext;
 #pragma warning(disable : 4996) // C4996: warning for deprecated POSIX names isatty and fileno
 #endif                          // __MSC__
 
-/* Redefinition du nombre de token max */
+// Redefinition du nombre de token max
 #undef YYLMAX
-#define	YYLMAX		100000		/* token and pushback buffer size */
+#define	YYLMAX		100000		// token and pushback buffer size
 
 #line 573 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
-/* pour avoir acces aux numeros de lignes, et moins cher que le -l de la ligne de commande */
+/* Pour avoir acces aux numeros de lignes, et moins cher que le -l de la ligne de commande */
 /* Attention, la liste des mots cles du langage doit etre reprise dans la methode KWClass::IsStringKeyWord() */
-/* si on veut autoriser des noms de variable en collision avec ces mots cles.                                */
+/* si on veut autoriser des noms de variable en collision avec ces mots cles. */
 #line 577 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
 
 #define INITIAL 0
@@ -786,7 +786,7 @@ YY_DECL
 		}
 
 	{
-#line 31 "KWCLex.lex"
+#line 32 "KWCLex.lex"
 
 
 #line 792 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
@@ -859,7 +859,7 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 33 "KWCLex.lex"
+#line 34 "KWCLex.lex"
 {
                           // Un commentaire tient sur une seule ligne, prefixe par '//', et precede potentiellement de caracteres d'espace
 							
@@ -886,7 +886,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 58 "KWCLex.lex"
+#line 59 "KWCLex.lex"
 {
                           // Un libelle est prefixe par '//', mais n'est pas seul sur sa ligne
 
@@ -916,7 +916,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 86 "KWCLex.lex"
+#line 87 "KWCLex.lex"
 {
                           ALString *sValue;
                           int nInput;
@@ -938,7 +938,8 @@ YY_RULE_SETUP
 								nNextInput = yyinput();
 								cNext = (unsigned char)nNextInput;
 
-								// Si pas d'autre double-quote (doublement de double-quote interne), on remet le caractere a analyser avant de declarer la fin du token
+								// Si pas d'autre double-quote (doublement de double-quote interne), on remet le caractere
+								//a analyser avant de declarer la fin du token
 								if (cNext != '"')
 								{
 								  unput(cNext);
@@ -973,7 +974,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 140 "KWCLex.lex"
+#line 142 "KWCLex.lex"
 {
                           ALString *sValue;
                           int nInput;
@@ -996,7 +997,8 @@ YY_RULE_SETUP
 								nNextInput = yyinput();
 								cNext = (unsigned char)nNextInput;
 
-								// Si pas d'autre back-quote (doublement de back-quote interne), on remet le caractere a analyser avant de declarer la fin du token
+								// Si pas d'autre back-quote (doublement de back-quote interne), on remet le caractere
+								// a analyser avant de declarer la fin du token
 								if (cNext != '`')
 								{
 								  unput(cNext);
@@ -1030,82 +1032,82 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 194 "KWCLex.lex"
+#line 197 "KWCLex.lex"
 return CLASS;
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 196 "KWCLex.lex"
+#line 199 "KWCLex.lex"
 return CONTINUOUSTYPE;
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 198 "KWCLex.lex"
+#line 201 "KWCLex.lex"
 return SYMBOLTYPE;
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 200 "KWCLex.lex"
+#line 203 "KWCLex.lex"
 return OBJECTARRAYTYPE;
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 202 "KWCLex.lex"
+#line 205 "KWCLex.lex"
 return ROOT;
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 204 "KWCLex.lex"
+#line 207 "KWCLex.lex"
 return UNUSED;
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 206 "KWCLex.lex"
+#line 209 "KWCLex.lex"
 return DATETYPE;
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 208 "KWCLex.lex"
+#line 211 "KWCLex.lex"
 return TIMETYPE;
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 210 "KWCLex.lex"
+#line 213 "KWCLex.lex"
 return TIMESTAMPTYPE;
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 212 "KWCLex.lex"
+#line 215 "KWCLex.lex"
 return TIMESTAMPTZTYPE;
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 214 "KWCLex.lex"
+#line 217 "KWCLex.lex"
 return TEXTTYPE;
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 216 "KWCLex.lex"
+#line 219 "KWCLex.lex"
 return TEXTLISTTYPE;
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 218 "KWCLex.lex"
+#line 221 "KWCLex.lex"
 return OBJECTTYPE;
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 220 "KWCLex.lex"
+#line 223 "KWCLex.lex"
 return STRUCTURETYPE;
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 223 "KWCLex.lex"
+#line 226 "KWCLex.lex"
 return *yytext;
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 225 "KWCLex.lex"
+#line 228 "KWCLex.lex"
 {
                           ALString *sValue;
                           sValue = new ALString ( (char*)yytext );
@@ -1115,7 +1117,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 232 "KWCLex.lex"
+#line 235 "KWCLex.lex"
 {
                           yylval.cValue=KWContinuous::StringToContinuous((char*)yytext);
                           return(CONTINUOUSLITTERAL);
@@ -1123,7 +1125,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 237 "KWCLex.lex"
+#line 240 "KWCLex.lex"
 {
                           yylval.cValue=KWContinuous::GetMissingValue();
                           return(CONTINUOUSLITTERAL);
@@ -1131,7 +1133,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 242 "KWCLex.lex"
+#line 245 "KWCLex.lex"
 {
                           // Les types retournes par le parser sont des unsigned char:
                           // il faut etre compatible sous peine de bugs pour des caracteres interpretes
@@ -1160,12 +1162,12 @@ YY_RULE_SETUP
 case 24:
 /* rule 24 can match eol */
 YY_RULE_SETUP
-#line 269 "KWCLex.lex"
+#line 272 "KWCLex.lex"
 ;
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 272 "KWCLex.lex"
+#line 275 "KWCLex.lex"
 {
 						  const int nMaxLength = 20;
                           ALString sTmp;
@@ -1223,10 +1225,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 326 "KWCLex.lex"
+#line 329 "KWCLex.lex"
 ECHO;
 	YY_BREAK
-#line 1229 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
+#line 1231 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2245,4 +2247,4 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 326 "KWCLex.lex"
+#line 329 "KWCLex.lex"

--- a/src/Learning/KWData/KWCLex.inc
+++ b/src/Learning/KWData/KWCLex.inc
@@ -370,8 +370,8 @@ static void yynoreturn yy_fatal_error ( const char* msg  );
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-#define YY_NUM_RULES 25
-#define YY_END_OF_BUFFER 26
+#define YY_NUM_RULES 26
+#define YY_END_OF_BUFFER 27
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -379,22 +379,22 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[122] =
+static const flex_int16_t yy_accept[127] =
     {   0,
-        0,    0,   26,   24,   23,   23,    2,   22,   18,   19,
-       18,   24,   18,   24,   20,   19,   19,   19,   19,   19,
-       19,   19,   19,    3,   23,    0,   19,    0,   20,   20,
-        1,    0,   20,   20,    0,   19,   19,   19,   19,   19,
-       19,   19,   19,   19,   19,   19,    0,   20,   20,   20,
-       20,   19,   19,   19,   19,   19,   19,   19,   19,   19,
-       19,   19,    0,   20,   20,   20,   19,   10,   19,   19,
-       19,    8,   19,   19,   14,   11,   19,    0,   19,   19,
-       19,   19,   19,    7,   19,   19,   19,    0,   19,   19,
-       16,   19,   19,   19,   19,    9,    0,   19,   19,   19,
+        0,    0,   27,   25,   24,   24,    3,   23,   19,   19,
+       25,   19,   25,   21,   20,   20,   20,   20,   20,   20,
+       20,   20,   20,    4,   24,   25,    0,    0,   21,   21,
+        2,    0,   21,   21,    0,   20,   20,   20,   20,   20,
+       20,   20,   20,   20,   20,   20,   20,    0,    0,    1,
+        0,   21,   21,   21,   21,   20,   20,   20,   20,   20,
+       20,   20,   20,   20,   20,   20,    1,    0,   21,   21,
+       21,   20,   11,   20,   20,   20,    9,   20,   20,   15,
+       12,   20,    0,   20,   20,   20,   20,   20,    8,   20,
+       20,   20,    0,   20,   20,   17,   20,   20,   20,   20,
 
-       19,   19,   19,   21,   19,   19,   19,   19,   15,   19,
-       19,   19,    5,   17,   12,   19,    4,   19,    6,   13,
-        0
+       10,    0,   20,   20,   20,   20,   20,   20,   22,   20,
+       20,   20,   20,   16,   20,   20,   20,    6,   18,   13,
+       20,    5,   20,    7,   14,    0
     } ;
 
 static const YY_CHAR yy_ec[256] =
@@ -403,16 +403,16 @@ static const YY_CHAR yy_ec[256] =
         2,    2,    2,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    2,    1,    4,    5,    1,    1,    1,    1,    6,
-        6,    7,    8,    6,    9,   10,   11,   12,   12,   12,
-       12,   12,   12,   12,   12,   12,   12,    6,    6,    6,
-        6,    6,    1,    1,    7,    7,   13,   14,   15,    7,
-        7,    7,    7,    7,    7,   16,   17,   18,    7,    7,
-        7,   19,   20,   21,   22,    7,    7,    7,    7,   23,
-        6,    1,    6,    1,    7,   24,   25,   26,   27,   28,
+        6,    1,    7,    6,    8,    9,   10,   11,   11,   11,
+       11,   11,   11,   11,   11,   11,   11,    6,    6,    6,
+        6,    6,    1,    1,   12,   12,   13,   14,   15,   12,
+       12,   12,   12,   12,   12,   16,   17,   18,   12,   12,
+       12,   19,   20,   21,   22,   12,   12,   12,   12,   23,
+        6,    1,    6,    1,   12,   24,   25,   26,   27,   28,
 
-       29,    7,   30,    7,   31,    7,    7,   32,   33,   34,
-       35,   36,    7,   37,   38,   39,   40,    7,    7,   41,
-       42,    7,    6,    1,    6,    1,    1,    1,    1,    1,
+       29,   12,   30,   12,   31,   12,   12,   32,   33,   34,
+       35,   36,   12,   37,   38,   39,   40,   12,   12,   41,
+       42,   12,    6,    1,    6,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -431,114 +431,116 @@ static const YY_CHAR yy_ec[256] =
 
 static const YY_CHAR yy_meta[43] =
     {   0,
-        1,    1,    1,    1,    1,    1,    2,    1,    1,    1,
-        1,    2,    2,    2,    2,    2,    2,    2,    2,    2,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    1,    2,    2,    2,    2,    2,    2,
         2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
         2,    2
     } ;
 
-static const flex_int16_t yy_base[123] =
+static const flex_int16_t yy_base[128] =
     {   0,
-        0,    0,  196,  197,   41,   43,  197,  178,  197,    0,
-       37,   38,  182,  182,   43,  167,   29,  157,  150,  154,
-      149,   32,  153,  197,   62,  155,    0,  173,   58,   66,
-      197,  172,   68,   76,   81,  144,  143,  154,  141,  146,
-      143,  140,  150,  134,  141,  133,  134,   91,  159,   99,
-      107,  141,  140,  129,  136,  137,  126,  124,  131,  123,
-      132,  122,  121,  115,  146,  117,  127,    0,  125,  116,
-      117,    0,  126,  123,  135,  112,  120,  117,  112,  110,
-      101,  111,  102,    0,  109,  100,  110,  103,   98,  100,
-        0,  106,   91,   83,   93,    0,   83,   81,   85,   84,
+        0,   41,  198,  199,  199,  199,  199,  180,  199,   35,
+       36,  185,  185,   41,    0,  169,   28,  159,  152,  156,
+      151,   29,  155,  199,   53,  178,  156,  175,   57,   66,
+      199,  174,   68,   81,   91,    0,  145,  144,  155,  142,
+      147,  144,  141,  151,  135,  142,  134,   59,  163,  199,
+      134,   93,  160,   98,  108,  141,  140,  129,  136,  137,
+      126,  124,  131,  123,  132,  122,  199,  121,  113,  147,
+      118,  127,    0,  125,  116,  117,    0,  126,  123,  135,
+      112,  120,  117,  111,  110,  102,  112,  102,    0,  109,
+      100,  110,  102,   98,  100,    0,  105,   91,   92,   93,
 
-       67,   63,   68,  197,   71,   59,   62,   63,    0,   46,
-       54,   29,    0,    0,   48,   30,    0,   36,    0,    0,
-      197,   54
+        0,   84,   81,   86,   82,   66,   55,   60,  199,   64,
+       50,   53,   55,    0,   46,   55,   36,    0,    0,   50,
+       35,    0,   39,    0,    0,  199,   55
     } ;
 
-static const flex_int16_t yy_def[123] =
+static const flex_int16_t yy_def[128] =
     {   0,
-      121,    1,  121,  121,  121,  121,  121,  121,  121,  122,
-      121,  121,  121,  121,  121,  122,  122,  122,  122,  122,
-      122,  122,  122,  121,  121,  121,  122,  121,  121,  121,
-      121,  121,  121,  121,  121,  122,  122,  122,  122,  122,
-      122,  122,  122,  122,  122,  122,  121,  121,  121,  121,
-      121,  122,  122,  122,  122,  122,  122,  122,  122,  122,
-      122,  122,  121,  121,  121,  121,  122,  122,  122,  122,
-      122,  122,  122,  122,  122,  122,  122,  121,  122,  122,
-      122,  122,  122,  122,  122,  122,  122,  121,  122,  122,
-      122,  122,  122,  122,  122,  122,  121,  122,  122,  122,
+      126,    1,  126,  126,  126,  126,  126,  126,  126,  126,
+      126,  126,  126,  126,  127,  127,  127,  127,  127,  127,
+      127,  127,  127,  126,  126,  126,  126,  126,  126,  126,
+      126,  126,  126,  126,  126,  127,  127,  127,  127,  127,
+      127,  127,  127,  127,  127,  127,  127,  126,  126,  126,
+      126,  126,  126,  126,  126,  127,  127,  127,  127,  127,
+      127,  127,  127,  127,  127,  127,  126,  126,  126,  126,
+      126,  127,  127,  127,  127,  127,  127,  127,  127,  127,
+      127,  127,  126,  127,  127,  127,  127,  127,  127,  127,
+      127,  127,  126,  127,  127,  127,  127,  127,  127,  127,
 
-      122,  122,  122,  121,  122,  122,  122,  122,  122,  122,
-      122,  122,  122,  122,  122,  122,  122,  122,  122,  122,
-        0,  121
+      127,  126,  127,  127,  127,  127,  127,  127,  126,  127,
+      127,  127,  127,  127,  127,  127,  127,  127,  127,  127,
+      127,  127,  127,  127,  127,    0,  126
     } ;
 
-static const flex_int16_t yy_nxt[240] =
+static const flex_int16_t yy_nxt[242] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
-       14,   15,   16,   17,   18,   10,   10,   19,   20,   21,
-       22,   23,   10,   24,   10,   10,   10,   10,   10,   10,
-       10,   10,   10,   10,   10,   10,   10,   10,   10,   10,
-       10,   10,   25,   25,   25,   25,   28,   28,   29,   29,
-       32,   32,   33,   37,   34,   27,   43,   35,  120,   38,
-       44,  119,   45,   25,   25,   32,   32,   33,  118,   34,
-      117,   35,   35,   32,   32,   32,   32,   48,  116,   50,
-       35,  115,   35,   32,   32,   33,   35,   51,   32,   32,
-       35,  114,   49,  113,   35,  112,   35,  111,   32,   32,
+       14,   15,   16,   17,   18,   15,   15,   19,   20,   21,
+       22,   23,   15,   24,   15,   15,   15,   15,   15,   15,
+       15,   15,   15,   15,   15,   15,   15,   15,   15,   15,
+       15,   15,   25,   28,   28,   29,   29,   32,   32,   33,
+       26,   34,   38,   44,   48,   35,   36,   45,   39,   46,
+       48,  125,   49,   32,   32,   33,  124,   34,   49,   35,
+      123,   35,   32,   32,   32,   32,   52,  122,   54,  121,
+       35,  120,   35,  119,  118,   35,  117,   32,   32,   33,
+      116,   55,  115,  114,   35,   35,   35,   32,   32,   32,
 
-      110,  109,   64,  108,   35,   35,   32,   32,  107,  106,
-       66,  105,  104,   35,   32,   32,   33,  103,   51,   35,
-      102,   35,   32,   32,   32,   32,   64,   35,   66,   35,
-      101,   35,  100,   99,   98,   35,   97,   96,   95,   94,
-       93,   92,   91,   35,   90,   35,   89,   88,   87,   86,
-       85,   84,   83,   82,   81,   80,   79,   65,   78,   77,
-       76,   75,   74,   73,   72,   71,   70,   69,   68,   67,
-       65,   63,   62,   61,   60,   59,   58,   57,   56,   55,
-       54,   53,   52,   49,   30,   47,   46,   42,   41,   40,
-       39,   36,   31,   30,   26,  121,    3,  121,  121,  121,
+       32,   53,  113,   69,   32,   32,  112,   35,   71,   35,
+      111,  110,   35,  109,   32,   32,   33,  108,   55,   32,
+       32,   35,   35,   69,   32,   32,   35,   35,   71,  107,
+      106,  105,   35,  104,  103,  102,   35,  101,  100,   99,
+       98,   35,   97,   96,   95,   94,   35,   93,   92,   91,
+       90,   89,   88,   87,   86,   85,   84,   70,   83,   82,
+       81,   80,   79,   78,   77,   76,   75,   74,   73,   72,
+       70,   68,   67,   66,   65,   64,   63,   62,   61,   60,
+       59,   58,   57,   56,   53,   30,   51,   50,   47,   43,
+       42,   41,   40,   37,   31,   30,   27,  126,    3,  126,
 
-      121,  121,  121,  121,  121,  121,  121,  121,  121,  121,
-      121,  121,  121,  121,  121,  121,  121,  121,  121,  121,
-      121,  121,  121,  121,  121,  121,  121,  121,  121,  121,
-      121,  121,  121,  121,  121,  121,  121,  121,  121
+      126,  126,  126,  126,  126,  126,  126,  126,  126,  126,
+      126,  126,  126,  126,  126,  126,  126,  126,  126,  126,
+      126,  126,  126,  126,  126,  126,  126,  126,  126,  126,
+      126,  126,  126,  126,  126,  126,  126,  126,  126,  126,
+      126
     } ;
 
-static const flex_int16_t yy_chk[240] =
+static const flex_int16_t yy_chk[242] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    5,    5,    6,    6,   11,   12,   11,   12,
-       15,   15,   15,   17,   15,  122,   22,   15,  118,   17,
-       22,  116,   22,   25,   25,   29,   29,   29,  115,   29,
-      112,   15,   29,   30,   30,   33,   33,   30,  111,   33,
-       30,  110,   33,   34,   34,   34,   29,   34,   35,   35,
-       34,  108,   35,  107,   30,  106,   33,  105,   48,   48,
+        1,    1,    2,   10,   11,   10,   11,   14,   14,   14,
+        2,   14,   17,   22,   25,   14,  127,   22,   17,   22,
+       48,  123,   25,   29,   29,   29,  121,   29,   48,   14,
+      120,   29,   30,   30,   33,   33,   30,  117,   33,  116,
+       30,  115,   33,  113,  112,   29,  111,   34,   34,   34,
+      110,   34,  108,  107,   30,   34,   33,   35,   35,   52,
 
-      103,  102,   48,  101,   34,   48,   50,   50,  100,   99,
-       50,   98,   97,   50,   51,   51,   51,   95,   51,   48,
-       94,   51,   64,   64,   66,   66,   64,   50,   66,   64,
-       93,   66,   92,   90,   89,   51,   88,   87,   86,   85,
-       83,   82,   81,   64,   80,   66,   79,   78,   77,   76,
-       75,   74,   73,   71,   70,   69,   67,   65,   63,   62,
-       61,   60,   59,   58,   57,   56,   55,   54,   53,   52,
-       49,   47,   46,   45,   44,   43,   42,   41,   40,   39,
-       38,   37,   36,   32,   28,   26,   23,   21,   20,   19,
-       18,   16,   14,   13,    8,    3,  121,  121,  121,  121,
+       52,   35,  106,   52,   54,   54,  105,   52,   54,   34,
+      104,  103,   54,  102,   55,   55,   55,  100,   55,   69,
+       69,   52,   55,   69,   71,   71,   54,   69,   71,   99,
+       98,   97,   71,   95,   94,   93,   55,   92,   91,   90,
+       88,   69,   87,   86,   85,   84,   71,   83,   82,   81,
+       80,   79,   78,   76,   75,   74,   72,   70,   68,   66,
+       65,   64,   63,   62,   61,   60,   59,   58,   57,   56,
+       53,   51,   49,   47,   46,   45,   44,   43,   42,   41,
+       40,   39,   38,   37,   32,   28,   27,   26,   23,   21,
+       20,   19,   18,   16,   13,   12,    8,    3,  126,  126,
 
-      121,  121,  121,  121,  121,  121,  121,  121,  121,  121,
-      121,  121,  121,  121,  121,  121,  121,  121,  121,  121,
-      121,  121,  121,  121,  121,  121,  121,  121,  121,  121,
-      121,  121,  121,  121,  121,  121,  121,  121,  121
+      126,  126,  126,  126,  126,  126,  126,  126,  126,  126,
+      126,  126,  126,  126,  126,  126,  126,  126,  126,  126,
+      126,  126,  126,  126,  126,  126,  126,  126,  126,  126,
+      126,  126,  126,  126,  126,  126,  126,  126,  126,  126,
+      126
     } ;
 
 /* Table of booleans, true if rule could match eol. */
-static const flex_int32_t yy_rule_can_match_eol[26] =
+static const flex_int32_t yy_rule_can_match_eol[27] =
     {   0,
 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 1, 0, 0,     };
+    0, 0, 0, 0, 1, 0, 0,     };
 
 static yy_state_type yy_last_accepting_state;
 static char *yy_last_accepting_cpos;
@@ -568,11 +570,11 @@ char *yytext;
 #undef YYLMAX
 #define	YYLMAX		100000		/* token and pushback buffer size */
 
-#line 571 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
+#line 573 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
 /* pour avoir acces aux numeros de lignes, et moins cher que le -l de la ligne de commande */
 /* Attention, la liste des mots cles du langage doit etre reprise dans la methode KWClass::IsStringKeyWord() */
 /* si on veut autoriser des noms de variable en collision avec ces mots cles.                                */
-#line 575 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
+#line 577 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
 
 #define INITIAL 0
 
@@ -744,6 +746,9 @@ extern int yylex (void);
 #endif
 
 #define YY_RULE_SETUP \
+	if ( yyleng > 0 ) \
+		YY_CURRENT_BUFFER_LVALUE->yy_at_bol = \
+				(yytext[yyleng - 1] == '\n'); \
 	YY_USER_ACTION
 
 /** The main scanner function which does all the work.
@@ -784,7 +789,7 @@ YY_DECL
 #line 31 "KWCLex.lex"
 
 
-#line 787 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
+#line 792 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -799,6 +804,7 @@ YY_DECL
 		yy_bp = yy_cp;
 
 		yy_current_state = (yy_start);
+		yy_current_state += YY_AT_BOL();
 yy_match:
 		do
 			{
@@ -811,13 +817,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 122 )
+				if ( yy_current_state >= 127 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 197 );
+		while ( yy_base[yy_current_state] != 199 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -855,14 +861,43 @@ case 1:
 YY_RULE_SETUP
 #line 33 "KWCLex.lex"
 {
-                          // Les types retournes par le parser sont des unsigned char:
-                          // il faut etre compatible sous peine de bugs pour des caracteres interpretes
-                          // commes des caracteres speciaux
+                          // Un commentaire tient sur une seule ligne, prefixe par '//', et precede potentiellement de caracteres d'espace
+							
                           ALString *sValue;
                           int nInput;
 						  unsigned char c;
 
-                          // Lecture du commentaire jusqu a la fin de ligne
+                          // Lecture du commentaire jusqu'a la fin de ligne
+                          sValue = new ALString ();
+						  while ((nInput = yyinput()) != YYEOF)
+						  {
+						      c = (unsigned char)nInput;
+						      if (c == '\n')
+						        break;
+						      *sValue += c;
+						  }
+                          sValue->TrimLeft();
+                          sValue->TrimRight();
+
+                          // Retour de la valeur et du token
+                          yylval.sValue = sValue;
+                          return  COMMENT;
+                          }
+	YY_BREAK
+case 2:
+YY_RULE_SETUP
+#line 58 "KWCLex.lex"
+{
+                          // Un libelle est prefixe par '//', mais n'est pas seul sur sa ligne
+
+                          ALString *sValue;
+                          int nInput;
+						  unsigned char c;
+                          // Les types retournes par le parser sont des unsigned char:
+                          // il faut etre compatible sous peine de bugs pour des caracteres interpretes
+                          // commes des caracteres speciaux
+
+                          // Lecture du libelle jusqu'a la fin de ligne
                           sValue = new ALString ();
 						  while ((nInput = yyinput()) != YYEOF)
 						  {
@@ -879,9 +914,9 @@ YY_RULE_SETUP
                           return  LABEL;
                           }
 	YY_BREAK
-case 2:
+case 3:
 YY_RULE_SETUP
-#line 59 "KWCLex.lex"
+#line 86 "KWCLex.lex"
 {
                           ALString *sValue;
                           int nInput;
@@ -936,9 +971,9 @@ YY_RULE_SETUP
                           return  STRINGLITTERAL;
                           }
 	YY_BREAK
-case 3:
+case 4:
 YY_RULE_SETUP
-#line 113 "KWCLex.lex"
+#line 140 "KWCLex.lex"
 {
                           ALString *sValue;
                           int nInput;
@@ -993,84 +1028,84 @@ YY_RULE_SETUP
                           return  EXTENDEDIDENTIFIER;
                           }
 	YY_BREAK
-case 4:
-YY_RULE_SETUP
-#line 167 "KWCLex.lex"
-return CLASS;
-	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 169 "KWCLex.lex"
-return CONTINUOUSTYPE;
+#line 194 "KWCLex.lex"
+return CLASS;
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 171 "KWCLex.lex"
-return SYMBOLTYPE;
+#line 196 "KWCLex.lex"
+return CONTINUOUSTYPE;
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 173 "KWCLex.lex"
-return OBJECTARRAYTYPE;
+#line 198 "KWCLex.lex"
+return SYMBOLTYPE;
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 175 "KWCLex.lex"
-return ROOT;
+#line 200 "KWCLex.lex"
+return OBJECTARRAYTYPE;
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 177 "KWCLex.lex"
-return UNUSED;
+#line 202 "KWCLex.lex"
+return ROOT;
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 179 "KWCLex.lex"
-return DATETYPE;
+#line 204 "KWCLex.lex"
+return UNUSED;
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 181 "KWCLex.lex"
-return TIMETYPE;
+#line 206 "KWCLex.lex"
+return DATETYPE;
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 183 "KWCLex.lex"
-return TIMESTAMPTYPE;
+#line 208 "KWCLex.lex"
+return TIMETYPE;
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 185 "KWCLex.lex"
-return TIMESTAMPTZTYPE;
+#line 210 "KWCLex.lex"
+return TIMESTAMPTYPE;
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 187 "KWCLex.lex"
-return TEXTTYPE;
+#line 212 "KWCLex.lex"
+return TIMESTAMPTZTYPE;
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 189 "KWCLex.lex"
-return TEXTLISTTYPE;
+#line 214 "KWCLex.lex"
+return TEXTTYPE;
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 191 "KWCLex.lex"
-return OBJECTTYPE;
+#line 216 "KWCLex.lex"
+return TEXTLISTTYPE;
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 193 "KWCLex.lex"
-return STRUCTURETYPE;
+#line 218 "KWCLex.lex"
+return OBJECTTYPE;
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 196 "KWCLex.lex"
-return *yytext;
+#line 220 "KWCLex.lex"
+return STRUCTURETYPE;
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 198 "KWCLex.lex"
+#line 223 "KWCLex.lex"
+return *yytext;
+	YY_BREAK
+case 20:
+YY_RULE_SETUP
+#line 225 "KWCLex.lex"
 {
                           ALString *sValue;
                           sValue = new ALString ( (char*)yytext );
@@ -1078,25 +1113,25 @@ YY_RULE_SETUP
                           return  BASICIDENTIFIER;
                           }
 	YY_BREAK
-case 20:
+case 21:
 YY_RULE_SETUP
-#line 205 "KWCLex.lex"
+#line 232 "KWCLex.lex"
 {
                           yylval.cValue=KWContinuous::StringToContinuous((char*)yytext);
                           return(CONTINUOUSLITTERAL);
                           }
 	YY_BREAK
-case 21:
+case 22:
 YY_RULE_SETUP
-#line 210 "KWCLex.lex"
+#line 237 "KWCLex.lex"
 {
                           yylval.cValue=KWContinuous::GetMissingValue();
                           return(CONTINUOUSLITTERAL);
                           }
 	YY_BREAK
-case 22:
+case 23:
 YY_RULE_SETUP
-#line 215 "KWCLex.lex"
+#line 242 "KWCLex.lex"
 {
                           // Les types retournes par le parser sont des unsigned char:
                           // il faut etre compatible sous peine de bugs pour des caracteres interpretes
@@ -1122,15 +1157,15 @@ YY_RULE_SETUP
                           return  APPLICATIONID;
                           }
 	YY_BREAK
-case 23:
-/* rule 23 can match eol */
+case 24:
+/* rule 24 can match eol */
 YY_RULE_SETUP
-#line 242 "KWCLex.lex"
+#line 269 "KWCLex.lex"
 ;
 	YY_BREAK
-case 24:
+case 25:
 YY_RULE_SETUP
-#line 245 "KWCLex.lex"
+#line 272 "KWCLex.lex"
 {
 						  const int nMaxLength = 20;
                           ALString sTmp;
@@ -1186,12 +1221,12 @@ YY_RULE_SETUP
                             sTmp + "Unexpected special chars <" + sToken + "> (ignored)");
                           }
 	YY_BREAK
-case 25:
+case 26:
 YY_RULE_SETUP
-#line 299 "KWCLex.lex"
+#line 326 "KWCLex.lex"
 ECHO;
 	YY_BREAK
-#line 1194 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
+#line 1229 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCLex.inc"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1476,6 +1511,7 @@ static int yy_get_next_buffer (void)
 	char *yy_cp;
     
 	yy_current_state = (yy_start);
+	yy_current_state += YY_AT_BOL();
 
 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
 		{
@@ -1488,7 +1524,7 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 122 )
+			if ( yy_current_state >= 127 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1516,11 +1552,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 122 )
+		if ( yy_current_state >= 127 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 121);
+	yy_is_jam = (yy_current_state == 126);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -1640,7 +1676,8 @@ static int yy_get_next_buffer (void)
 	*(yy_c_buf_p) = '\0';	/* preserve yytext */
 	(yy_hold_char) = *++(yy_c_buf_p);
 
-	if ( c == '\n' )
+	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = (c == '\n');
+	if ( YY_CURRENT_BUFFER_LVALUE->yy_at_bol )
 		
     yylineno++;
 ;
@@ -2208,4 +2245,4 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 299 "KWCLex.lex"
+#line 326 "KWCLex.lex"

--- a/src/Learning/KWData/KWCLex.lex
+++ b/src/Learning/KWData/KWCLex.lex
@@ -22,7 +22,7 @@ sign      [\-\+]
 exponent  [eE]
 separator [\.]
 continuous {sign}?({digit}{digit}*{separator}?{digit}*|{digit}*{separator}?{digit}{digit}*)({exponent}?{sign}?{digit}{digit}*)?
-letter    [a-zA-Z_\*]
+letter    [a-zA-Z_]
 name      {letter}({letter}|{digit})*
 
 /* Attention, la liste des mots cles du langage doit etre reprise dans la methode KWClass::IsStringKeyWord() */
@@ -30,15 +30,42 @@ name      {letter}({letter}|{digit})*
 
 %%
 
-\/\/                      {
-                          // Les types retournes par le parser sont des unsigned char:
-                          // il faut etre compatible sous peine de bugs pour des caracteres interpretes
-                          // commes des caracteres speciaux
+^[ \t\f\r\v]*\/\/       {
+                          // Un commentaire tient sur une seule ligne, prefixe par '//', et precede potentiellement de caracteres d'espace
+							
                           ALString *sValue;
                           int nInput;
 						  unsigned char c;
 
-                          // Lecture du commentaire jusqu a la fin de ligne
+                          // Lecture du commentaire jusqu'a la fin de ligne
+                          sValue = new ALString ();
+						  while ((nInput = yyinput()) != YYEOF)
+						  {
+						      c = (unsigned char)nInput;
+						      if (c == '\n')
+						        break;
+						      *sValue += c;
+						  }
+                          sValue->TrimLeft();
+                          sValue->TrimRight();
+
+                          // Retour de la valeur et du token
+                          yylval.sValue = sValue;
+                          return  COMMENT;
+                          }
+
+
+\/\/                      {
+                          // Un libelle est prefixe par '//', mais n'est pas seul sur sa ligne
+
+                          ALString *sValue;
+                          int nInput;
+						  unsigned char c;
+                          // Les types retournes par le parser sont des unsigned char:
+                          // il faut etre compatible sous peine de bugs pour des caracteres interpretes
+                          // commes des caracteres speciaux
+
+                          // Lecture du libelle jusqu'a la fin de ligne
                           sValue = new ALString ();
 						  while ((nInput = yyinput()) != YYEOF)
 						  {
@@ -55,7 +82,7 @@ name      {letter}({letter}|{digit})*
                           return  LABEL;
                           }
                           
-
+                      
 \"                       {
                           ALString *sValue;
                           int nInput;
@@ -239,7 +266,7 @@ name      {letter}({letter}|{digit})*
                           
 
 
-[ \t\n\f\r\v]+                  ;
+[ \t\n\f\r\v]                  ;
 
 
 .                         {

--- a/src/Learning/KWData/KWCLex.lex
+++ b/src/Learning/KWData/KWCLex.lex
@@ -7,14 +7,15 @@
 #pragma warning(disable : 4996) // C4996: warning for deprecated POSIX names isatty and fileno
 #endif                          // __MSC__
 
-/* Redefinition du nombre de token max */
+// Redefinition du nombre de token max
 #undef YYLMAX
-#define	YYLMAX		100000		/* token and pushback buffer size */
+#define	YYLMAX		100000		// token and pushback buffer size
 
 %}
 
 %p 5000
-/* pour avoir acces aux numeros de lignes, et moins cher que le -l de la ligne de commande */
+
+/* Pour avoir acces aux numeros de lignes, et moins cher que le -l de la ligne de commande */
 %option yylineno 
 
 digit     [0-9]
@@ -26,7 +27,7 @@ letter    [a-zA-Z_]
 name      {letter}({letter}|{digit})*
 
 /* Attention, la liste des mots cles du langage doit etre reprise dans la methode KWClass::IsStringKeyWord() */
-/* si on veut autoriser des noms de variable en collision avec ces mots cles.                                */
+/* si on veut autoriser des noms de variable en collision avec ces mots cles. */
 
 %%
 
@@ -104,7 +105,8 @@ name      {letter}({letter}|{digit})*
 								nNextInput = yyinput();
 								cNext = (unsigned char)nNextInput;
 
-								// Si pas d'autre double-quote (doublement de double-quote interne), on remet le caractere a analyser avant de declarer la fin du token
+								// Si pas d'autre double-quote (doublement de double-quote interne), on remet le caractere
+								//a analyser avant de declarer la fin du token
 								if (cNext != '"')
 								{
 								  unput(cNext);
@@ -159,7 +161,8 @@ name      {letter}({letter}|{digit})*
 								nNextInput = yyinput();
 								cNext = (unsigned char)nNextInput;
 
-								// Si pas d'autre back-quote (doublement de back-quote interne), on remet le caractere a analyser avant de declarer la fin du token
+								// Si pas d'autre back-quote (doublement de back-quote interne), on remet le caractere
+								// a analyser avant de declarer la fin du token
 								if (cNext != '`')
 								{
 								  unput(cNext);
@@ -220,7 +223,7 @@ name      {letter}({letter}|{digit})*
 "Structure"               return STRUCTURETYPE;
 
 
-[<>(){}=;:,+\[\]\.]                return *yytext;
+[<>(){}=;:,+\[\]\.]       return *yytext;
 
 {name}                    {
                           ALString *sValue;
@@ -266,7 +269,7 @@ name      {letter}({letter}|{digit})*
                           
 
 
-[ \t\n\f\r\v]                  ;
+[ \t\n\f\r\v]             ;
 
 
 .                         {

--- a/src/Learning/KWData/KWCYac.cpp
+++ b/src/Learning/KWData/KWCYac.cpp
@@ -125,9 +125,10 @@ static int nFileParsingErrorNumber = 0;
 /*
 #define YYDEBUG 1
 extern char   *yyptok(int i);
+// Ajouter l'instruction yydebug = 1 dans le code d'une action du fichier .lex ou .yac
 */
 
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 135 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 #ifndef YY_CAST
 #ifdef __cplusplus
@@ -162,68 +163,71 @@ enum yysymbol_kind_t
 	YYSYMBOL_EXTENDEDIDENTIFIER = 4,           /* EXTENDEDIDENTIFIER  */
 	YYSYMBOL_CONTINUOUSLITTERAL = 5,           /* CONTINUOUSLITTERAL  */
 	YYSYMBOL_STRINGLITTERAL = 6,               /* STRINGLITTERAL  */
-	YYSYMBOL_LABEL = 7,                        /* LABEL  */
-	YYSYMBOL_APPLICATIONID = 8,                /* APPLICATIONID  */
-	YYSYMBOL_CLASS = 9,                        /* CLASS  */
-	YYSYMBOL_CONTINUOUSTYPE = 10,              /* CONTINUOUSTYPE  */
-	YYSYMBOL_SYMBOLTYPE = 11,                  /* SYMBOLTYPE  */
-	YYSYMBOL_OBJECTTYPE = 12,                  /* OBJECTTYPE  */
-	YYSYMBOL_OBJECTARRAYTYPE = 13,             /* OBJECTARRAYTYPE  */
-	YYSYMBOL_ROOT = 14,                        /* ROOT  */
-	YYSYMBOL_UNUSED = 15,                      /* UNUSED  */
-	YYSYMBOL_DATETYPE = 16,                    /* DATETYPE  */
-	YYSYMBOL_TIMETYPE = 17,                    /* TIMETYPE  */
-	YYSYMBOL_TIMESTAMPTYPE = 18,               /* TIMESTAMPTYPE  */
-	YYSYMBOL_TIMESTAMPTZTYPE = 19,             /* TIMESTAMPTZTYPE  */
-	YYSYMBOL_TEXTTYPE = 20,                    /* TEXTTYPE  */
-	YYSYMBOL_TEXTLISTTYPE = 21,                /* TEXTLISTTYPE  */
-	YYSYMBOL_STRUCTURETYPE = 22,               /* STRUCTURETYPE  */
-	YYSYMBOL_23_ = 23,                         /* '}'  */
-	YYSYMBOL_24_ = 24,                         /* '{'  */
-	YYSYMBOL_25_ = 25,                         /* '('  */
-	YYSYMBOL_26_ = 26,                         /* ')'  */
-	YYSYMBOL_27_ = 27,                         /* ','  */
-	YYSYMBOL_28_ = 28,                         /* '<'  */
-	YYSYMBOL_29_ = 29,                         /* '='  */
-	YYSYMBOL_30_ = 30,                         /* '>'  */
-	YYSYMBOL_31_ = 31,                         /* ']'  */
-	YYSYMBOL_32_ = 32,                         /* '['  */
-	YYSYMBOL_33_ = 33,                         /* ':'  */
-	YYSYMBOL_34_ = 34,                         /* '.'  */
-	YYSYMBOL_35_ = 35,                         /* '+'  */
-	YYSYMBOL_36_ = 36,                         /* ';'  */
-	YYSYMBOL_YYACCEPT = 37,                    /* $accept  */
-	YYSYMBOL_IDENTIFIER = 38,                  /* IDENTIFIER  */
-	YYSYMBOL_SIMPLEIDENTIFIER = 39,            /* SIMPLEIDENTIFIER  */
-	YYSYMBOL_kwclassFile = 40,                 /* kwclassFile  */
-	YYSYMBOL_kwclasses = 41,                   /* kwclasses  */
-	YYSYMBOL_kwclass = 42,                     /* kwclass  */
-	YYSYMBOL_kwclassBegin = 43,                /* kwclassBegin  */
-	YYSYMBOL_oaAttributeArrayDeclaration = 44, /* oaAttributeArrayDeclaration  */
-	YYSYMBOL_kwclassHeader = 45,               /* kwclassHeader  */
-	YYSYMBOL_keyFields = 46,                   /* keyFields  */
-	YYSYMBOL_fieldList = 47,                   /* fieldList  */
-	YYSYMBOL_metaData = 48,                    /* metaData  */
-	YYSYMBOL_kwattributeDeclaration = 49,      /* kwattributeDeclaration  */
-	YYSYMBOL_applicationids = 50,              /* applicationids  */
-	YYSYMBOL_comments = 51,                    /* comments  */
-	YYSYMBOL_rootDeclaration = 52,             /* rootDeclaration  */
-	YYSYMBOL_usedDeclaration = 53,             /* usedDeclaration  */
-	YYSYMBOL_typeDeclaration = 54,             /* typeDeclaration  */
-	YYSYMBOL_refIdentifier = 55,               /* refIdentifier  */
-	YYSYMBOL_usedDerivationRule = 56,          /* usedDerivationRule  */
-	YYSYMBOL_referenceRule = 57,               /* referenceRule  */
-	YYSYMBOL_referenceRuleBody = 58,           /* referenceRuleBody  */
-	YYSYMBOL_derivationRule = 59,              /* derivationRule  */
-	YYSYMBOL_derivationRuleBody = 60,          /* derivationRuleBody  */
-	YYSYMBOL_operandList = 61,                 /* operandList  */
-	YYSYMBOL_derivationRuleHeader = 62,        /* derivationRuleHeader  */
-	YYSYMBOL_derivationRuleBegin = 63,         /* derivationRuleBegin  */
-	YYSYMBOL_derivationRuleOperand = 64,       /* derivationRuleOperand  */
-	YYSYMBOL_bigstring = 65,                   /* bigstring  */
-	YYSYMBOL_semicolon = 66,                   /* semicolon  */
-	YYSYMBOL_openparenthesis = 67,             /* openparenthesis  */
-	YYSYMBOL_closeparenthesis = 68             /* closeparenthesis  */
+	YYSYMBOL_COMMENT = 7,                      /* COMMENT  */
+	YYSYMBOL_LABEL = 8,                        /* LABEL  */
+	YYSYMBOL_APPLICATIONID = 9,                /* APPLICATIONID  */
+	YYSYMBOL_CLASS = 10,                       /* CLASS  */
+	YYSYMBOL_CONTINUOUSTYPE = 11,              /* CONTINUOUSTYPE  */
+	YYSYMBOL_SYMBOLTYPE = 12,                  /* SYMBOLTYPE  */
+	YYSYMBOL_OBJECTTYPE = 13,                  /* OBJECTTYPE  */
+	YYSYMBOL_OBJECTARRAYTYPE = 14,             /* OBJECTARRAYTYPE  */
+	YYSYMBOL_ROOT = 15,                        /* ROOT  */
+	YYSYMBOL_UNUSED = 16,                      /* UNUSED  */
+	YYSYMBOL_DATETYPE = 17,                    /* DATETYPE  */
+	YYSYMBOL_TIMETYPE = 18,                    /* TIMETYPE  */
+	YYSYMBOL_TIMESTAMPTYPE = 19,               /* TIMESTAMPTYPE  */
+	YYSYMBOL_TIMESTAMPTZTYPE = 20,             /* TIMESTAMPTZTYPE  */
+	YYSYMBOL_TEXTTYPE = 21,                    /* TEXTTYPE  */
+	YYSYMBOL_TEXTLISTTYPE = 22,                /* TEXTLISTTYPE  */
+	YYSYMBOL_STRUCTURETYPE = 23,               /* STRUCTURETYPE  */
+	YYSYMBOL_24_ = 24,                         /* '}'  */
+	YYSYMBOL_25_ = 25,                         /* '{'  */
+	YYSYMBOL_26_ = 26,                         /* '('  */
+	YYSYMBOL_27_ = 27,                         /* ')'  */
+	YYSYMBOL_28_ = 28,                         /* ','  */
+	YYSYMBOL_29_ = 29,                         /* '<'  */
+	YYSYMBOL_30_ = 30,                         /* '='  */
+	YYSYMBOL_31_ = 31,                         /* '>'  */
+	YYSYMBOL_32_ = 32,                         /* ']'  */
+	YYSYMBOL_33_ = 33,                         /* '['  */
+	YYSYMBOL_34_ = 34,                         /* ':'  */
+	YYSYMBOL_35_ = 35,                         /* '.'  */
+	YYSYMBOL_36_ = 36,                         /* '+'  */
+	YYSYMBOL_37_ = 37,                         /* ';'  */
+	YYSYMBOL_YYACCEPT = 38,                    /* $accept  */
+	YYSYMBOL_IDENTIFIER = 39,                  /* IDENTIFIER  */
+	YYSYMBOL_SIMPLEIDENTIFIER = 40,            /* SIMPLEIDENTIFIER  */
+	YYSYMBOL_kwclassFile = 41,                 /* kwclassFile  */
+	YYSYMBOL_kwclasses = 42,                   /* kwclasses  */
+	YYSYMBOL_kwclass = 43,                     /* kwclass  */
+	YYSYMBOL_kwclassBegin = 44,                /* kwclassBegin  */
+	YYSYMBOL_oaAttributeArrayDeclaration = 45, /* oaAttributeArrayDeclaration  */
+	YYSYMBOL_kwclassHeader = 46,               /* kwclassHeader  */
+	YYSYMBOL_keyFields = 47,                   /* keyFields  */
+	YYSYMBOL_fieldList = 48,                   /* fieldList  */
+	YYSYMBOL_metaData = 49,                    /* metaData  */
+	YYSYMBOL_kwattributeDeclaration = 50,      /* kwattributeDeclaration  */
+	YYSYMBOL_applicationids = 51,              /* applicationids  */
+	YYSYMBOL_label = 52,                       /* label  */
+	YYSYMBOL_comments = 53,                    /* comments  */
+	YYSYMBOL_labelOrComments = 54,             /* labelOrComments  */
+	YYSYMBOL_rootDeclaration = 55,             /* rootDeclaration  */
+	YYSYMBOL_usedDeclaration = 56,             /* usedDeclaration  */
+	YYSYMBOL_typeDeclaration = 57,             /* typeDeclaration  */
+	YYSYMBOL_refIdentifier = 58,               /* refIdentifier  */
+	YYSYMBOL_usedDerivationRule = 59,          /* usedDerivationRule  */
+	YYSYMBOL_referenceRule = 60,               /* referenceRule  */
+	YYSYMBOL_referenceRuleBody = 61,           /* referenceRuleBody  */
+	YYSYMBOL_derivationRule = 62,              /* derivationRule  */
+	YYSYMBOL_derivationRuleBody = 63,          /* derivationRuleBody  */
+	YYSYMBOL_operandList = 64,                 /* operandList  */
+	YYSYMBOL_derivationRuleHeader = 65,        /* derivationRuleHeader  */
+	YYSYMBOL_derivationRuleBegin = 66,         /* derivationRuleBegin  */
+	YYSYMBOL_derivationRuleOperand = 67,       /* derivationRuleOperand  */
+	YYSYMBOL_bigstring = 68,                   /* bigstring  */
+	YYSYMBOL_semicolon = 69,                   /* semicolon  */
+	YYSYMBOL_openparenthesis = 70,             /* openparenthesis  */
+	YYSYMBOL_closeparenthesis = 71             /* closeparenthesis  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -530,19 +534,19 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL 3
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST 207
+#define YYLAST 209
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS 37
+#define YYNTOKENS 38
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS 32
+#define YYNNTS 34
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES 97
+#define YYNRULES 101
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES 142
+#define YYNSTATES 147
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK 277
+#define YYMAXUTOK 278
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
@@ -553,24 +557,24 @@ union yyalloc
    as returned by yylex.  */
 static const yytype_int8 yytranslate[] = {
     0,  2,  2, 2, 2, 2, 2, 2, 2, 2,  2,  2, 2,  2,  2, 2,  2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2, 2, 2, 2, 2, 2, 2, 25, 26, 2, 35, 27, 2, 34, 2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  33, 36, 28, 29,
-    30, 2,  2, 2, 2, 2, 2, 2, 2, 2,  2,  2, 2,  2,  2, 2,  2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  32, 2,
-    31, 2,  2, 2, 2, 2, 2, 2, 2, 2,  2,  2, 2,  2,  2, 2,  2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  24,
-    2,  23, 2, 2, 2, 2, 2, 2, 2, 2,  2,  2, 2,  2,  2, 2,  2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+    2,  2,  2, 2, 2, 2, 2, 2, 2, 26, 27, 2, 36, 28, 2, 35, 2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  34, 37, 29, 30,
+    31, 2,  2, 2, 2, 2, 2, 2, 2, 2,  2,  2, 2,  2,  2, 2,  2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  33, 2,
+    32, 2,  2, 2, 2, 2, 2, 2, 2, 2,  2,  2, 2,  2,  2, 2,  2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  25,
+    2,  24, 2, 2, 2, 2, 2, 2, 2, 2,  2,  2, 2,  2,  2, 2,  2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
     2,  2,  2, 2, 2, 2, 2, 2, 2, 2,  2,  2, 2,  2,  2, 2,  2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
     2,  2,  2, 2, 2, 2, 2, 2, 2, 2,  2,  2, 2,  2,  2, 2,  2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
     2,  2,  2, 2, 2, 2, 2, 2, 2, 2,  2,  2, 2,  2,  2, 2,  2, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2, 2, 2, 2, 2, 2, 1, 2,  3,  4, 5,  6,  7, 8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    2,  2,  2, 2, 2, 2, 2, 2, 1, 2,  3,  4, 5,  6,  7, 8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
 
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] = {
-    0,    143,  143,  147,  154,  158,  162,  166,  170,  174,  178,  182,  186,  190,  194,  198,  202,
-    206,  210,  216,  229,  230,  233,  236,  246,  254,  296,  376,  395,  406,  450,  498,  591,  598,
-    606,  612,  622,  635,  655,  677,  696,  713,  721,  856,  868,  875,  887,  894,  899,  906,  911,
-    918,  922,  926,  930,  934,  938,  942,  946,  950,  954,  958,  966,  971,  977,  981,  985,  990,
-    999,  1004, 1010, 1030, 1046, 1154, 1158, 1204, 1211, 1222, 1235, 1248, 1259, 1273, 1282, 1291, 1301,
-    1311, 1322, 1331, 1338, 1339, 1343, 1348, 1354, 1355, 1359, 1364, 1376, 1378};
+    0,    147,  147,  151,  158,  162,  166,  170,  174,  178,  182,  186,  190,  194,  198,  202,  206,
+    210,  214,  220,  235,  236,  237,  242,  261,  266,  308,  392,  413,  424,  468,  516,  658,  661,
+    668,  678,  691,  694,  714,  736,  755,  776,  919,  922,  937,  940,  947,  950,  968,  971,  979,
+    997,  1000, 1008, 1011, 1019, 1023, 1027, 1031, 1035, 1039, 1043, 1047, 1051, 1055, 1059, 1067, 1070,
+    1078, 1081, 1085, 1089, 1094, 1104, 1110, 1130, 1146, 1254, 1258, 1304, 1311, 1322, 1335, 1348, 1359,
+    1373, 1382, 1391, 1401, 1411, 1422, 1431, 1438, 1441, 1442, 1446, 1453, 1459, 1460, 1464, 1472, 1478};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -590,6 +594,7 @@ static const char* const yytname[] = {"\"end of file\"",
 				      "EXTENDEDIDENTIFIER",
 				      "CONTINUOUSLITTERAL",
 				      "STRINGLITTERAL",
+				      "COMMENT",
 				      "LABEL",
 				      "APPLICATIONID",
 				      "CLASS",
@@ -634,7 +639,9 @@ static const char* const yytname[] = {"\"end of file\"",
 				      "metaData",
 				      "kwattributeDeclaration",
 				      "applicationids",
+				      "label",
 				      "comments",
+				      "labelOrComments",
 				      "rootDeclaration",
 				      "usedDeclaration",
 				      "typeDeclaration",
@@ -660,89 +667,93 @@ static const char* yysymbol_name(yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-83)
+#define YYPACT_NINF (-87)
 
 #define yypact_value_is_default(Yyn) ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-96)
+#define YYTABLE_NINF (-97)
 
 #define yytable_value_is_error(Yyn) 0
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
 static const yytype_int16 yypact[] = {
-    -83, 2,   14,  -83, -83, 67,  -83, -83, 110, -83, 66,  -83, -83, -12, -83, -83, 185, 38,  -83, -83, 60,
-    46,  -83, 18,  -83, -83, -83, -83, -83, -83, -83, -83, -83, -83, -83, 62,  152, 52,  152, 55,  -83, 152,
-    152, -83, -83, -83, -83, -83, -83, -83, -83, -83, -83, -83, -83, -83, -83, -83, -83, 9,   -83, -83, 54,
-    152, -83, 68,  54,  152, -83, 38,  152, 152, 43,  -12, -83, -8,  54,  -83, -12, -83, 17,  61,  70,  72,
-    73,  74,  43,  57,  -83, -83, 43,  6,   -83, -83, 58,  -83, 43,  -83, -12, -83, -83, 152, -83, 172, -83,
-    76,  -83, -83, -83, -83, -83, 43,  43,  -83, 86,  75,  -83, -83, 75,  38,  -83, 42,  77,  -83, 71,  -83,
-    -83, 38,  75,  38,  132, -83, -83, 43,  38,  78,  80,  82,  -83, -83, -83, -83};
+    -87, 9,   27,  -87, -87, 181, -87, -87, 77,  -87, 0,   -87, -87, 168, -87, -87, 37,  -87, 24,  -87, 186,
+    130, 39,  -87, -87, -87, 170, -87, -87, -87, -87, -87, -87, -87, -87, -87, -87, -87, 51,  -87, -87, -87,
+    -87, -87, -87, -87, -87, -87, -87, -87, -87, -87, -87, -87, -87, 72,  -87, 44,  -87, 171, 130, 130, 130,
+    -87, -1,  -87, 130, 16,  58,  16,  -87, 130, 72,  16,  130, 130, 52,  24,  -87, 5,   -87, 24,  -87, -9,
+    85,  24,  78,  80,  81,  83,  52,  75,  -87, -87, 52,  17,  -87, -87, 68,  -87, 52,  -87, -87, -87, 130,
+    -5,  -87, -87, 90,  -87, -87, -87, -87, -87, 52,  52,  -87, 101, 89,  -87, -3,  -87, 151, 6,   -3,  110,
+    -87, 107, -87, -87, 131, -87, -87, 29,  -87, -87, -87, 52,  109, -87, -87, 106, 108, 124, -87, -87, -87};
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
    Performed when YYTABLE does not specify something else to do.  Zero
    means the default is an error.  */
 static const yytype_int8 yydefact[] = {
-    44, 0,  22, 1,  43, 0,  21, 20, 0,  46, 19, 28, 49, 91, 46, 25, 0,  24, 45, 47, 0,  88, 23, 50, 51, 52, 59, 60, 53,
-    54, 55, 56, 57, 58, 61, 63, 0,  89, 0,  50, 30, 0,  0,  4,  3,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
-    18, 34, 2,  90, 68, 0,  29, 0,  68, 0,  41, 33, 0,  0,  0,  91, 65, 0,  68, 62, 91, 36, 0,  0,  0,  95, 64, 97, 75,
-    73, 82, 87, 0,  81, 84, 70, 83, 41, 0,  69, 91, 41, 46, 0,  31, 0,  67, 92, 78, 66, 96, 72, 79, 0,  0,  85, 0,  46,
-    71, 41, 46, 32, 35, 0,  93, 80, 74, 77, 86, 27, 46, 42, 0,  39, 94, 0,  26, 0,  0,  0,  76, 38, 37, 40};
+    42, 0,  20, 1,  43, 0,  22, 21, 0,  24, 19, 28,  25, 53, 47,  52, 0,  54, 92, 46, 0,  0,  93, 23, 46,
+    30, 53, 55, 56, 63, 64, 57, 58, 59, 60, 61, 62,  65, 66, 4,   3,  5,  6,  7,  8,  9,  10, 11, 12, 13,
+    14, 15, 16, 17, 18, 48, 2,  94, 29, 53, 0,  0,   0,  49, 32,  95, 0,  68, 0,  68, 50, 0,  48, 68, 0,
+    0,  0,  92, 70, 0,  67, 92, 35, 0,  36, 92, 0,   96, 69, 100, 79, 77, 86, 91, 0,  85, 88, 74, 87, 36,
+    0,  73, 36, 33, 0,  48, 36, 72, 97, 82, 71, 101, 76, 83, 0,   0,  89, 0,  46, 75, 44, 34, 0,  0,  44,
+    98, 84, 78, 81, 90, 27, 45, 41, 0,  31, 26, 99,  0,  0,  39,  80, 0,  0,  0,  38, 37, 40};
 
 /* YYPGOTO[NTERM-NUM].  */
-static const yytype_int8 yypgoto[] = {-83, -35, 1,   -83, -83, -83, -83, -83, -83, -83, -83, -78, 3,   -83, -9,  -83,
-				      -83, -83, -83, -39, -83, -83, 34,  -83, -83, -83, -83, -82, -83, -60, -83, -83};
+static const yytype_int8 yypgoto[] = {-87, -21, 34,  -87, -87, -87, -87, -87, -87, -87, -87, -20,
+				      -8,  -87, 33,  -7,  -70, -87, -87, -87, -87, -25, -87, -87,
+				      84,  -87, -87, -87, -87, -86, -87, -47, -87, -87};
 
 /* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int8 yydefgoto[] = {0,  91, 60, 1,  5,  7,  8,  39, 9,   68, 80, 81, 15, 2,  10,  20,
-					16, 35, 42, 73, 74, 75, 92, 85, 124, 86, 87, 93, 94, 22, 106, 109};
+static const yytype_uint8 yydefgoto[] = {0,  95, 56, 1,  5,  7,  8,  24, 9,  72,  83, 105, 12, 2,  132, 10,  64,
+					 16, 20, 38, 62, 77, 78, 79, 96, 89, 127, 90, 91,  97, 98, 23,  109, 112};
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
    positive, shift that token.  If negative, reduce the rule whose
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] = {
-    17,  59,  3,   62,  110, 23,  65,  66,  113, -95, -95, -95, -95, 95,  116, -95, -46, 115, 99,  96,  -95,
-    118, 4,   97,  21,  18,  40,  78,  76,  123, 125, 105, 79,  12,  67,  82,  83,  98,  117, 128, -95, 38,
-    64,  100, 101, 18,  43,  44,  88,  89,  69,  138, 45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,
-    56,  57,  58,  120, -46, 6,   36,  12,  130, 131, 18,  -46, -48, -46, 90,  63,  70,  19,  -46, 37,  71,
-    111, 102, 72,  41,  61,  103, 112, 119, 126, 114, 77,  137, 104, 105, 133, 107, 108, 122, 132, 103, 121,
-    84,  127, 0,   139, 129, 140, 11,  141, 0,   0,   0,   0,   0,   0,   134, -50, -50, -50, -50, 0,   12,
-    -50, -50, -50, -50, -50, -50, -50, 13,  14,  43,  44,  135, 136, 0,   0,   45,  46,  47,  48,  49,  50,
-    51,  52,  53,  54,  55,  56,  57,  58,  43,  44,  0,   0,   0,   0,   45,  46,  47,  48,  49,  50,  51,
-    52,  53,  54,  55,  56,  57,  58,  43,  0,   0,   0,   0,   0,   45,  46,  47,  48,  49,  50,  51,  52,
-    53,  54,  55,  56,  57,  58,  24,  25,  26,  27,  0,   0,   28,  29,  30,  31,  32,  33,  34};
+    55,  13,  84,  63,  113, 131, 70,  14,  116, 3,   -51, 25,  26,  70,  119, 15,  58,  59,  103, 104, -96,
+    -96, -96, -96, 122, 71,  122, -96, 126, 128, 99,  134, -96, 100, 102, 123, 4,   101, 106, 67,  68,  69,
+    74,  108, 81,  73,  75,  21,  85,  76,  82,  140, -96, 86,  87,  39,  40,  92,  93,  138, 139, 22,  41,
+    42,  43,  44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  57,  61,  11,  118, 63,  65,  120, 121,
+    -46, 80,  124, 94,  -46, -46, -46, -46, 70,  -46, -46, -46, -46, -46, -46, -46, -46, -46, -46, 114, 117,
+    107, 108, 129, 110, 115, 111, 130, 39,  40,  141, 142, 125, 143, 122, 41,  42,  43,  44,  45,  46,  47,
+    48,  49,  50,  51,  52,  53,  54,  39,  40,  137, 136, 144, 14,  145, 41,  42,  43,  44,  45,  46,  47,
+    48,  49,  50,  51,  52,  53,  54,  39,  146, 133, 135, 0,   88,  0,   41,  42,  43,  44,  45,  46,  47,
+    48,  49,  50,  51,  52,  53,  54,  14,  0,   14,  14,  0,   0,   -46, 6,   0,   17,  0,   17,  17,  -46,
+    0,   0,   -46, 18,  19,  60,  66,  -46, 27,  28,  29,  30,  0,   0,   31,  32,  33,  34,  35,  36,  37};
 
 static const yytype_int16 yycheck[] = {
-    9,   36, 0,   38,  86,  14,  41, 42, 90, 3,  4,  5,  6,  73,  96,  9,   7,  95,  78, 27, 14, 99, 8,  31, 36, 7,
-    23,  66, 63,  111, 112, 25,  67, 15, 25, 70, 71, 76, 98, 117, 34,  23,  39, 26,  27, 7,  3,  4,  5,  6,  59, 133,
-    9,   10, 11,  12,  13,  14,  15, 16, 17, 18, 19, 20, 21, 22,  101, 0,   1,  9,   15, 29, 30, 7,  7,  9,  9,  34,
-    23,  25, 14,  14,  36,  29,  27, 24, 32, 25, 36, 28, 33, 100, 6,   35,  26, 130, 26, 25, 27, 26, 26, 25, 25, 28,
-    103, 71, 115, -1,  30,  118, 30, 1,  30, -1, -1, -1, -1, -1,  -1,  128, 10, 11,  12, 13, -1, 15, 16, 17, 18, 19,
-    20,  21, 22,  23,  24,  3,   4,  5,  6,  -1, -1, 9,  10, 11,  12,  13,  14, 15,  16, 17, 18, 19, 20, 21, 22, 3,
-    4,   -1, -1,  -1,  -1,  9,   10, 11, 12, 13, 14, 15, 16, 17,  18,  19,  20, 21,  22, 3,  -1, -1, -1, -1, -1, 9,
-    10,  11, 12,  13,  14,  15,  16, 17, 18, 19, 20, 21, 22, 10,  11,  12,  13, -1,  -1, 16, 17, 18, 19, 20, 21, 22};
+    21, 8,  72, 8,   90,  8,   7,  7,  94, 0,  10,  19,  19,  7,   100, 15,  24, 24, 27, 28, 3,  4,   5,  6,
+    29, 26, 29, 10,  114, 115, 77, 25, 15, 28, 81,  105, 9,   32,  85,  60,  61, 62, 26, 26, 69, 66,  30, 10,
+    73, 33, 71, 137, 35,  74,  75, 3,  4,  5,  6,   30,  31,  37,  10,  11,  12, 13, 14, 15, 16, 17,  18, 19,
+    20, 21, 22, 23,  37,  26,  1,  99, 8,  37, 102, 104, 7,   27,  106, 35,  11, 12, 13, 14, 7,  16,  17, 18,
+    19, 20, 21, 22,  23,  24,  25, 28, 36, 27, 26,  6,   27,  34,  27,  118, 3,  4,  5,  6,  26, 138, 29, 10,
+    11, 12, 13, 14,  15,  16,  17, 18, 19, 20, 21,  22,  23,  3,   4,   28,  26, 31, 7,  31, 10, 11,  12, 13,
+    14, 15, 16, 17,  18,  19,  20, 21, 22, 23, 3,   31,  122, 124, -1,  75,  -1, 10, 11, 12, 13, 14,  15, 16,
+    17, 18, 19, 20,  21,  22,  23, 7,  -1, 7,  7,   -1,  -1,  0,   1,   -1,  16, -1, 16, 16, 7,  -1,  -1, 10,
+    24, 25, 24, 24,  15,  11,  12, 13, 14, -1, -1,  17,  18,  19,  20,  21,  22, 23};
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
    state STATE-NUM.  */
 static const yytype_int8 yystos[] = {
-    0,  40, 50, 0,  8,  41, 1,  42, 43, 45, 51, 1,  15, 23, 24, 49, 53, 51, 7,  14, 52, 36, 66, 51, 10, 11, 12, 13, 16,
-    17, 18, 19, 20, 21, 22, 54, 9,  36, 23, 44, 49, 25, 55, 3,  4,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-    22, 38, 39, 36, 38, 23, 49, 38, 38, 25, 46, 51, 25, 29, 32, 56, 57, 58, 38, 26, 56, 38, 47, 48, 38, 38, 59, 60, 62,
-    63, 5,  6,  34, 38, 59, 64, 65, 66, 27, 31, 56, 66, 26, 27, 24, 28, 26, 25, 67, 26, 26, 68, 64, 27, 33, 64, 35, 48,
-    64, 66, 48, 51, 38, 39, 25, 64, 61, 64, 6,  51, 48, 51, 29, 30, 25, 27, 51, 5,  6,  38, 64, 30, 30, 30};
+    0,  41, 51, 0,  9,  42, 1,  43, 44, 46, 53, 1,  50, 53, 7,  15, 55, 16, 24, 25, 56, 10, 37, 69, 45,
+    50, 53, 11, 12, 13, 14, 17, 18, 19, 20, 21, 22, 23, 57, 3,  4,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+    19, 20, 21, 22, 23, 39, 40, 37, 50, 53, 24, 26, 58, 8,  54, 37, 24, 39, 39, 39, 7,  26, 47, 39, 26,
+    30, 33, 59, 60, 61, 27, 59, 39, 48, 54, 59, 39, 39, 62, 63, 65, 66, 5,  6,  35, 39, 62, 67, 68, 69,
+    28, 32, 69, 27, 28, 49, 69, 27, 26, 70, 27, 27, 71, 67, 28, 34, 67, 36, 49, 67, 49, 39, 29, 54, 49,
+    26, 67, 64, 67, 6,  53, 8,  52, 40, 25, 52, 26, 28, 30, 31, 67, 5,  6,  39, 31, 31, 31};
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
-static const yytype_int8 yyr1[] = {0,  37, 38, 38, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 39, 40,
-				   41, 41, 41, 42, 43, 43, 43, 43, 43, 44, 44, 45, 46, 46, 46, 47, 47, 48, 48, 48,
-				   48, 48, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 54, 54, 54, 54, 54, 54, 54,
-				   54, 54, 55, 55, 56, 56, 56, 56, 56, 57, 58, 58, 59, 60, 60, 60, 61, 61, 62, 63,
-				   63, 64, 64, 64, 64, 64, 65, 65, 66, 66, 66, 66, 67, 67, 67, 67, 68, 68};
+static const yytype_int8 yyr1[] = {0,  38, 39, 39, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40, 41, 42,
+				   42, 42, 43, 44, 44, 44, 44, 44, 45, 45, 46, 47, 47, 48, 48, 49, 49, 49, 49, 49, 50,
+				   51, 51, 52, 52, 53, 53, 54, 54, 54, 55, 55, 56, 56, 57, 57, 57, 57, 57, 57, 57, 57,
+				   57, 57, 57, 58, 58, 59, 59, 59, 59, 59, 60, 61, 61, 62, 63, 63, 63, 64, 64, 65, 66,
+				   66, 67, 67, 67, 67, 67, 68, 68, 69, 69, 69, 69, 70, 70, 70, 70, 71, 71};
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
-static const yytype_int8 yyr2[] = {0, 2,  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 2, 2, 0, 3, 2,
-				   2, 10, 9, 2, 2, 1, 7, 4, 1, 0, 3, 1, 6, 6, 4, 6, 0, 8, 2, 0, 2, 0, 1, 0, 1,
-				   0, 1,  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 0, 2, 1, 3, 3, 0, 2, 2, 3, 2, 1, 3,
-				   1, 3,  1, 2, 2, 3, 1, 1, 1, 1, 2, 3, 1, 1, 2, 3, 0, 1, 2, 3, 0, 1, 0};
+static const yytype_int8 yyr2[] = {0,  2,  1, 1, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 0, 2, 2, 4, 1, 2,
+				   11, 10, 2, 2, 1, 10, 0, 3, 3, 1, 0, 6, 6, 4, 6, 9, 0, 2, 0, 1, 0, 2, 0, 1, 2, 0,
+				   1,  0,  1, 1, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1, 0, 3, 0, 2, 1, 3, 3, 2, 2, 3, 2, 1,
+				   3,  1,  3, 1, 2, 2,  3, 1, 1, 1, 1, 2, 3, 1, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1};
 
 enum
 {
@@ -923,253 +934,283 @@ static void yydestruct(const char* yymsg, yysymbol_kind_t yykind, YYSTYPE* yyval
 	switch (yykind)
 	{
 	case YYSYMBOL_BASICIDENTIFIER: /* BASICIDENTIFIER  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1046 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1053 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_EXTENDEDIDENTIFIER: /* EXTENDEDIDENTIFIER  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1052 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1059 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_STRINGLITTERAL: /* STRINGLITTERAL  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1058 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1065 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case YYSYMBOL_COMMENT: /* COMMENT  */
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		if (((*yyvaluep).sValue) != NULL)
+			delete ((*yyvaluep).sValue);
+		((*yyvaluep).sValue) = NULL;
+	}
+#line 1071 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_LABEL: /* LABEL  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1064 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1077 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_APPLICATIONID: /* APPLICATIONID  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1070 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1083 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_IDENTIFIER: /* IDENTIFIER  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1076 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1089 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_SIMPLEIDENTIFIER: /* SIMPLEIDENTIFIER  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1082 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1095 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_oaAttributeArrayDeclaration: /* oaAttributeArrayDeclaration  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).oaAttributes) != NULL)
 			delete ((*yyvaluep).oaAttributes);
 		((*yyvaluep).oaAttributes) = NULL;
 	}
-#line 1088 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1101 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_keyFields: /* keyFields  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).svValue) != NULL)
 			delete ((*yyvaluep).svValue);
 		((*yyvaluep).svValue) = NULL;
 	}
-#line 1094 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1107 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_fieldList: /* fieldList  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).svValue) != NULL)
 			delete ((*yyvaluep).svValue);
 		((*yyvaluep).svValue) = NULL;
 	}
-#line 1100 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1113 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_metaData: /* metaData  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwmdMetaData) != NULL)
 			delete ((*yyvaluep).kwmdMetaData);
 		((*yyvaluep).kwmdMetaData) = NULL;
 	}
-#line 1106 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1119 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_kwattributeDeclaration: /* kwattributeDeclaration  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwaValue) != NULL)
 			delete ((*yyvaluep).kwaValue);
 		((*yyvaluep).kwaValue) = NULL;
 	}
-#line 1112 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_applicationids: /* applicationids  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1118 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1131 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case YYSYMBOL_label: /* label  */
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		if (((*yyvaluep).sValue) != NULL)
+			delete ((*yyvaluep).sValue);
+		((*yyvaluep).sValue) = NULL;
+	}
+#line 1137 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_comments: /* comments  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		if (((*yyvaluep).sValue) != NULL)
-			delete ((*yyvaluep).sValue);
-		((*yyvaluep).sValue) = NULL;
+		if (((*yyvaluep).svValue) != NULL)
+			delete ((*yyvaluep).svValue);
+		((*yyvaluep).svValue) = NULL;
 	}
-#line 1124 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1143 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case YYSYMBOL_labelOrComments: /* labelOrComments  */
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		if (((*yyvaluep).svValue) != NULL)
+			delete ((*yyvaluep).svValue);
+		((*yyvaluep).svValue) = NULL;
+	}
+#line 1149 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_refIdentifier: /* refIdentifier  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1130 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1155 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_usedDerivationRule: /* usedDerivationRule  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1136 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1161 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_referenceRule: /* referenceRule  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1142 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1167 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_referenceRuleBody: /* referenceRuleBody  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1148 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1173 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRule: /* derivationRule  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1154 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1179 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleBody: /* derivationRuleBody  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1160 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1185 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_operandList: /* operandList  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).oaOperands) != NULL)
 			delete ((*yyvaluep).oaOperands);
 		((*yyvaluep).oaOperands) = NULL;
 	}
-#line 1166 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1191 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleHeader: /* derivationRuleHeader  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1172 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1197 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleBegin: /* derivationRuleBegin  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1178 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1203 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleOperand: /* derivationRuleOperand  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdroValue) != NULL)
 			delete ((*yyvaluep).kwdroValue);
 		((*yyvaluep).kwdroValue) = NULL;
 	}
-#line 1184 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1209 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_bigstring: /* bigstring  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1190 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1215 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	default:
@@ -1419,190 +1460,199 @@ yyreduce:
 	switch (yyn)
 	{
 	case 2: /* IDENTIFIER: SIMPLEIDENTIFIER  */
-#line 144 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.sValue) = (yyvsp[0].sValue);
-	}
-#line 1462 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 3: /* IDENTIFIER: EXTENDEDIDENTIFIER  */
 #line 148 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1470 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1487 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 4: /* SIMPLEIDENTIFIER: BASICIDENTIFIER  */
-#line 155 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 3: /* IDENTIFIER: EXTENDEDIDENTIFIER  */
+#line 152 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1478 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1495 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 4: /* SIMPLEIDENTIFIER: BASICIDENTIFIER  */
+#line 159 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.sValue) = (yyvsp[0].sValue);
+	}
+#line 1503 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 5: /* SIMPLEIDENTIFIER: CLASS  */
-#line 159 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 163 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Dictionary");
 	}
-#line 1486 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1511 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 6: /* SIMPLEIDENTIFIER: CONTINUOUSTYPE  */
-#line 163 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 167 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Numerical");
 	}
-#line 1494 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1519 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 7: /* SIMPLEIDENTIFIER: SYMBOLTYPE  */
-#line 167 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 171 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Categorical");
 	}
-#line 1502 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1527 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 8: /* SIMPLEIDENTIFIER: OBJECTTYPE  */
-#line 171 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 175 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Entity");
 	}
-#line 1510 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1535 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 9: /* SIMPLEIDENTIFIER: OBJECTARRAYTYPE  */
-#line 175 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 179 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Table");
 	}
-#line 1518 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1543 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 10: /* SIMPLEIDENTIFIER: ROOT  */
-#line 179 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 183 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Root");
 	}
-#line 1526 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1551 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 11: /* SIMPLEIDENTIFIER: UNUSED  */
-#line 183 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 187 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Unused");
 	}
-#line 1534 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1559 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 12: /* SIMPLEIDENTIFIER: DATETYPE  */
-#line 187 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 191 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Date");
 	}
-#line 1542 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1567 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 13: /* SIMPLEIDENTIFIER: TIMETYPE  */
-#line 191 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 195 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Time");
 	}
-#line 1550 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1575 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 14: /* SIMPLEIDENTIFIER: TIMESTAMPTYPE  */
-#line 195 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 199 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Timestamp");
 	}
-#line 1558 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1583 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 15: /* SIMPLEIDENTIFIER: TIMESTAMPTZTYPE  */
-#line 199 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 203 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("TimestampTZ");
 	}
-#line 1566 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1591 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 16: /* SIMPLEIDENTIFIER: TEXTTYPE  */
-#line 203 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 207 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Text");
 	}
-#line 1574 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1599 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 17: /* SIMPLEIDENTIFIER: TEXTLISTTYPE  */
-#line 207 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 211 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("TextList");
 	}
-#line 1582 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1607 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 18: /* SIMPLEIDENTIFIER: STRUCTURETYPE  */
-#line 211 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 215 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Structure");
 	}
-#line 1590 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1615 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 19: /* kwclassFile: applicationids kwclasses comments  */
-#line 217 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 221 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ignore l'identification d'application */
 		if ((yyvsp[-2].sValue) != NULL)
 			delete (yyvsp[-2].sValue);
 
-		/* On ignore les commentaires en fin de fichier */
-		if ((yyvsp[0].sValue) != NULL)
-			delete (yyvsp[0].sValue);
+		/* On interdit les commentaires en fin de fichier */
+		if ((yyvsp[0].svValue) != NULL)
+		{
+			delete (yyvsp[0].svValue);
+			yyerrorWithLineCorrection("Comments at the end of the file are not allowed", -1);
+		}
 	}
-#line 1604 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1632 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 21: /* kwclasses: kwclasses error  */
-#line 231 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 22: /* kwclasses: kwclasses error  */
+#line 238 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Error outside the definition of a dictionary");
 		YYABORT;
 	}
-#line 1611 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1639 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 23: /* kwclass: kwclassBegin '}' semicolon  */
-#line 237 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 23: /* kwclass: kwclassBegin comments '}' semicolon  */
+#line 243 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		KWClass* kwcClass = (yyvsp[-3].kwcValue);
+
 		/* La completion des informations de type (CompleteTypeInfo) est centralisee */
 		/* au niveau du domaine en fin de parsing */
+
+		/* Commentaires internes */
+		if ((yyvsp[-2].svValue) != NULL)
+		{
+			kwcClass->SetInternalComments((yyvsp[-2].svValue));
+			delete (yyvsp[-2].svValue);
+		}
 
 		/* Reinitialisation de la classe courante */
 		kwcLoadCurrentClass = NULL;
 	}
-#line 1623 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1660 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 24: /* kwclassBegin: kwclassHeader comments  */
-#line 247 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 24: /* kwclassBegin: kwclassHeader  */
+#line 262 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		/* On ignore les premiers comemntaires */
-		if ((yyvsp[0].sValue) != NULL)
-			delete (yyvsp[0].sValue);
-		assert(kwcLoadCurrentClass == (yyvsp[-1].kwcValue));
-		(yyval.kwcValue) = (yyvsp[-1].kwcValue);
+		assert(kwcLoadCurrentClass == (yyvsp[0].kwcValue));
+		(yyval.kwcValue) = (yyvsp[0].kwcValue);
 	}
-#line 1635 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1669 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 25: /* kwclassBegin: kwclassBegin kwattributeDeclaration  */
-#line 255 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 267 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-1].kwcValue);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
@@ -1646,26 +1696,22 @@ yyreduce:
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1681 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1715 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 26: /* kwclassBegin: kwclassBegin '{' comments oaAttributeArrayDeclaration '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 297 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 26: /* kwclassBegin: kwclassBegin comments '{' oaAttributeArrayDeclaration comments '}' IDENTIFIER usedDerivationRule semicolon metaData label  */
+#line 309 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		KWClass* kwcClass = (yyvsp[-9].kwcValue);
+		KWClass* kwcClass = (yyvsp[-10].kwcValue);
 		KWAttributeBlock* attributeBlock;
-		ObjectArray* oaAttributes = (yyvsp[-6].oaAttributes);
+		ObjectArray* oaAttributes = (yyvsp[-7].oaAttributes);
 		ALString sBlockName;
 		KWAttribute* firstAttribute;
 		KWAttribute* lastAttribute;
 		KWDerivationRule* rule = (yyvsp[-3].kwdrValue);
 		ALString sMessage;
-		assert(kwcLoadCurrentClass == (yyvsp[-9].kwcValue));
+		assert(kwcLoadCurrentClass == (yyvsp[-10].kwcValue));
 		check(oaAttributes);
-
-		/* On ignore les premiers comemntaires */
-		if ((yyvsp[-7].sValue) != NULL)
-			delete (yyvsp[-7].sValue);
 
 		/* Nom du bloc */
 		if ((yyvsp[-4].sValue) != NULL)
@@ -1710,6 +1756,10 @@ yyreduce:
 					attributeBlock->GetMetaData()->CopyFrom((yyvsp[-1].kwmdMetaData));
 				if ((yyvsp[0].sValue) != NULL)
 					attributeBlock->SetLabel(*((yyvsp[0].sValue)));
+				if ((yyvsp[-9].svValue) != NULL)
+					attributeBlock->SetComments((yyvsp[-9].svValue));
+				if ((yyvsp[-6].svValue) != NULL)
+					attributeBlock->SetInternalComments((yyvsp[-6].svValue));
 
 				/* On marque la rule a NULL pour indiquer qu'elle est utilisee */
 				rule = NULL;
@@ -1725,6 +1775,10 @@ yyreduce:
 		delete oaAttributes;
 
 		/* Nettoyage */
+		if ((yyvsp[-9].svValue) != NULL)
+			delete (yyvsp[-9].svValue);
+		if ((yyvsp[-6].svValue) != NULL)
+			delete (yyvsp[-6].svValue);
 		if ((yyvsp[-4].sValue) != NULL)
 			delete (yyvsp[-4].sValue);
 		if ((yyvsp[-1].kwmdMetaData) != NULL)
@@ -1734,34 +1788,36 @@ yyreduce:
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1765 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1803 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 27: /* kwclassBegin: kwclassBegin '{' comments '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 377 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 27: /* kwclassBegin: kwclassBegin comments '{' comments '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
+#line 393 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		KWClass* kwcClass = (yyvsp[-8].kwcValue);
+		KWClass* kwcClass = (yyvsp[-9].kwcValue);
 
 		/* Message d'erreur */
 		yyerror("Empty sparse variable block not allowed");
 
 		/* Nettoyage */
-		if ((yyvsp[-6].sValue) != NULL)
-			delete (yyvsp[-6].sValue);
+		if ((yyvsp[-8].svValue) != NULL)
+			delete (yyvsp[-8].svValue);
+		if ((yyvsp[-6].svValue) != NULL)
+			delete (yyvsp[-6].svValue);
 		delete (yyvsp[-4].sValue);
 		if ((yyvsp[-3].kwdrValue) != NULL)
 			delete (yyvsp[-3].kwdrValue);
 		if ((yyvsp[-1].kwmdMetaData) != NULL)
 			delete (yyvsp[-1].kwmdMetaData);
-		if ((yyvsp[0].sValue) != NULL)
-			delete (yyvsp[0].sValue);
+		if ((yyvsp[0].svValue) != NULL)
+			delete (yyvsp[0].svValue);
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1788 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1828 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 28: /* kwclassBegin: kwclassBegin error  */
-#line 396 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 414 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* ERRORMGT */
 		/* Attention: cette regle qui permet une gestion des erreurs amelioree */
@@ -1769,11 +1825,11 @@ yyreduce:
 		kwcLoadCurrentClass = NULL;
 		YYABORT;
 	}
-#line 1800 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1840 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 29: /* oaAttributeArrayDeclaration: oaAttributeArrayDeclaration kwattributeDeclaration  */
-#line 407 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 425 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes = (yyvsp[-1].oaAttributes);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
@@ -1819,11 +1875,11 @@ yyreduce:
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1848 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1888 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 30: /* oaAttributeArrayDeclaration: kwattributeDeclaration  */
-#line 451 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 469 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes;
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
@@ -1871,27 +1927,39 @@ yyreduce:
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1898 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1938 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 31: /* kwclassHeader: comments rootDeclaration CLASS IDENTIFIER keyFields metaData '{'  */
-#line 499 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 31: /* kwclassHeader: comments rootDeclaration CLASS IDENTIFIER labelOrComments keyFields labelOrComments metaData labelOrComments '{'  */
+#line 521 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		StringVector* svComments1 = (yyvsp[-9].svValue);
+		boolean bRoot = (yyvsp[-8].bValue);
+		ALString* sIdentifier = (yyvsp[-6].sValue);
+		StringVector* svComments2 = (yyvsp[-5].svValue);
+		StringVector* svKeyFields = (yyvsp[-4].svValue);
+		StringVector* svComments3 = (yyvsp[-3].svValue);
+		KWMetaData* metaData = (yyvsp[-2].kwmdMetaData);
+		StringVector* svComments4 = (yyvsp[-1].svValue);
 		KWClass* kwcClass;
 		KWClass* kwcReferencedClass;
+		StringVector svAllComments;
+		StringVector svClassComments;
+		int nCommentStartIndex;
+		int i;
 		ALString sMessage;
 
 		/* Test d'existence de la classe */
-		kwcClass = kwcdLoadDomain->LookupClass(*((yyvsp[-3].sValue)));
+		kwcClass = kwcdLoadDomain->LookupClass(*sIdentifier);
 
 		/* Test d'existence de la classe en tant que classe referencee uniquement */
-		kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*((yyvsp[-3].sValue))));
+		kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*sIdentifier));
 		assert(kwcReferencedClass == NULL or kwcClass == NULL);
 
 		/* Erreur si la classe existe deja */
 		if (kwcClass != NULL)
 		{
-			yyerror("Dictionary " + *((yyvsp[-3].sValue)) + " already exists");
+			yyerror("Dictionary " + *sIdentifier + " already exists");
 			kwcClass = NULL;
 		}
 		/* On utilise la classe referencee si elle existe */
@@ -1909,10 +1977,10 @@ yyreduce:
 		else
 		{
 			/* Test de nom de classe */
-			if (KWClass::CheckNameWithMessage(*((yyvsp[-3].sValue)), KWClass::Class, sMessage))
+			if (KWClass::CheckNameWithMessage(*sIdentifier, KWClass::Class, sMessage))
 			{
 				kwcClass = new KWClass;
-				kwcClass->SetName(*((yyvsp[-3].sValue)));
+				kwcClass->SetName(*sIdentifier);
 				kwcdLoadDomain->InsertClass(kwcClass);
 			}
 			else
@@ -1922,85 +1990,108 @@ yyreduce:
 		/* Initialisation si necessaire de la classe */
 		if (kwcClass != NULL)
 		{
-			/* Class Label */
-			if ((yyvsp[-6].sValue) != NULL)
-				kwcClass->SetLabel(*((yyvsp[-6].sValue)));
+			/* Commentaire de la classe en cours */
+			svClassComments.CopyFrom(kwcClass->GetComments());
 
 			/* Classe racine */
-			kwcClass->SetRoot((yyvsp[-5].bValue));
+			kwcClass->SetRoot(bRoot);
 
 			/* Attribut key field */
-			if ((yyvsp[-2].svValue) != NULL)
+			if (svKeyFields != NULL)
 			{
-				StringVector* svKeyFields;
-				int i;
-
 				// Transfert des champs de la cle */
-				svKeyFields = cast(StringVector*, (yyvsp[-2].svValue));
+				svKeyFields = cast(StringVector*, svKeyFields);
 				kwcClass->SetKeyAttributeNumber(svKeyFields->GetSize());
 				for (i = 0; i < svKeyFields->GetSize(); i++)
 					kwcClass->SetKeyAttributeNameAt(i, svKeyFields->GetAt(i));
 			}
 
 			/* Meta-donnees de la classe */
-			if ((yyvsp[-1].kwmdMetaData) != NULL)
+			if (metaData != NULL)
+				kwcClass->GetMetaData()->CopyFrom(metaData);
+
+			/* On recupere les commentaires existants */
+			svAllComments.CopyFrom(kwcClass->GetComments());
+
+			/* On recupere tous les commentaires entre le debut et la fin de la declaration de la classe */
+			if (svComments1 != NULL)
 			{
-				kwcClass->GetMetaData()->CopyFrom((yyvsp[-1].kwmdMetaData));
+				for (i = 0; i < svComments1->GetSize(); i++)
+					svAllComments.Add(svComments1->GetAt(i));
+			}
+			if (svComments2 != NULL)
+			{
+				for (i = 0; i < svComments2->GetSize(); i++)
+					svAllComments.Add(svComments2->GetAt(i));
+			}
+			if (svComments3 != NULL)
+			{
+				for (i = 0; i < svComments3->GetSize(); i++)
+					svAllComments.Add(svComments3->GetAt(i));
+			}
+			if (svComments4 != NULL)
+			{
+				for (i = 0; i < svComments4->GetSize(); i++)
+					svAllComments.Add(svComments4->GetAt(i));
+			}
+
+			/* Libelle de la classe: le premier des commentaires, sauf s'il existe deja */
+			nCommentStartIndex = 0;
+			if (kwcClass->GetLabel() == "" and svAllComments.GetSize() > 0)
+			{
+				kwcClass->SetLabel(svAllComments.GetAt(0));
+				nCommentStartIndex = 1;
+			}
+
+			/* Mise a jour des commentaires de la classe, en excluant potentiellement le premier commentaire reserve au libelle */
+			if (svAllComments.GetSize() > 0)
+			{
+				for (i = nCommentStartIndex; i < svAllComments.GetSize(); i++)
+					svClassComments.Add(svAllComments.GetAt(i));
+				kwcClass->SetComments(&svClassComments);
 			}
 		}
 
 		/* Liberation des tokens */
-		if ((yyvsp[-6].sValue) != NULL)
-			delete (yyvsp[-6].sValue); /* Label */
-		delete (yyvsp[-3].sValue);         /* Name */
-		if ((yyvsp[-2].svValue) != NULL)   /* Key fields */
-		{
-			StringVector* svKeyFields;
-			svKeyFields = cast(StringVector*, (yyvsp[-2].svValue));
+		delete sIdentifier;
+		if (svKeyFields != NULL)
 			delete svKeyFields;
-		}
-		if ((yyvsp[-1].kwmdMetaData) != NULL)
-			delete (yyvsp[-1].kwmdMetaData); /* Key value pairs */
+		if (metaData != NULL)
+			delete metaData;
+		if (svComments1 != NULL)
+			delete svComments1;
+		if (svComments2 != NULL)
+			delete svComments2;
+		if (svComments3 != NULL)
+			delete svComments3;
+		if (svComments4 != NULL)
+			delete svComments4;
 
-		/* Memorisation dz la classe courante */
+		/* Memorisation de la classe courante */
 		kwcLoadCurrentClass = kwcClass;
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1992 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2076 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 32: /* keyFields: '(' fieldList ')' comments  */
-#line 592 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		/* On ignore les comemntaires */
-		if ((yyvsp[0].sValue) != NULL)
-			delete (yyvsp[0].sValue);
-		(yyval.svValue) = (yyvsp[-2].svValue);
-	}
-#line 2003 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 33: /* keyFields: comments  */
-#line 599 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		/* On ignore les comemntaires */
-		if ((yyvsp[0].sValue) != NULL)
-			delete (yyvsp[0].sValue);
-		(yyval.svValue) = NULL; /* pas de champ cle */
-	}
-#line 2014 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 34: /* keyFields: %empty  */
-#line 606 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 32: /* keyFields: %empty  */
+#line 658 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.svValue) = NULL; /* pas de champ cle */
 	}
-#line 2022 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2084 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 35: /* fieldList: fieldList ',' IDENTIFIER  */
-#line 613 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 33: /* keyFields: '(' fieldList ')'  */
+#line 662 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.svValue) = (yyvsp[-1].svValue);
+	}
+#line 2092 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 34: /* fieldList: fieldList ',' IDENTIFIER  */
+#line 669 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svFields;
 
@@ -2010,11 +2101,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svFields;
 	}
-#line 2036 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2106 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 36: /* fieldList: IDENTIFIER  */
-#line 623 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 35: /* fieldList: IDENTIFIER  */
+#line 679 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svFields;
 
@@ -2024,11 +2115,19 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svFields;
 	}
-#line 2050 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2120 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 36: /* metaData: %empty  */
+#line 691 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.kwmdMetaData) = NULL; /* pas de paires cle valeurs */
+	}
+#line 2128 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 37: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' STRINGLITTERAL '>'  */
-#line 636 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 695 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2048,11 +2147,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2074 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2152 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 38: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' CONTINUOUSLITTERAL '>'  */
-#line 656 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 715 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2074,11 +2173,11 @@ yyreduce:
 		delete (yyvsp[-3].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2100 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2178 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 39: /* metaData: metaData '<' SIMPLEIDENTIFIER '>'  */
-#line 678 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 737 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2097,11 +2196,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2123 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2201 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 40: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' IDENTIFIER '>'  */
-#line 697 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 756 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
@@ -2118,19 +2217,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2143 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2221 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 41: /* metaData: %empty  */
-#line 713 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.kwmdMetaData) = NULL; /* pas de paires cle valeurs */
-	}
-#line 2151 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 42: /* kwattributeDeclaration: usedDeclaration typeDeclaration refIdentifier IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 729 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 41: /* kwattributeDeclaration: comments usedDeclaration typeDeclaration refIdentifier IDENTIFIER usedDerivationRule semicolon metaData label  */
+#line 785 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWAttribute* attribute;
 		KWDerivationRule* rule;
@@ -2154,8 +2245,8 @@ yyreduce:
 		{
 			if ((yyvsp[-5].sValue) == NULL)
 				yyerrorWithLineCorrection("Variable " + *((yyvsp[-4].sValue)) + " of type " +
-							      KWType::ToString((yyvsp[-6].nValue)) + ": missing " +
-							      KWType::ToString((yyvsp[-6].nValue)) + " dictionary",
+							      KWType::ToString((yyvsp[-7].bValue)) + ": missing " +
+							      KWType::ToString((yyvsp[-7].bValue)) + " dictionary",
 							  -1);
 		}
 		/* Test d'absence de complement de type dans les autres cas */
@@ -2264,20 +2355,35 @@ yyreduce:
 			delete (yyvsp[-1].kwmdMetaData);
 		}
 
-		/* Commentaires */
+		/* Libelle */
 		if ((yyvsp[0].sValue) != NULL)
 		{
 			attribute->SetLabel(*((yyvsp[0].sValue)));
 			delete (yyvsp[0].sValue);
 		}
 
+		/* Commentaires */
+		if ((yyvsp[-8].svValue) != NULL)
+		{
+			attribute->SetComments((yyvsp[-8].svValue));
+			delete (yyvsp[-8].svValue);
+		}
+
 		(yyval.kwaValue) = attribute;
 	}
-#line 2278 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2355 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 42: /* applicationids: %empty  */
+#line 919 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.sValue) = NULL; /* pas d'identification d'application */
+	}
+#line 2363 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 43: /* applicationids: applicationids APPLICATIONID  */
-#line 857 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 923 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* On ne garde que la premiere ligne de chaque identification d'application */
 		if ((yyvsp[-1].sValue) == NULL)
@@ -2288,203 +2394,262 @@ yyreduce:
 			(yyval.sValue) = (yyvsp[-1].sValue);
 		}
 	}
-#line 2293 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2378 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 44: /* applicationids: %empty  */
-#line 868 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 44: /* label: %empty  */
+#line 937 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.sValue) = NULL; /* pas d'identification d'application */
+		(yyval.sValue) = NULL; /* pas de libelle */
 	}
-#line 2301 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2386 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 45: /* comments: comments LABEL  */
-#line 876 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 45: /* label: LABEL  */
+#line 941 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		/* On ne garde que la premiere ligne de chaque commentaire */
-		if ((yyvsp[-1].sValue) == NULL)
-			(yyval.sValue) = (yyvsp[0].sValue);
-		else
-		{
-			delete (yyvsp[0].sValue);
-			(yyval.sValue) = (yyvsp[-1].sValue);
-		}
+		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 2316 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2394 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 46: /* comments: %empty  */
-#line 887 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.sValue) = NULL; /* pas de commentaire */
-	}
-#line 2324 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 47: /* rootDeclaration: ROOT  */
-#line 895 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.bValue) = true;
-	}
-#line 2332 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 48: /* rootDeclaration: %empty  */
-#line 899 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.bValue) = false; /* valeur par defaut */
-	}
-#line 2340 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 49: /* usedDeclaration: UNUSED  */
-#line 907 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.bValue) = false;
-	}
-#line 2348 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 50: /* usedDeclaration: %empty  */
-#line 911 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.bValue) = true; /* valeur par defaut */
-	}
-#line 2356 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 51: /* typeDeclaration: CONTINUOUSTYPE  */
-#line 919 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.nValue) = KWType::Continuous;
-	}
-#line 2364 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 52: /* typeDeclaration: SYMBOLTYPE  */
-#line 923 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.nValue) = KWType::Symbol;
-	}
-#line 2372 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 53: /* typeDeclaration: DATETYPE  */
-#line 927 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.nValue) = KWType::Date;
-	}
-#line 2380 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 54: /* typeDeclaration: TIMETYPE  */
-#line 931 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.nValue) = KWType::Time;
-	}
-#line 2388 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 55: /* typeDeclaration: TIMESTAMPTYPE  */
-#line 935 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.nValue) = KWType::Timestamp;
-	}
-#line 2396 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 56: /* typeDeclaration: TIMESTAMPTZTYPE  */
-#line 939 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.nValue) = KWType::TimestampTZ;
-	}
-#line 2404 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 57: /* typeDeclaration: TEXTTYPE  */
-#line 943 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.nValue) = KWType::Text;
-	}
-#line 2412 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 58: /* typeDeclaration: TEXTLISTTYPE  */
 #line 947 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.nValue) = KWType::TextList;
+		(yyval.svValue) = NULL; /* pas de commentaire */
 	}
-#line 2420 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2402 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 59: /* typeDeclaration: OBJECTTYPE  */
+	case 47: /* comments: comments COMMENT  */
 #line 951 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.nValue) = KWType::Object;
+		StringVector* svComments;
+
+		/* Creation du vecteur de commentaires si neccesaire */
+		if ((yyvsp[-1].svValue) == NULL)
+			svComments = new StringVector;
+		else
+			svComments = (yyvsp[-1].svValue);
+
+		/* Ajout du commentaire */
+		svComments->Add(*(yyvsp[0].sValue));
+		delete (yyvsp[0].sValue);
+		(yyval.svValue) = svComments;
 	}
-#line 2428 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2421 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 60: /* typeDeclaration: OBJECTARRAYTYPE  */
-#line 955 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 48: /* labelOrComments: %empty  */
+#line 968 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.nValue) = KWType::ObjectArray;
+		(yyval.svValue) = NULL; /* pas de commentaire */
 	}
-#line 2436 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2429 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 61: /* typeDeclaration: STRUCTURETYPE  */
-#line 959 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 49: /* labelOrComments: LABEL  */
+#line 972 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.nValue) = KWType::Structure;
+		StringVector* svComments;
+		svComments = new StringVector;
+		svComments->Add(*(yyvsp[0].sValue));
+		delete (yyvsp[0].sValue);
+		(yyval.svValue) = svComments;
 	}
-#line 2444 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2441 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 62: /* refIdentifier: '(' IDENTIFIER ')'  */
-#line 967 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 50: /* labelOrComments: labelOrComments COMMENT  */
+#line 980 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.sValue) = (yyvsp[-1].sValue);
-	}
-#line 2452 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
+		StringVector* svComments;
 
-	case 63: /* refIdentifier: %empty  */
-#line 971 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.sValue) = NULL;
+		/* Creation du vecteur de commentaires si neccesaire */
+		if ((yyvsp[-1].svValue) == NULL)
+			svComments = new StringVector;
+		else
+			svComments = (yyvsp[-1].svValue);
+
+		/* Ajout du commentaire */
+		svComments->Add(*(yyvsp[0].sValue));
+		delete (yyvsp[0].sValue);
+		(yyval.svValue) = svComments;
 	}
 #line 2460 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 64: /* usedDerivationRule: '=' derivationRule  */
-#line 978 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 51: /* rootDeclaration: %empty  */
+#line 997 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
+		(yyval.bValue) = false; /* valeur par defaut */
 	}
 #line 2468 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 65: /* usedDerivationRule: referenceRule  */
-#line 982 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 52: /* rootDeclaration: ROOT  */
+#line 1001 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
+		(yyval.bValue) = true;
 	}
 #line 2476 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 66: /* usedDerivationRule: '=' derivationRule ')'  */
-#line 986 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 53: /* usedDeclaration: %empty  */
+#line 1008 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.bValue) = true; /* valeur par defaut */
+	}
+#line 2484 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 54: /* usedDeclaration: UNUSED  */
+#line 1012 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.bValue) = false;
+	}
+#line 2492 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 55: /* typeDeclaration: CONTINUOUSTYPE  */
+#line 1020 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::Continuous;
+	}
+#line 2500 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 56: /* typeDeclaration: SYMBOLTYPE  */
+#line 1024 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::Symbol;
+	}
+#line 2508 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 57: /* typeDeclaration: DATETYPE  */
+#line 1028 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::Date;
+	}
+#line 2516 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 58: /* typeDeclaration: TIMETYPE  */
+#line 1032 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::Time;
+	}
+#line 2524 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 59: /* typeDeclaration: TIMESTAMPTYPE  */
+#line 1036 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::Timestamp;
+	}
+#line 2532 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 60: /* typeDeclaration: TIMESTAMPTZTYPE  */
+#line 1040 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::TimestampTZ;
+	}
+#line 2540 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 61: /* typeDeclaration: TEXTTYPE  */
+#line 1044 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::Text;
+	}
+#line 2548 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 62: /* typeDeclaration: TEXTLISTTYPE  */
+#line 1048 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::TextList;
+	}
+#line 2556 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 63: /* typeDeclaration: OBJECTTYPE  */
+#line 1052 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::Object;
+	}
+#line 2564 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 64: /* typeDeclaration: OBJECTARRAYTYPE  */
+#line 1056 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::ObjectArray;
+	}
+#line 2572 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 65: /* typeDeclaration: STRUCTURETYPE  */
+#line 1060 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.nValue) = KWType::Structure;
+	}
+#line 2580 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 66: /* refIdentifier: %empty  */
+#line 1067 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.sValue) = NULL;
+	}
+#line 2588 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 67: /* refIdentifier: '(' IDENTIFIER ')'  */
+#line 1071 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.sValue) = (yyvsp[-1].sValue);
+	}
+#line 2596 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 68: /* usedDerivationRule: %empty  */
+#line 1078 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.kwdrValue) = NULL;
+	}
+#line 2604 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 69: /* usedDerivationRule: '=' derivationRule  */
+#line 1082 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
+	}
+#line 2612 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 70: /* usedDerivationRule: referenceRule  */
+#line 1086 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
+	}
+#line 2620 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 71: /* usedDerivationRule: '=' derivationRule ')'  */
+#line 1090 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ')'");
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2485 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2629 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 67: /* usedDerivationRule: '(' IDENTIFIER ')'  */
-#line 991 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 72: /* usedDerivationRule: '(' IDENTIFIER ')'  */
+#line 1095 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ALString sTmp;
 		yyerror(sTmp + "Invalid syntax (" + *(yyvsp[-1].sValue) + ")");
@@ -2492,27 +2657,19 @@ yyreduce:
 			delete (yyvsp[-1].sValue);
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2497 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2641 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 68: /* usedDerivationRule: %empty  */
-#line 999 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		(yyval.kwdrValue) = NULL;
-	}
-#line 2505 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 69: /* referenceRule: referenceRuleBody ']'  */
-#line 1005 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 73: /* referenceRule: referenceRuleBody ']'  */
+#line 1105 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2513 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2649 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 70: /* referenceRuleBody: '[' derivationRuleOperand  */
-#line 1011 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 74: /* referenceRuleBody: '[' derivationRuleOperand  */
+#line 1111 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule;
 		KWDerivationRuleOperand* operand;
@@ -2532,11 +2689,11 @@ yyreduce:
 		/* On retourner la regle */
 		(yyval.kwdrValue) = rule;
 	}
-#line 2537 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2673 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 71: /* referenceRuleBody: referenceRuleBody ',' derivationRuleOperand  */
-#line 1031 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 75: /* referenceRuleBody: referenceRuleBody ',' derivationRuleOperand  */
+#line 1131 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand;
@@ -2550,11 +2707,11 @@ yyreduce:
 		/* On retourner la regle */
 		(yyval.kwdrValue) = rule;
 	}
-#line 2555 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2691 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 72: /* derivationRule: derivationRuleBody closeparenthesis  */
-#line 1047 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 76: /* derivationRule: derivationRuleBody closeparenthesis  */
+#line 1147 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		boolean bOk = true;
 		KWDerivationRule* ruleBody = (yyvsp[-1].kwdrValue);
@@ -2661,19 +2818,19 @@ yyreduce:
 		delete ruleBody;
 		(yyval.kwdrValue) = rule;
 	}
-#line 2664 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2800 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 73: /* derivationRuleBody: derivationRuleBegin  */
-#line 1155 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 77: /* derivationRuleBody: derivationRuleBegin  */
+#line 1255 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2672 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2808 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 74: /* derivationRuleBody: derivationRuleBegin ':' operandList  */
-#line 1159 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 78: /* derivationRuleBody: derivationRuleBegin ':' operandList  */
+#line 1259 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* ruleBody = (yyvsp[-2].kwdrValue);
 		KWDRRelationCreationRule* ruleRelationCreationBody;
@@ -2719,19 +2876,19 @@ yyreduce:
 
 		(yyval.kwdrValue) = ruleRelationCreationBody;
 	}
-#line 2722 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2858 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 75: /* derivationRuleBody: derivationRuleHeader  */
-#line 1205 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 79: /* derivationRuleBody: derivationRuleHeader  */
+#line 1305 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2730 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2866 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 76: /* operandList: operandList ',' derivationRuleOperand  */
-#line 1212 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 80: /* operandList: operandList ',' derivationRuleOperand  */
+#line 1312 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaOperandList = (yyvsp[-2].oaOperands);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2742,11 +2899,11 @@ yyreduce:
 		oaOperandList->Add(operand);
 		(yyval.oaOperands) = oaOperandList;
 	}
-#line 2745 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2881 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 77: /* operandList: derivationRuleOperand  */
-#line 1223 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 81: /* operandList: derivationRuleOperand  */
+#line 1323 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaOperandList;
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2757,11 +2914,11 @@ yyreduce:
 		oaOperandList->Add(operand);
 		(yyval.oaOperands) = oaOperandList;
 	}
-#line 2760 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2896 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 78: /* derivationRuleHeader: IDENTIFIER openparenthesis  */
-#line 1236 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 82: /* derivationRuleHeader: IDENTIFIER openparenthesis  */
+#line 1336 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule;
 
@@ -2771,11 +2928,11 @@ yyreduce:
 		delete (yyvsp[-1].sValue);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2774 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2910 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 79: /* derivationRuleBegin: derivationRuleHeader derivationRuleOperand  */
-#line 1249 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 83: /* derivationRuleBegin: derivationRuleHeader derivationRuleOperand  */
+#line 1349 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-1].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2786,11 +2943,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2789 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2925 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 80: /* derivationRuleBegin: derivationRuleBegin ',' derivationRuleOperand  */
-#line 1260 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 84: /* derivationRuleBegin: derivationRuleBegin ',' derivationRuleOperand  */
+#line 1360 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2801,11 +2958,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2804 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2940 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 81: /* derivationRuleOperand: IDENTIFIER  */
-#line 1274 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 85: /* derivationRuleOperand: IDENTIFIER  */
+#line 1374 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2814,11 +2971,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2817 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2953 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 82: /* derivationRuleOperand: CONTINUOUSLITTERAL  */
-#line 1283 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 86: /* derivationRuleOperand: CONTINUOUSLITTERAL  */
+#line 1383 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2827,11 +2984,11 @@ yyreduce:
 		operand->SetContinuousConstant((yyvsp[0].cValue));
 		(yyval.kwdroValue) = operand;
 	}
-#line 2830 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2966 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 83: /* derivationRuleOperand: bigstring  */
-#line 1292 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 87: /* derivationRuleOperand: bigstring  */
+#line 1392 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2841,11 +2998,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2844 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2980 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 84: /* derivationRuleOperand: derivationRule  */
-#line 1302 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 88: /* derivationRuleOperand: derivationRule  */
+#line 1402 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2855,22 +3012,22 @@ yyreduce:
 			operand->SetType(operand->GetDerivationRule()->GetType());
 		(yyval.kwdroValue) = operand;
 	}
-#line 2858 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2994 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 85: /* derivationRuleOperand: '.' derivationRuleOperand  */
-#line 1312 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 89: /* derivationRuleOperand: '.' derivationRuleOperand  */
+#line 1412 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = (yyvsp[0].kwdroValue);
 		operand->SetScopeLevel(operand->GetScopeLevel() + 1);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2869 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3005 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 86: /* bigstring: bigstring '+' STRINGLITTERAL  */
-#line 1323 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 90: /* bigstring: bigstring '+' STRINGLITTERAL  */
+#line 1423 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		/* Concatenation des deux chaines */
 		(yyval.sValue) = new ALString(*(yyvsp[-2].sValue) + *(yyvsp[0].sValue));
@@ -2879,84 +3036,80 @@ yyreduce:
 		delete (yyvsp[-2].sValue);
 		delete (yyvsp[0].sValue);
 	}
-#line 2882 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3018 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 87: /* bigstring: STRINGLITTERAL  */
-#line 1332 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 91: /* bigstring: STRINGLITTERAL  */
+#line 1432 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 2890 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3026 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 89: /* semicolon: ';' ';'  */
-#line 1340 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		yyerror("There is one superfluous ';'");
-	}
-#line 2898 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 90: /* semicolon: ';' ';' ';'  */
-#line 1344 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		yyerror("Too many ';'");
-	}
-#line 2906 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 91: /* semicolon: %empty  */
-#line 1348 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 92: /* semicolon: %empty  */
+#line 1438 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Missing ';'");
 	}
-#line 2914 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3034 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 93: /* openparenthesis: '(' '('  */
-#line 1356 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 94: /* semicolon: ';' ';'  */
+#line 1443 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		yyerror("There is one superfluous ';'");
+	}
+#line 3042 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 95: /* semicolon: ';' ';' ';'  */
+#line 1447 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		yyerror("Too many ';'");
+	}
+#line 3050 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 96: /* openparenthesis: %empty  */
+#line 1453 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		/* Cette instruction est la pour aider au diagnostique des erreurs */
+		/* de parenthesage: elle est utile dans ce cas, mais genere (avec  */
+		/* sa consoeur de nombreux shift/reduce et reduce conflicts        */
+		yyerror("Missing '('");
+	}
+#line 3061 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 98: /* openparenthesis: '(' '('  */
+#line 1461 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous '('");
 	}
-#line 2922 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3069 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 94: /* openparenthesis: '(' '(' '('  */
-#line 1360 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 99: /* openparenthesis: '(' '(' '('  */
+#line 1465 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many '('");
 	}
-#line 2930 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3077 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 95: /* openparenthesis: %empty  */
-#line 1364 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 100: /* closeparenthesis: %empty  */
+#line 1472 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		/* ERRORMGT */
-		/* Attention: supprimer cette instruction en cas d'evolution du parser */
 		/* Cette instruction est la pour aider au diagnostique des erreurs */
 		/* de parenthesage: elle est utile dans ce cas, mais genere (avec  */
-		/* sa consoeur 3 shift/reduce conflicts et 12 reduce conflicts     */
-		yyerror("Missing '('");
-	}
-#line 2943 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 97: /* closeparenthesis: %empty  */
-#line 1378 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		/* ERRORMGT */
-		/* Attention: supprimer cette instruction en cas d'evolution du parser */
-		/* Cette instruction est la pour aider au diagnostique des erreurs */
-		/* de parenthesage: elle est utile dans ce cas, mais genere (avec  */
-		/* sa consoeur 3 shift/reduce conflicts et 12 reduce conflicts     */
+		/* sa consoeur de nombreux shift/reduce et reduce conflicts        */
 		yyerror("Missing ')'");
 	}
-#line 2956 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3088 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-#line 2960 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3092 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 	default:
 		break;
@@ -3135,7 +3288,7 @@ yyreturnlab:
 	return yyresult;
 }
 
-#line 1389 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1482 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 #include "KWCLex.inc"
 

--- a/src/Learning/KWData/KWCYac.cpp
+++ b/src/Learning/KWData/KWCYac.cpp
@@ -70,13 +70,10 @@
 /* First part of user prologue.  */
 #line 1 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
-/* ATTENTION: les regles openparenthesis et closeparenthesis generent             */
-/* 3 shift/reduce conflicts et 15 reduce/reduce conflicts                         */
-/* La regle kwclassBegin genere 1 reduce/reduce conflict supplementaire           */
-/* Attention: modifier ces regles en cas d'evolution du parser                    */
-/* Ces regles ne sont utiles que pour le diagnostique des erreurs de parenthesage */
-/* ou de rattrapage sur declaration d'attribut erronee                            */
-/* Ces regles sont reperables par le mot cle ERRORMGT                             */
+// ATTENTION: les regles openparenthesis et closeparenthesis generent
+// de nombreux shift/reduce et reduce/reduce conflicts
+// D'autre regles, notamment pour le gestion des commentaires, generent
+// egalement des conflits
 
 #include "KWClassDomain.h"
 #include "KWClass.h"
@@ -86,49 +83,47 @@
 #include "KWStructureRule.h"
 #include "KWMetaData.h"
 
-/* Declaration du lexer utilise */
+// Declaration du lexer utilise
 void yyerror(char const* fmt);
 void yyerrorWithLineCorrection(char const* fmt, int nDeltaLineNumber);
 int yylex();
 
-/* Fonctions utilitaires pour rappatrier les information du parser vers une regle */
+// Fonctions utilitaires pour rappatrier les information du parser vers une regle
 boolean ImportParserRuleOperands(const KWDerivationRule* parsedRule, KWDerivationRule* rule);
 boolean ImportParserRuleOutputOperands(const KWDerivationRule* parsedRule, KWDerivationRule* rule);
 boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex, KWDerivationRuleOperand* parsedOperand,
 			    KWDerivationRuleOperand* operand);
 
-/* Work around a bug in the relation between bison and GCC 3.x: */
+// Work around a bug in the relation between bison and GCC 3.x:
 #if defined(__GNUC__) && 3 <= __GNUC__
 #define __attribute__(arglist)
 #endif
 
-/* Domaine de classe courant a utiliser pendant la lecture d'un fichier. */
-/* Ce domaine est positionner par la methode Load de KWClassDomain       */
+// Domaine de classe courant a utiliser pendant la lecture d'un fichier.
+// Ce domaine est positionner par la methode Load de KWClassDomain
 static KWClassDomain* kwcdLoadDomain = NULL;
 
-/* Classe courante a utiliser pendant la lecture d'un fichier.     */
-/* Ce domaine est positionner par la methode Load de KWClassDomain */
+// Classe courante a utiliser pendant la lecture d'un fichier.
+// Ce domaine est positionner par la methode Load de KWClassDomain
 static KWClass* kwcLoadCurrentClass = NULL;
 
-/* Dictionnaire des classes referencees creees a la volee lorsqu'elles sont      */
-/* utilisees, mais non crees.                                                    */
-/* On rajoute les classes referencees non crees, et on retire les classes crees. */
+// Dictionnaire des classes referencees creees a la volee lorsqu'elles sont
+// utilisees, mais non crees.
+// On rajoute les classes referencees non crees, et on retire les classes crees.
 static ObjectDictionary* odReferencedUncreatedClasses = NULL;
 
-/* Nombre total d'erreurs de parsing */
+// Nombre total d'erreurs de parsing
 static int nFileParsingErrorNumber = 0;
 
 #define YY_STATIC
 
-/* Debugging YAC */
-
-/*
-#define YYDEBUG 1
-extern char   *yyptok(int i);
+// Debugging YAC
+// Ajouter ici les instruction suivantes
+//   #define YYDEBUG 1
+//   extern char   *yyptok(int i);
 // Ajouter l'instruction yydebug = 1 dans le code d'une action du fichier .lex ou .yac
-*/
 
-#line 135 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 130 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 #ifndef YY_CAST
 #ifdef __cplusplus
@@ -569,12 +564,12 @@ static const yytype_int8 yytranslate[] = {
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] = {
-    0,    147,  147,  151,  158,  162,  166,  170,  174,  178,  182,  186,  190,  194,  198,  202,  206,
-    210,  214,  220,  235,  236,  237,  242,  261,  266,  308,  392,  413,  424,  468,  516,  658,  661,
-    668,  678,  691,  694,  714,  736,  755,  776,  919,  922,  937,  940,  947,  950,  968,  971,  979,
-    997,  1000, 1008, 1011, 1019, 1023, 1027, 1031, 1035, 1039, 1043, 1047, 1051, 1055, 1059, 1067, 1070,
-    1078, 1081, 1085, 1089, 1094, 1104, 1110, 1130, 1146, 1254, 1258, 1304, 1311, 1322, 1335, 1348, 1359,
-    1373, 1382, 1391, 1401, 1411, 1422, 1431, 1438, 1441, 1442, 1446, 1453, 1459, 1460, 1464, 1472, 1478};
+    0,    142,  142,  146,  153,  157,  161,  165,  169,  173,  177,  181,  185,  189,  193,  197,  201,
+    205,  209,  215,  230,  231,  232,  237,  256,  261,  303,  387,  408,  418,  462,  510,  652,  655,
+    662,  672,  685,  688,  708,  730,  749,  770,  913,  916,  931,  934,  941,  944,  962,  965,  973,
+    991,  994,  1002, 1005, 1013, 1017, 1021, 1025, 1029, 1033, 1037, 1041, 1045, 1049, 1053, 1061, 1064,
+    1072, 1075, 1079, 1083, 1088, 1098, 1104, 1124, 1140, 1248, 1252, 1298, 1305, 1316, 1329, 1342, 1353,
+    1367, 1376, 1385, 1395, 1405, 1416, 1425, 1432, 1435, 1436, 1440, 1447, 1453, 1454, 1458, 1466, 1472};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -934,283 +929,283 @@ static void yydestruct(const char* yymsg, yysymbol_kind_t yykind, YYSTYPE* yyval
 	switch (yykind)
 	{
 	case YYSYMBOL_BASICIDENTIFIER: /* BASICIDENTIFIER  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1053 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1048 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_EXTENDEDIDENTIFIER: /* EXTENDEDIDENTIFIER  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1059 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1054 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_STRINGLITTERAL: /* STRINGLITTERAL  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1065 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1060 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_COMMENT: /* COMMENT  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1071 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1066 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_LABEL: /* LABEL  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1077 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1072 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_APPLICATIONID: /* APPLICATIONID  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1083 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1078 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_IDENTIFIER: /* IDENTIFIER  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1089 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1084 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_SIMPLEIDENTIFIER: /* SIMPLEIDENTIFIER  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1095 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1090 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_oaAttributeArrayDeclaration: /* oaAttributeArrayDeclaration  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).oaAttributes) != NULL)
 			delete ((*yyvaluep).oaAttributes);
 		((*yyvaluep).oaAttributes) = NULL;
 	}
-#line 1101 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1096 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_keyFields: /* keyFields  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).svValue) != NULL)
 			delete ((*yyvaluep).svValue);
 		((*yyvaluep).svValue) = NULL;
 	}
-#line 1107 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1102 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_fieldList: /* fieldList  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).svValue) != NULL)
 			delete ((*yyvaluep).svValue);
 		((*yyvaluep).svValue) = NULL;
 	}
-#line 1113 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1108 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_metaData: /* metaData  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwmdMetaData) != NULL)
 			delete ((*yyvaluep).kwmdMetaData);
 		((*yyvaluep).kwmdMetaData) = NULL;
 	}
-#line 1119 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1114 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_kwattributeDeclaration: /* kwattributeDeclaration  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwaValue) != NULL)
 			delete ((*yyvaluep).kwaValue);
 		((*yyvaluep).kwaValue) = NULL;
 	}
-#line 1125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1120 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_applicationids: /* applicationids  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1131 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1126 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_label: /* label  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1137 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1132 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_comments: /* comments  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).svValue) != NULL)
 			delete ((*yyvaluep).svValue);
 		((*yyvaluep).svValue) = NULL;
 	}
-#line 1143 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_labelOrComments: /* labelOrComments  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).svValue) != NULL)
 			delete ((*yyvaluep).svValue);
 		((*yyvaluep).svValue) = NULL;
 	}
-#line 1149 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1144 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_refIdentifier: /* refIdentifier  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1155 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1150 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_usedDerivationRule: /* usedDerivationRule  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1161 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1156 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_referenceRule: /* referenceRule  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1167 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1162 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_referenceRuleBody: /* referenceRuleBody  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1173 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1168 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRule: /* derivationRule  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1179 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1174 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleBody: /* derivationRuleBody  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1185 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1180 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_operandList: /* operandList  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).oaOperands) != NULL)
 			delete ((*yyvaluep).oaOperands);
 		((*yyvaluep).oaOperands) = NULL;
 	}
-#line 1191 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1186 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleHeader: /* derivationRuleHeader  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1197 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1192 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleBegin: /* derivationRuleBegin  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdrValue) != NULL)
 			delete ((*yyvaluep).kwdrValue);
 		((*yyvaluep).kwdrValue) = NULL;
 	}
-#line 1203 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1198 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_derivationRuleOperand: /* derivationRuleOperand  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).kwdroValue) != NULL)
 			delete ((*yyvaluep).kwdroValue);
 		((*yyvaluep).kwdroValue) = NULL;
 	}
-#line 1209 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1204 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case YYSYMBOL_bigstring: /* bigstring  */
-#line 138 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 133 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 1215 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1210 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	default:
@@ -1460,218 +1455,218 @@ yyreduce:
 	switch (yyn)
 	{
 	case 2: /* IDENTIFIER: SIMPLEIDENTIFIER  */
-#line 148 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 143 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1487 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1482 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 3: /* IDENTIFIER: EXTENDEDIDENTIFIER  */
-#line 152 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 147 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1495 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1490 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 4: /* SIMPLEIDENTIFIER: BASICIDENTIFIER  */
-#line 159 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 154 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 1503 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1498 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 5: /* SIMPLEIDENTIFIER: CLASS  */
-#line 163 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 158 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Dictionary");
 	}
-#line 1511 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1506 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 6: /* SIMPLEIDENTIFIER: CONTINUOUSTYPE  */
-#line 167 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 162 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Numerical");
 	}
-#line 1519 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1514 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 7: /* SIMPLEIDENTIFIER: SYMBOLTYPE  */
-#line 171 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 166 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Categorical");
 	}
-#line 1527 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1522 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 8: /* SIMPLEIDENTIFIER: OBJECTTYPE  */
-#line 175 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 170 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Entity");
 	}
-#line 1535 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1530 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 9: /* SIMPLEIDENTIFIER: OBJECTARRAYTYPE  */
-#line 179 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 174 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Table");
 	}
-#line 1543 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1538 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 10: /* SIMPLEIDENTIFIER: ROOT  */
-#line 183 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 178 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Root");
 	}
-#line 1551 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1546 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 11: /* SIMPLEIDENTIFIER: UNUSED  */
-#line 187 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 182 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Unused");
 	}
-#line 1559 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1554 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 12: /* SIMPLEIDENTIFIER: DATETYPE  */
-#line 191 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 186 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Date");
 	}
-#line 1567 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1562 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 13: /* SIMPLEIDENTIFIER: TIMETYPE  */
-#line 195 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 190 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Time");
 	}
-#line 1575 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1570 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 14: /* SIMPLEIDENTIFIER: TIMESTAMPTYPE  */
-#line 199 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 194 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Timestamp");
 	}
-#line 1583 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1578 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 15: /* SIMPLEIDENTIFIER: TIMESTAMPTZTYPE  */
-#line 203 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 198 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("TimestampTZ");
 	}
-#line 1591 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1586 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 16: /* SIMPLEIDENTIFIER: TEXTTYPE  */
-#line 207 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 202 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Text");
 	}
-#line 1599 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1594 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 17: /* SIMPLEIDENTIFIER: TEXTLISTTYPE  */
-#line 211 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 206 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("TextList");
 	}
-#line 1607 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1602 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 18: /* SIMPLEIDENTIFIER: STRUCTURETYPE  */
-#line 215 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 210 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = new ALString("Structure");
 	}
-#line 1615 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1610 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 19: /* kwclassFile: applicationids kwclasses comments  */
-#line 221 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 216 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		/* On ignore l'identification d'application */
+		// On ignore l'identification d'application
 		if ((yyvsp[-2].sValue) != NULL)
 			delete (yyvsp[-2].sValue);
 
-		/* On interdit les commentaires en fin de fichier */
+		// On interdit les commentaires en fin de fichier
 		if ((yyvsp[0].svValue) != NULL)
 		{
 			delete (yyvsp[0].svValue);
 			yyerrorWithLineCorrection("Comments at the end of the file are not allowed", -1);
 		}
 	}
-#line 1632 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1627 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 22: /* kwclasses: kwclasses error  */
-#line 238 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 233 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Error outside the definition of a dictionary");
 		YYABORT;
 	}
-#line 1639 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1634 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 23: /* kwclass: kwclassBegin comments '}' semicolon  */
-#line 243 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 238 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-3].kwcValue);
 
-		/* La completion des informations de type (CompleteTypeInfo) est centralisee */
-		/* au niveau du domaine en fin de parsing */
+		// La completion des informations de type (CompleteTypeInfo) est centralisee
+		// au niveau du domaine en fin de parsing
 
-		/* Commentaires internes */
+		// Commentaires internes
 		if ((yyvsp[-2].svValue) != NULL)
 		{
 			kwcClass->SetInternalComments((yyvsp[-2].svValue));
 			delete (yyvsp[-2].svValue);
 		}
 
-		/* Reinitialisation de la classe courante */
+		// Reinitialisation de la classe courante
 		kwcLoadCurrentClass = NULL;
 	}
-#line 1660 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1655 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 24: /* kwclassBegin: kwclassHeader  */
-#line 262 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 257 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		assert(kwcLoadCurrentClass == (yyvsp[0].kwcValue));
 		(yyval.kwcValue) = (yyvsp[0].kwcValue);
 	}
-#line 1669 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1664 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 25: /* kwclassBegin: kwclassBegin kwattributeDeclaration  */
-#line 267 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 262 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-1].kwcValue);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
 		ALString sMessage;
 		assert(kwcLoadCurrentClass == (yyvsp[-1].kwcValue));
 
-		/* Si attribut non valide: on ne fait rien */
+		// Si attribut non valide: on ne fait rien
 		if (attribute == NULL)
 			;
-		/* Si classe non valide, supression de l'attribut */
+		// Si classe non valide, supression de l'attribut
 		else if (kwcClass == NULL)
 			delete attribute;
-		/* Sinon, test de validite du nom de l'attribut */
+		// Sinon, test de validite du nom de l'attribut
 		else if (!kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		{
 			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ", " + sMessage, -1);
 			delete attribute;
 		}
-		/* Test de non existence parmi les attributs */
+		// Test de non existence parmi les attributs
 		else if (kwcClass->LookupAttribute(attribute->GetName()) != NULL)
 		{
 			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() +
@@ -1679,7 +1674,7 @@ yyreduce:
 						  -1);
 			delete attribute;
 		}
-		/* Test de non existence parmi les blocs */
+		// Test de non existence parmi les blocs
 		else if (kwcClass->LookupAttributeBlock(attribute->GetName()) != NULL)
 		{
 			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() +
@@ -1688,7 +1683,7 @@ yyreduce:
 						  -1);
 			delete attribute;
 		}
-		/* Si OK, d'insertion */
+		// Si OK, d'insertion
 		else
 		{
 			kwcClass->InsertAttribute(attribute);
@@ -1696,11 +1691,11 @@ yyreduce:
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1715 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1710 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 26: /* kwclassBegin: kwclassBegin comments '{' oaAttributeArrayDeclaration comments '}' IDENTIFIER usedDerivationRule semicolon metaData label  */
-#line 309 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 304 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-10].kwcValue);
 		KWAttributeBlock* attributeBlock;
@@ -1713,19 +1708,19 @@ yyreduce:
 		assert(kwcLoadCurrentClass == (yyvsp[-10].kwcValue));
 		check(oaAttributes);
 
-		/* Nom du bloc */
+		// Nom du bloc
 		if ((yyvsp[-4].sValue) != NULL)
 			sBlockName = *((yyvsp[-4].sValue));
 
-		/* Cas d'un bloc avec au moins un attribut valide */
+		// Cas d'un bloc avec au moins un attribut valide
 		if (oaAttributes->GetSize() > 0)
 		{
-			/* Test de validite du nom de l'attribut */
+			// Test de validite du nom de l'attribut
 			if (!kwcClass->CheckNameWithMessage(sBlockName, KWClass::AttributeBlock, sMessage))
 			{
 				yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ", " + sMessage, -1);
 			}
-			/* Test de non existence parmi les attributs */
+			// Test de non existence parmi les attributs
 			else if (kwcClass->LookupAttribute(sBlockName) != NULL)
 			{
 				yyerrorWithLineCorrection(
@@ -1733,7 +1728,7 @@ yyreduce:
 					": Sparse variable block name already used by a variable (" + sBlockName + ")",
 				    -1);
 			}
-			/* Test de non existence parmi les blocs */
+			// Test de non existence parmi les blocs
 			else if (kwcClass->LookupAttributeBlock(sBlockName) != NULL)
 			{
 				yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() +
@@ -1741,16 +1736,16 @@ yyreduce:
 							      sBlockName + ")",
 							  -1);
 			}
-			/* Creation du bloc dans la classe */
+			// Creation du bloc dans la classe
 			else
 			{
-				/* Creation du bloc */
+				// Creation du bloc
 				firstAttribute = cast(KWAttribute*, oaAttributes->GetAt(0));
 				lastAttribute = cast(KWAttribute*, oaAttributes->GetAt(oaAttributes->GetSize() - 1));
 				attributeBlock =
 				    kwcClass->CreateAttributeBlock(sBlockName, firstAttribute, lastAttribute);
 
-				/* Parametrage du bloc */
+				// Parametrage du bloc
 				attributeBlock->SetDerivationRule(rule);
 				if ((yyvsp[-1].kwmdMetaData) != NULL)
 					attributeBlock->GetMetaData()->CopyFrom((yyvsp[-1].kwmdMetaData));
@@ -1761,20 +1756,20 @@ yyreduce:
 				if ((yyvsp[-6].svValue) != NULL)
 					attributeBlock->SetInternalComments((yyvsp[-6].svValue));
 
-				/* On marque la rule a NULL pour indiquer qu'elle est utilisee */
+				// On marque la rule a NULL pour indiquer qu'elle est utilisee
 				rule = NULL;
 			}
 		}
 
-		/* Destruction de l'eventuelle regle si non utilisee */
+		// Destruction de l'eventuelle regle si non utilisee
 		if (rule != NULL)
 			delete rule;
 
-		/* Tous les attributs du tableau ont deja ete inseres dans la classe */
-		// On se contente de detruire le tableau */
+		// Tous les attributs du tableau ont deja ete inseres dans la classe
+		// On se contente de detruire le tableau
 		delete oaAttributes;
 
-		/* Nettoyage */
+		// Nettoyage
 		if ((yyvsp[-9].svValue) != NULL)
 			delete (yyvsp[-9].svValue);
 		if ((yyvsp[-6].svValue) != NULL)
@@ -1788,18 +1783,18 @@ yyreduce:
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1803 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1798 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 27: /* kwclassBegin: kwclassBegin comments '{' comments '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 393 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 388 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-9].kwcValue);
 
-		/* Message d'erreur */
+		// Message d'erreur
 		yyerror("Empty sparse variable block not allowed");
 
-		/* Nettoyage */
+		// Nettoyage
 		if ((yyvsp[-8].svValue) != NULL)
 			delete (yyvsp[-8].svValue);
 		if ((yyvsp[-6].svValue) != NULL)
@@ -1813,23 +1808,22 @@ yyreduce:
 			delete (yyvsp[0].svValue);
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1828 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1823 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 28: /* kwclassBegin: kwclassBegin error  */
-#line 414 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 409 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		/* ERRORMGT */
-		/* Attention: cette regle qui permet une gestion des erreurs amelioree */
-		/* genere un conflit reduce/reduce */
+		// Attention: cette regle qui permet une gestion des erreurs amelioree
+		// genere un conflit reduce/reduce
 		kwcLoadCurrentClass = NULL;
 		YYABORT;
 	}
-#line 1840 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1834 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 29: /* oaAttributeArrayDeclaration: oaAttributeArrayDeclaration kwattributeDeclaration  */
-#line 425 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 419 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes = (yyvsp[-1].oaAttributes);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
@@ -1837,19 +1831,19 @@ yyreduce:
 		ALString sMessage;
 		check(oaAttributes);
 
-		/* Si attribut non valide: on ne fait rien */
+		// Si attribut non valide: on ne fait rien
 		if (attribute == NULL)
 			;
-		/* Si classe non valide, supression de l'attribut */
+		// Si classe non valide, supression de l'attribut
 		else if (kwcClass == NULL)
 			delete attribute;
-		/* Sinon, test de validite du nom de l'attribut */
+		// Sinon, test de validite du nom de l'attribut
 		else if (!kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		{
 			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ", " + sMessage, -1);
 			delete attribute;
 		}
-		/* Test de non existence parmi les attributs */
+		// Test de non existence parmi les attributs
 		else if (kwcClass->LookupAttribute(attribute->GetName()) != NULL)
 		{
 			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() +
@@ -1857,7 +1851,7 @@ yyreduce:
 						  -1);
 			delete attribute;
 		}
-		/* Test de non existence parmi les blocs */
+		// Test de non existence parmi les blocs
 		else if (kwcClass->LookupAttributeBlock(attribute->GetName()) != NULL)
 		{
 			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() +
@@ -1866,7 +1860,7 @@ yyreduce:
 						  -1);
 			delete attribute;
 		}
-		/* Si OK, d'insertion */
+		// Si OK, d'insertion
 		else
 		{
 			kwcClass->InsertAttribute(attribute);
@@ -1875,33 +1869,33 @@ yyreduce:
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1888 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1882 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 30: /* oaAttributeArrayDeclaration: kwattributeDeclaration  */
-#line 469 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 463 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes;
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
 		KWClass* kwcClass = kwcLoadCurrentClass;
 		ALString sMessage;
 
-		/* Creation d'un tableau */
+		// Creation d'un tableau
 		oaAttributes = new ObjectArray;
 
-		/* Si attribut non valide: on ne fait rien */
+		// Si attribut non valide: on ne fait rien
 		if (attribute == NULL)
 			;
-		/* Si classe non valide, supression de l'attribut */
+		// Si classe non valide, supression de l'attribut
 		else if (kwcClass == NULL)
 			delete attribute;
-		/* Sinon, test de validite du nom de l'attribut */
+		// Sinon, test de validite du nom de l'attribut
 		else if (!kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		{
 			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ", " + sMessage, -1);
 			delete attribute;
 		}
-		/* Test de non existence parmi les attributs */
+		// Test de non existence parmi les attributs
 		else if (kwcClass->LookupAttribute(attribute->GetName()) != NULL)
 		{
 			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() +
@@ -1909,7 +1903,7 @@ yyreduce:
 						  -1);
 			delete attribute;
 		}
-		/* Test de non existence parmi les blocs */
+		// Test de non existence parmi les blocs
 		else if (kwcClass->LookupAttributeBlock(attribute->GetName()) != NULL)
 		{
 			yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() +
@@ -1918,7 +1912,7 @@ yyreduce:
 						  -1);
 			delete attribute;
 		}
-		/* Si OK, d'insertion */
+		// Si OK, d'insertion
 		else
 		{
 			kwcClass->InsertAttribute(attribute);
@@ -1927,11 +1921,11 @@ yyreduce:
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1938 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1932 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 31: /* kwclassHeader: comments rootDeclaration CLASS IDENTIFIER labelOrComments keyFields labelOrComments metaData labelOrComments '{'  */
-#line 521 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 515 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svComments1 = (yyvsp[-9].svValue);
 		boolean bRoot = (yyvsp[-8].bValue);
@@ -1949,34 +1943,34 @@ yyreduce:
 		int i;
 		ALString sMessage;
 
-		/* Test d'existence de la classe */
+		// Test d'existence de la classe
 		kwcClass = kwcdLoadDomain->LookupClass(*sIdentifier);
 
-		/* Test d'existence de la classe en tant que classe referencee uniquement */
+		// Test d'existence de la classe en tant que classe referencee uniquement
 		kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*sIdentifier));
 		assert(kwcReferencedClass == NULL or kwcClass == NULL);
 
-		/* Erreur si la classe existe deja */
+		// Erreur si la classe existe deja
 		if (kwcClass != NULL)
 		{
 			yyerror("Dictionary " + *sIdentifier + " already exists");
 			kwcClass = NULL;
 		}
-		/* On utilise la classe referencee si elle existe */
+		// On utilise la classe referencee si elle existe
 		else if (kwcReferencedClass != NULL)
 		{
-			/* Insertion dans le domaine */
+			// Insertion dans le domaine
 			kwcClass = kwcReferencedClass;
 			kwcdLoadDomain->InsertClass(kwcClass);
 
-			/* Supression de la classe referencees */
+			// Supression de la classe referencees
 			odReferencedUncreatedClasses->RemoveKey(kwcReferencedClass->GetName());
 			kwcReferencedClass = NULL;
 		}
-		/* Sinon, on cree la classe et on l'enregistre */
+		// Sinon, on cree la classe et on l'enregistre
 		else
 		{
-			/* Test de nom de classe */
+			// Test de nom de classe
 			if (KWClass::CheckNameWithMessage(*sIdentifier, KWClass::Class, sMessage))
 			{
 				kwcClass = new KWClass;
@@ -1987,33 +1981,33 @@ yyreduce:
 				yyerror(sMessage);
 		}
 
-		/* Initialisation si necessaire de la classe */
+		// Initialisation si necessaire de la classe
 		if (kwcClass != NULL)
 		{
-			/* Commentaire de la classe en cours */
+			// Commentaire de la classe en cours
 			svClassComments.CopyFrom(kwcClass->GetComments());
 
-			/* Classe racine */
+			// Classe racine
 			kwcClass->SetRoot(bRoot);
 
-			/* Attribut key field */
+			// Attribut key field
 			if (svKeyFields != NULL)
 			{
-				// Transfert des champs de la cle */
+				// Transfert des champs de la cle
 				svKeyFields = cast(StringVector*, svKeyFields);
 				kwcClass->SetKeyAttributeNumber(svKeyFields->GetSize());
 				for (i = 0; i < svKeyFields->GetSize(); i++)
 					kwcClass->SetKeyAttributeNameAt(i, svKeyFields->GetAt(i));
 			}
 
-			/* Meta-donnees de la classe */
+			// Meta-donnees de la classe
 			if (metaData != NULL)
 				kwcClass->GetMetaData()->CopyFrom(metaData);
 
-			/* On recupere les commentaires existants */
+			// On recupere les commentaires existants
 			svAllComments.CopyFrom(kwcClass->GetComments());
 
-			/* On recupere tous les commentaires entre le debut et la fin de la declaration de la classe */
+			// On recupere tous les commentaires entre le debut et la fin de la declaration de la classe
 			if (svComments1 != NULL)
 			{
 				for (i = 0; i < svComments1->GetSize(); i++)
@@ -2035,7 +2029,7 @@ yyreduce:
 					svAllComments.Add(svComments4->GetAt(i));
 			}
 
-			/* Libelle de la classe: le premier des commentaires, sauf s'il existe deja */
+			// Libelle de la classe: le premier des commentaires, sauf s'il existe deja
 			nCommentStartIndex = 0;
 			if (kwcClass->GetLabel() == "" and svAllComments.GetSize() > 0)
 			{
@@ -2043,7 +2037,7 @@ yyreduce:
 				nCommentStartIndex = 1;
 			}
 
-			/* Mise a jour des commentaires de la classe, en excluant potentiellement le premier commentaire reserve au libelle */
+			// Mise a jour des commentaires de la classe, en excluant potentiellement le premier commentaire reserve au libelle
 			if (svAllComments.GetSize() > 0)
 			{
 				for (i = nCommentStartIndex; i < svAllComments.GetSize(); i++)
@@ -2052,7 +2046,7 @@ yyreduce:
 			}
 		}
 
-		/* Liberation des tokens */
+		// Liberation des tokens
 		delete sIdentifier;
 		if (svKeyFields != NULL)
 			delete svKeyFields;
@@ -2067,171 +2061,171 @@ yyreduce:
 		if (svComments4 != NULL)
 			delete svComments4;
 
-		/* Memorisation de la classe courante */
+		// Memorisation de la classe courante
 		kwcLoadCurrentClass = kwcClass;
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 2076 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2070 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 32: /* keyFields: %empty  */
-#line 658 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 652 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.svValue) = NULL; /* pas de champ cle */
+		(yyval.svValue) = NULL; // pas de champ cle
 	}
-#line 2084 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2078 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 33: /* keyFields: '(' fieldList ')'  */
-#line 662 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 656 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.svValue) = (yyvsp[-1].svValue);
 	}
-#line 2092 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2086 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 34: /* fieldList: fieldList ',' IDENTIFIER  */
-#line 669 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 663 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svFields;
 
-		/* Ajout d'un nouveau de champ */
+		// Ajout d'un nouveau de champ
 		svFields = cast(StringVector*, (yyvsp[-2].svValue));
 		svFields->Add(*(yyvsp[0].sValue));
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svFields;
 	}
-#line 2106 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2100 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 35: /* fieldList: IDENTIFIER  */
-#line 679 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 673 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svFields;
 
-		/* Creation d'un tableau de champs, avec un premier champ */
+		// Creation d'un tableau de champs, avec un premier champ
 		svFields = new StringVector;
 		svFields->Add(*(yyvsp[0].sValue));
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svFields;
 	}
-#line 2120 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2114 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 36: /* metaData: %empty  */
-#line 691 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 685 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.kwmdMetaData) = NULL; /* pas de paires cle valeurs */
+		(yyval.kwmdMetaData) = NULL; // pas de paires cle valeurs
 	}
-#line 2128 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2122 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 37: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' STRINGLITTERAL '>'  */
-#line 695 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 689 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
-		/* Creation si necessaire d'une ensemble de paires cles valeur */
+		// Creation si necessaire d'une ensemble de paires cles valeur
 		if ((yyvsp[-5].kwmdMetaData) == NULL)
 			metaData = new KWMetaData;
 		else
 			metaData = cast(KWMetaData*, (yyvsp[-5].kwmdMetaData));
 
-		/* Erreur si cle deja existante */
+		// Erreur si cle deja existante
 		if (metaData->IsKeyPresent(*(yyvsp[-3].sValue)))
 			yyerror("Duplicate key in meta-data for key " + *((yyvsp[-3].sValue)));
-		/* Insertion d'une paire avec valeur chaine de caracteres sinon */
+		// Insertion d'une paire avec valeur chaine de caracteres sinon
 		else
 			metaData->SetStringValueAt(*((yyvsp[-3].sValue)), *((yyvsp[-1].sValue)));
 		delete (yyvsp[-3].sValue);
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2152 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2146 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 38: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' CONTINUOUSLITTERAL '>'  */
-#line 715 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 709 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
-		/* Creation si necessaire d'une ensemble de paires cles valeur */
+		// Creation si necessaire d'une ensemble de paires cles valeur
 		if ((yyvsp[-5].kwmdMetaData) == NULL)
 			metaData = new KWMetaData;
 		else
 			metaData = cast(KWMetaData*, (yyvsp[-5].kwmdMetaData));
 
-		/* Erreur si cle deja existante */
+		// Erreur si cle deja existante
 		if (metaData->IsKeyPresent(*(yyvsp[-3].sValue)))
 			yyerror("Duplicate key in meta-data for key " + *((yyvsp[-3].sValue)));
-		/* Erreur si valeur Missing */
+		// Erreur si valeur Missing
 		else if ((yyvsp[-1].cValue) == KWContinuous::GetMissingValue())
 			yyerror("Missing value not allowed in meta-data for key " + *((yyvsp[-3].sValue)));
-		/* Insertion d'une paire avec valeur numerique sinon */
+		// Insertion d'une paire avec valeur numerique sinon
 		else
 			metaData->SetDoubleValueAt(*((yyvsp[-3].sValue)), (yyvsp[-1].cValue));
 		delete (yyvsp[-3].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2178 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2172 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 39: /* metaData: metaData '<' SIMPLEIDENTIFIER '>'  */
-#line 737 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 731 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
-		/* Creation si necessaire d'une ensemble de paires cles valeur */
+		// Creation si necessaire d'une ensemble de paires cles valeur
 		if ((yyvsp[-3].kwmdMetaData) == NULL)
 			metaData = new KWMetaData;
 		else
 			metaData = cast(KWMetaData*, (yyvsp[-3].kwmdMetaData));
 
-		/* Erreur si cle deja existante */
+		// Erreur si cle deja existante
 		if (metaData->IsKeyPresent(*(yyvsp[-1].sValue)))
 			yyerror("Duplicate key in meta-data for key " + *((yyvsp[-1].sValue)));
-		/* Insertion d'une paire avec valeur numerique sinon */
+		// Insertion d'une paire avec valeur numerique sinon
 		else
 			metaData->SetNoValueAt(*((yyvsp[-1].sValue)));
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2201 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2195 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 40: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' IDENTIFIER '>'  */
-#line 756 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 750 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWMetaData* metaData;
 
-		/* Creation si necessaire d'une ensemble de paires cles valeur */
+		// Creation si necessaire d'une ensemble de paires cles valeur
 		if ((yyvsp[-5].kwmdMetaData) == NULL)
 			metaData = new KWMetaData;
 		else
 			metaData = cast(KWMetaData*, (yyvsp[-5].kwmdMetaData));
 
-		/* Erreur car la valeur n'est pas du bon type */
+		// Erreur car la valeur n'est pas du bon type
 		yyerror("Value (" + *((yyvsp[-1].sValue)) + ") of meta-data for key " + *((yyvsp[-3].sValue)) +
 			" should be a string value between double quotes");
 		delete (yyvsp[-3].sValue);
 		delete (yyvsp[-1].sValue);
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2221 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2215 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 41: /* kwattributeDeclaration: comments usedDeclaration typeDeclaration refIdentifier IDENTIFIER usedDerivationRule semicolon metaData label  */
-#line 785 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 779 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWAttribute* attribute;
 		KWDerivationRule* rule;
 
-		/* Creation  et initialisation d'un attribut */
+		// Creation  et initialisation d'un attribut
 		attribute = new KWAttribute;
 		attribute->SetUsed((yyvsp[-7].bValue));
 		attribute->SetType((yyvsp[-6].nValue));
 
-		/* Test de coherence entre le type et le complement de type dans le cas d'un type relation */
+		// Test de coherence entre le type et le complement de type dans le cas d'un type relation
 		if (KWType::IsRelation(attribute->GetType()))
 		{
 			if ((yyvsp[-5].sValue) == NULL)
@@ -2240,7 +2234,7 @@ yyreduce:
 							      KWType::ToString((yyvsp[-6].nValue)) + " dictionary",
 							  -1);
 		}
-		/* Test de coherence entre le type et le complement de type dans le cas d'un type Structure */
+		// Test de coherence entre le type et le complement de type dans le cas d'un type Structure
 		else if (attribute->GetType() == KWType::Structure)
 		{
 			if ((yyvsp[-5].sValue) == NULL)
@@ -2249,7 +2243,7 @@ yyreduce:
 							      KWType::ToString((yyvsp[-7].bValue)) + " dictionary",
 							  -1);
 		}
-		/* Test d'absence de complement de type dans les autres cas */
+		// Test d'absence de complement de type dans les autres cas
 		else
 		{
 			if ((yyvsp[-5].sValue) != NULL)
@@ -2259,30 +2253,30 @@ yyreduce:
 							  -1);
 		}
 
-		/* Classe referencee */
+		// Classe referencee
 		if (KWType::IsRelation(attribute->GetType()))
 		{
 			KWClass* kwcReferencedClass = NULL;
 
-			/* Test d'existence de la classe */
+			// Test d'existence de la classe
 			if ((yyvsp[-5].sValue) != NULL)
 				kwcReferencedClass = kwcdLoadDomain->LookupClass(*((yyvsp[-5].sValue)));
 
-			/* Sinon, test d'existence de la classe en tant que classe referencee uniquement */
+			// Sinon, test d'existence de la classe en tant que classe referencee uniquement
 			if (kwcReferencedClass == NULL and (yyvsp[-5].sValue) != NULL)
 				kwcReferencedClass =
 				    cast(KWClass*, odReferencedUncreatedClasses->Lookup(*((yyvsp[-5].sValue))));
 
-			/* Si la classe n'existe pas, on essaie de la creer */
+			// Si la classe n'existe pas, on essaie de la creer
 			if (kwcReferencedClass == NULL and (yyvsp[-5].sValue) != NULL)
 			{
-				/* Test de nom de classe */
+				// Test de nom de classe
 				if (KWClass::CheckName(*((yyvsp[-5].sValue)), KWClass::Class, NULL))
 				{
 					kwcReferencedClass = new KWClass;
 					kwcReferencedClass->SetName(*((yyvsp[-5].sValue)));
 
-					/* Memorisation dans le dictionnaire des classe referencees */
+					// Memorisation dans le dictionnaire des classe referencees
 					odReferencedUncreatedClasses->SetAt(kwcReferencedClass->GetName(),
 									    kwcReferencedClass);
 				}
@@ -2291,10 +2285,10 @@ yyreduce:
 					    "Incorrect referenced dictionary name (" + *((yyvsp[-5].sValue)) + ")", -1);
 			}
 
-			/* On memorise la classe referencee */
+			// On memorise la classe referencee
 			attribute->SetClass(kwcReferencedClass);
 		}
-		/* Structure referencee */
+		// Structure referencee
 		else if (attribute->GetType() == KWType::Structure)
 		{
 			if ((yyvsp[-5].sValue) != NULL)
@@ -2303,13 +2297,13 @@ yyreduce:
 		if ((yyvsp[-5].sValue) != NULL)
 			delete (yyvsp[-5].sValue);
 
-		/* Nom de l'attribut */
+		// Nom de l'attribut
 		attribute->SetName(*((yyvsp[-4].sValue)));
-		delete (yyvsp[-4].sValue); /* liberation de la valeur de IDENTIFIER */
+		delete (yyvsp[-4].sValue); // liberation de la valeur de IDENTIFIER
 		rule = (yyvsp[-3].kwdrValue);
 		attribute->SetDerivationRule(rule);
 
-		/* Completion eventuelle de la regle par les infos de type de l'attribut */
+		// Completion eventuelle de la regle par les infos de type de l'attribut
 		if (rule != NULL)
 		{
 			// Completion specifique dans le cas de la regle de gestion des references
@@ -2348,21 +2342,21 @@ yyreduce:
 				    -1);
 		}
 
-		/* Meta-donnees de l'attribut */
+		// Meta-donnees de l'attribut
 		if ((yyvsp[-1].kwmdMetaData) != NULL)
 		{
 			attribute->GetMetaData()->CopyFrom((yyvsp[-1].kwmdMetaData));
 			delete (yyvsp[-1].kwmdMetaData);
 		}
 
-		/* Libelle */
+		// Libelle
 		if ((yyvsp[0].sValue) != NULL)
 		{
 			attribute->SetLabel(*((yyvsp[0].sValue)));
 			delete (yyvsp[0].sValue);
 		}
 
-		/* Commentaires */
+		// Commentaires
 		if ((yyvsp[-8].svValue) != NULL)
 		{
 			attribute->SetComments((yyvsp[-8].svValue));
@@ -2371,21 +2365,21 @@ yyreduce:
 
 		(yyval.kwaValue) = attribute;
 	}
-#line 2355 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2349 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 42: /* applicationids: %empty  */
-#line 919 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 913 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.sValue) = NULL; /* pas d'identification d'application */
+		(yyval.sValue) = NULL; // pas d'identification d'application
 	}
-#line 2363 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2357 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 43: /* applicationids: applicationids APPLICATIONID  */
-#line 923 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 917 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		/* On ne garde que la premiere ligne de chaque identification d'application */
+		// On ne garde que la premiere ligne de chaque identification d'application
 		if ((yyvsp[-1].sValue) == NULL)
 			(yyval.sValue) = (yyvsp[0].sValue);
 		else
@@ -2394,62 +2388,62 @@ yyreduce:
 			(yyval.sValue) = (yyvsp[-1].sValue);
 		}
 	}
-#line 2378 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2372 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 44: /* label: %empty  */
-#line 937 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 931 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.sValue) = NULL; /* pas de libelle */
+		(yyval.sValue) = NULL; // pas de libelle
 	}
-#line 2386 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2380 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 45: /* label: LABEL  */
-#line 941 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 935 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 2394 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2388 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 46: /* comments: %empty  */
-#line 947 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 941 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.svValue) = NULL; /* pas de commentaire */
+		(yyval.svValue) = NULL; // pas de commentaire
 	}
-#line 2402 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2396 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 47: /* comments: comments COMMENT  */
-#line 951 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 945 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svComments;
 
-		/* Creation du vecteur de commentaires si neccesaire */
+		// Creation du vecteur de commentaires si neccesaire
 		if ((yyvsp[-1].svValue) == NULL)
 			svComments = new StringVector;
 		else
 			svComments = (yyvsp[-1].svValue);
 
-		/* Ajout du commentaire */
+		// Ajout du commentaire
 		svComments->Add(*(yyvsp[0].sValue));
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svComments;
 	}
-#line 2421 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2415 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 48: /* labelOrComments: %empty  */
-#line 968 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 962 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.svValue) = NULL; /* pas de commentaire */
+		(yyval.svValue) = NULL; // pas de commentaire
 	}
-#line 2429 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2423 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 49: /* labelOrComments: LABEL  */
-#line 972 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 966 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svComments;
 		svComments = new StringVector;
@@ -2457,199 +2451,199 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svComments;
 	}
-#line 2441 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2435 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 50: /* labelOrComments: labelOrComments COMMENT  */
-#line 980 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 974 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svComments;
 
-		/* Creation du vecteur de commentaires si neccesaire */
+		// Creation du vecteur de commentaires si neccesaire
 		if ((yyvsp[-1].svValue) == NULL)
 			svComments = new StringVector;
 		else
 			svComments = (yyvsp[-1].svValue);
 
-		/* Ajout du commentaire */
+		// Ajout du commentaire
 		svComments->Add(*(yyvsp[0].sValue));
 		delete (yyvsp[0].sValue);
 		(yyval.svValue) = svComments;
 	}
-#line 2460 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2454 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 51: /* rootDeclaration: %empty  */
-#line 997 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 991 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.bValue) = false; /* valeur par defaut */
+		(yyval.bValue) = false; // valeur par defaut
 	}
-#line 2468 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2462 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 52: /* rootDeclaration: ROOT  */
-#line 1001 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 995 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = true;
 	}
-#line 2476 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2470 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 53: /* usedDeclaration: %empty  */
-#line 1008 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1002 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		(yyval.bValue) = true; /* valeur par defaut */
+		(yyval.bValue) = true; // valeur par defaut
 	}
-#line 2484 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2478 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 54: /* usedDeclaration: UNUSED  */
-#line 1012 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1006 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = false;
 	}
-#line 2492 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2486 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 55: /* typeDeclaration: CONTINUOUSTYPE  */
-#line 1020 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1014 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Continuous;
 	}
-#line 2500 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2494 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 56: /* typeDeclaration: SYMBOLTYPE  */
-#line 1024 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1018 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Symbol;
 	}
-#line 2508 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2502 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 57: /* typeDeclaration: DATETYPE  */
-#line 1028 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1022 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Date;
 	}
-#line 2516 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2510 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 58: /* typeDeclaration: TIMETYPE  */
-#line 1032 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1026 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Time;
 	}
-#line 2524 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2518 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 59: /* typeDeclaration: TIMESTAMPTYPE  */
-#line 1036 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1030 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Timestamp;
 	}
-#line 2532 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2526 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 60: /* typeDeclaration: TIMESTAMPTZTYPE  */
-#line 1040 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1034 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::TimestampTZ;
 	}
-#line 2540 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2534 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 61: /* typeDeclaration: TEXTTYPE  */
-#line 1044 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1038 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Text;
 	}
-#line 2548 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2542 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 62: /* typeDeclaration: TEXTLISTTYPE  */
-#line 1048 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1042 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::TextList;
 	}
-#line 2556 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2550 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 63: /* typeDeclaration: OBJECTTYPE  */
-#line 1052 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1046 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Object;
 	}
-#line 2564 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2558 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 64: /* typeDeclaration: OBJECTARRAYTYPE  */
-#line 1056 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1050 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::ObjectArray;
 	}
-#line 2572 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2566 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 65: /* typeDeclaration: STRUCTURETYPE  */
-#line 1060 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1054 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Structure;
 	}
-#line 2580 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2574 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 66: /* refIdentifier: %empty  */
-#line 1067 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1061 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL;
 	}
-#line 2588 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2582 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 67: /* refIdentifier: '(' IDENTIFIER ')'  */
-#line 1071 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1065 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[-1].sValue);
 	}
-#line 2596 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2590 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 68: /* usedDerivationRule: %empty  */
-#line 1078 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1072 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2604 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2598 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 69: /* usedDerivationRule: '=' derivationRule  */
-#line 1082 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1076 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2612 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2606 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 70: /* usedDerivationRule: referenceRule  */
-#line 1086 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1080 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2620 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2614 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 71: /* usedDerivationRule: '=' derivationRule ')'  */
-#line 1090 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1084 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ')'");
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2629 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2623 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 72: /* usedDerivationRule: '(' IDENTIFIER ')'  */
-#line 1095 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1089 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ALString sTmp;
 		yyerror(sTmp + "Invalid syntax (" + *(yyvsp[-1].sValue) + ")");
@@ -2657,113 +2651,113 @@ yyreduce:
 			delete (yyvsp[-1].sValue);
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2641 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2635 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 73: /* referenceRule: referenceRuleBody ']'  */
-#line 1105 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1099 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2649 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2643 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 74: /* referenceRuleBody: '[' derivationRuleOperand  */
-#line 1111 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1105 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule;
 		KWDerivationRuleOperand* operand;
 
-		/* Construction d'une regle pour accueillir les specifications */
+		// Construction d'une regle pour accueillir les specifications
 		rule = KWDerivationRule::CloneDerivationRule(KWDerivationRule::GetReferenceRuleName());
 
-		/* Destruction des operandes */
+		// Destruction des operandes
 		rule->DeleteAllOperands();
 
-		/* Ajout d'un premier operande: le premier champ de la cle de reference */
+		// Ajout d'un premier operande: le premier champ de la cle de reference
 		operand = (yyvsp[0].kwdroValue);
 		if (operand->GetType() == KWType::Unknown)
 			operand->SetType(KWType::Symbol);
 		rule->AddOperand(operand);
 
-		/* On retourner la regle */
+		// On retourner la regle
 		(yyval.kwdrValue) = rule;
 	}
-#line 2673 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2667 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 75: /* referenceRuleBody: referenceRuleBody ',' derivationRuleOperand  */
-#line 1131 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand;
 
-		/* Ajout d'un autre operande: un autre champ de la cle de reference */
+		// Ajout d'un autre operande: un autre champ de la cle de reference
 		operand = (yyvsp[0].kwdroValue);
 		if (operand->GetType() == KWType::Unknown)
 			operand->SetType(KWType::Symbol);
 		rule->AddOperand(operand);
 
-		/* On retourner la regle */
+		// On retourner la regle
 		(yyval.kwdrValue) = rule;
 	}
-#line 2691 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2685 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 76: /* derivationRule: derivationRuleBody closeparenthesis  */
-#line 1147 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1141 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		boolean bOk = true;
 		KWDerivationRule* ruleBody = (yyvsp[-1].kwdrValue);
 		KWDerivationRule* rule;
 		ALString sTmp;
 
-		/* Recherche de la regle de reference */
-		/* On ensuite recuperer au maximum les informations de la regle clonee */
-		/* et rapatrier les informations issues du parsing concernant les operandes */
+		// Recherche de la regle de reference
+		// On ensuite recuperer au maximum les informations de la regle clonee
+		// et rapatrier les informations issues du parsing concernant les operandes
 		check(ruleBody);
 		rule = KWDerivationRule::CloneDerivationRule(ruleBody->GetName());
 
-		/* Erreur si regle inexistante */
+		// Erreur si regle inexistante
 		if (rule == NULL)
 		{
 			yyerror("Unknown derivation rule '" + ruleBody->GetName() + "'");
 			bOk = false;
 		}
-		/* Erreur si regle predefinie de Reference */
+		// Erreur si regle predefinie de Reference
 		else if (rule->GetName() == KWDerivationRule::GetReferenceRuleName())
 		{
 			yyerror("Unknown derivation rule '" + ruleBody->GetName() + "'");
 			bOk = false;
 		}
 
-		/* Import des operandes de la regle */
+		// Import des operandes de la regle
 		if (bOk)
 			bOk = ImportParserRuleOperands(ruleBody, rule);
 
-		/* Gestion des operandes en sortie dans le cas ou le parser a stocke des operandes en sortie */
+		// Gestion des operandes en sortie dans le cas ou le parser a stocke des operandes en sortie
 		if (bOk and KWType::IsRelation(ruleBody->GetType()) and not ruleBody->GetReference())
 		{
-			/* Erreur si la regle en cours n'est pas une regle de creation d'instance */
+			// Erreur si la regle en cours n'est pas une regle de creation d'instance
 			if (not KWType::IsRelation(rule->GetType()) or rule->GetReference())
 			{
 				yyerror(sTmp + "Derivation rule " + rule->GetName() +
 					" does not accept output operands");
 				bOk = false;
 			}
-			/* Sinon, transfert des operandes en sortie */
+			// Sinon, transfert des operandes en sortie
 			else
 			{
-				/* Import des operandes en sortie de la regle */
-				/* On est passe prealablement dans le parser par une regle de creation de relation */
-				/* pour stocker les operandes en sortie, que l'on va ici exploiter */
+				// Import des operandes en sortie de la regle
+				// On est passe prealablement dans le parser par une regle de creation de relation
+				// pour stocker les operandes en sortie, que l'on va ici exploiter
 				bOk = ImportParserRuleOutputOperands(ruleBody, rule);
 			}
 		}
-		/* Gestion des operandes en sortie dans le cas ou le parser n'a stocke des operandes en sortie */
+		// Gestion des operandes en sortie dans le cas ou le parser n'a stocke des operandes en sortie
 		else if (bOk and KWType::IsRelation(rule->GetType()) and not rule->GetReference())
 		{
-			/* Test du nombre d'operandes en sortie */
+			// Test du nombre d'operandes en sortie
 			if ((rule->GetVariableOutputOperandNumber() and rule->GetOutputOperandNumber() > 1) or
 			    (not rule->GetVariableOutputOperandNumber() and rule->GetOutputOperandNumber() > 0))
 			{
@@ -2774,19 +2768,19 @@ yyreduce:
 					")");
 				bOk = false;
 			}
-			/* Supression des eventuels operandes en sortie inutiles */
+			// Supression des eventuels operandes en sortie inutiles
 			else if (rule->GetOutputOperandNumber() > 0)
 				cast(KWDRRelationCreationRule*, rule)->DeleteAllOutputOperands();
 		}
 
-		/* Verification de la definition de la regle */
+		// Verification de la definition de la regle
 		if (bOk and not rule->CheckDefinition())
 		{
 			yyerror(sTmp + "Derivation rule " + rule->GetName() + " incorrectly specified");
 			bOk = false;
 		}
 
-		/* Test si erreur dans le transfert des operandes */
+		// Test si erreur dans le transfert des operandes
 		if (not bOk)
 		{
 			if (rule != NULL)
@@ -2795,18 +2789,18 @@ yyreduce:
 				rule = NULL;
 			}
 		}
-		/* Sinon, on tente de compresser la regle */
+		// Sinon, on tente de compresser la regle
 		else
 		{
 			if (rule->IsStructureRule())
 			{
 				KWDRStructureRule* structureRule;
 
-				/* Acces a la regle de structure, transformation au format structure et nettoyage memoire */
-				/* Cette optimisation memoire des regles structure est critique dans le cas de dictionnaires */
-				/* de tres grande taille. Sinon, des millions d'operandes de regles sont potentiellement crees, */
-				/* puis lors de la compilation des dictionnaire, l'essentiel de la memoire liberee laisse des trous */
-				/* dans les segments de la heap, qui ne peuvent etre rendus au systeme */
+				// Acces a la regle de structure, transformation au format structure et nettoyage memoire
+				// Cette optimisation memoire des regles structure est critique dans le cas de dictionnaires
+				// de tres grande taille. Sinon, des millions d'operandes de regles sont potentiellement crees,
+				// puis lors de la compilation des dictionnaire, l'essentiel de la memoire liberee laisse des trous
+				// dans les segments de la heap, qui ne peuvent etre rendus au systeme
 				assert(rule->CheckDefinition());
 				structureRule = cast(KWDRStructureRule*, rule);
 				structureRule->BuildStructureFromBase(rule);
@@ -2814,23 +2808,23 @@ yyreduce:
 			}
 		}
 
-		/* Finalisation */
+		// Finalisation
 		delete ruleBody;
 		(yyval.kwdrValue) = rule;
 	}
-#line 2800 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2794 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 77: /* derivationRuleBody: derivationRuleBegin  */
-#line 1255 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1249 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2808 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2802 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 78: /* derivationRuleBody: derivationRuleBegin ':' operandList  */
-#line 1259 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1253 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* ruleBody = (yyvsp[-2].kwdrValue);
 		KWDRRelationCreationRule* ruleRelationCreationBody;
@@ -2839,7 +2833,7 @@ yyreduce:
 		int nOperand;
 		KWDerivationRuleOperand* operand;
 
-		/* On passe par une regle de creation de relation pour stocker les operandes en sortie */
+		// On passe par une regle de creation de relation pour stocker les operandes en sortie
 		ruleRelationCreationBody = new KWDRRelationCreationRule;
 
 		// On transfer les operande initiaux vers un tableau
@@ -2850,22 +2844,22 @@ yyreduce:
 		}
 		ruleBody->RemoveAllOperands();
 
-		/* On copie la regle initiale, maintenant nettoyee de ses operandes */
+		// On copie la regle initiale, maintenant nettoyee de ses operandes
 		ruleBody->SetType(KWType::ObjectArray);
 		ruleRelationCreationBody->CopyFrom(ruleBody);
 		delete ruleBody;
 
-		/* On recupere les operandes initiaux */
+		// On recupere les operandes initiaux
 		for (nOperand = 0; nOperand < oaOperands.GetSize(); nOperand++)
 		{
 			operand = cast(KWDerivationRuleOperand*, oaOperands.GetAt(nOperand));
 			ruleRelationCreationBody->AddOperand(operand);
 		}
 
-		/* On recupere la liste des operandes en sortie */
+		// On recupere la liste des operandes en sortie
 		oaOutputOperands = cast(ObjectArray*, (yyvsp[0].oaOperands));
 
-		/* Parametrage des operandes en sortie */
+		// Parametrage des operandes en sortie
 		assert(ruleRelationCreationBody->GetOutputOperandNumber() == 0);
 		for (nOperand = 0; nOperand < oaOutputOperands->GetSize(); nOperand++)
 		{
@@ -2876,63 +2870,63 @@ yyreduce:
 
 		(yyval.kwdrValue) = ruleRelationCreationBody;
 	}
-#line 2858 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2852 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 79: /* derivationRuleBody: derivationRuleHeader  */
-#line 1305 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1299 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2866 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2860 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 80: /* operandList: operandList ',' derivationRuleOperand  */
-#line 1312 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1306 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaOperandList = (yyvsp[-2].oaOperands);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
 		check(oaOperandList);
 		check(operand);
 
-		/* Ajout d'un operande */
+		// Ajout d'un operande
 		oaOperandList->Add(operand);
 		(yyval.oaOperands) = oaOperandList;
 	}
-#line 2881 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2875 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 81: /* operandList: derivationRuleOperand  */
-#line 1323 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1317 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaOperandList;
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
 		check(operand);
 
-		/* Creation d'un tableau doperandes, avec un premier operande */
+		// Creation d'un tableau doperandes, avec un premier operande
 		oaOperandList = new ObjectArray;
 		oaOperandList->Add(operand);
 		(yyval.oaOperands) = oaOperandList;
 	}
-#line 2896 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2890 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 82: /* derivationRuleHeader: IDENTIFIER openparenthesis  */
-#line 1336 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1330 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule;
 
-		/* Construction d'une regle pour accueillir les specification */
+		// Construction d'une regle pour accueillir les specification
 		rule = new KWDerivationRule;
 		rule->SetName(*((yyvsp[-1].sValue)));
 		delete (yyvsp[-1].sValue);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2910 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2904 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 83: /* derivationRuleBegin: derivationRuleHeader derivationRuleOperand  */
-#line 1349 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1343 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-1].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2943,11 +2937,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2925 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2919 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 84: /* derivationRuleBegin: derivationRuleBegin ',' derivationRuleOperand  */
-#line 1360 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1354 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2958,11 +2952,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2940 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2934 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 85: /* derivationRuleOperand: IDENTIFIER  */
-#line 1374 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1368 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2971,11 +2965,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2953 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2947 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 86: /* derivationRuleOperand: CONTINUOUSLITTERAL  */
-#line 1383 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1377 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2984,11 +2978,11 @@ yyreduce:
 		operand->SetContinuousConstant((yyvsp[0].cValue));
 		(yyval.kwdroValue) = operand;
 	}
-#line 2966 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2960 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 87: /* derivationRuleOperand: bigstring  */
-#line 1392 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1386 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -2998,11 +2992,11 @@ yyreduce:
 		delete (yyvsp[0].sValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2980 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2974 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 88: /* derivationRuleOperand: derivationRule  */
-#line 1402 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1396 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = new KWDerivationRuleOperand;
@@ -3012,104 +3006,104 @@ yyreduce:
 			operand->SetType(operand->GetDerivationRule()->GetType());
 		(yyval.kwdroValue) = operand;
 	}
-#line 2994 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2988 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 89: /* derivationRuleOperand: '.' derivationRuleOperand  */
-#line 1412 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1406 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand;
 		operand = (yyvsp[0].kwdroValue);
 		operand->SetScopeLevel(operand->GetScopeLevel() + 1);
 		(yyval.kwdroValue) = operand;
 	}
-#line 3005 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2999 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 90: /* bigstring: bigstring '+' STRINGLITTERAL  */
-#line 1423 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1417 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		/* Concatenation des deux chaines */
+		// Concatenation des deux chaines
 		(yyval.sValue) = new ALString(*(yyvsp[-2].sValue) + *(yyvsp[0].sValue));
 
-		/* Destruction des ancienne chaines */
+		// Destruction des ancienne chaines
 		delete (yyvsp[-2].sValue);
 		delete (yyvsp[0].sValue);
 	}
-#line 3018 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3012 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 91: /* bigstring: STRINGLITTERAL  */
-#line 1432 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1426 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 3026 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3020 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 92: /* semicolon: %empty  */
-#line 1438 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1432 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Missing ';'");
 	}
-#line 3034 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3028 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 94: /* semicolon: ';' ';'  */
-#line 1443 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1437 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous ';'");
 	}
-#line 3042 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3036 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 95: /* semicolon: ';' ';' ';'  */
-#line 1447 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1441 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ';'");
 	}
-#line 3050 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3044 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 96: /* openparenthesis: %empty  */
-#line 1453 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1447 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		/* Cette instruction est la pour aider au diagnostique des erreurs */
-		/* de parenthesage: elle est utile dans ce cas, mais genere (avec  */
-		/* sa consoeur de nombreux shift/reduce et reduce conflicts        */
+		// Cette instruction est la pour aider au diagnostic des erreurs
+		// de parenthesage: elle est utile dans ce cas, mais genere (avec
+		// sa consoeur de nombreux shift/reduce et reduce conflicts
 		yyerror("Missing '('");
 	}
-#line 3061 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3055 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 98: /* openparenthesis: '(' '('  */
-#line 1461 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1455 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous '('");
 	}
-#line 3069 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3063 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 99: /* openparenthesis: '(' '(' '('  */
-#line 1465 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1459 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many '('");
 	}
-#line 3077 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3071 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 100: /* closeparenthesis: %empty  */
-#line 1472 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1466 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		/* Cette instruction est la pour aider au diagnostique des erreurs */
-		/* de parenthesage: elle est utile dans ce cas, mais genere (avec  */
-		/* sa consoeur de nombreux shift/reduce et reduce conflicts        */
+		// Cette instruction est la pour aider au diagnostic des erreurs
+		// de parenthesage: elle est utile dans ce cas, mais genere (avec
+		// sa consoeur de nombreux shift/reduce et reduce conflicts
 		yyerror("Missing ')'");
 	}
-#line 3088 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3082 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-#line 3092 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3086 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 	default:
 		break;
@@ -3288,23 +3282,23 @@ yyreturnlab:
 	return yyresult;
 }
 
-#line 1482 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1476 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 #include "KWCLex.inc"
 
-/* default yywrap that tells yylex to return 0 */
+// default yywrap that tells yylex to return 0
 int yywrap()
 {
 	return 1;
 }
 
-/* default yyerror for YACC and LEX */
+// default yyerror for YACC and LEX
 void yyerror(char const* fmt)
 {
 	yyerrorWithLineCorrection(fmt, 0);
 }
 
-/* Variante avec une correction du numero de ligne */
+// Variante avec une correction du numero de ligne
 void yyerrorWithLineCorrection(char const* fmt, int nDeltaLineNumber)
 {
 	char sErrorLine[20];
@@ -3331,7 +3325,7 @@ boolean ImportParserRuleOperands(const KWDerivationRule* parsedRule, KWDerivatio
 	require(parsedRule != NULL);
 	require(rule != NULL);
 
-	/* Test du nombre d'operandes */
+	// Test du nombre d'operandes
 	if ((rule->GetVariableOperandNumber() and parsedRule->GetOperandNumber() < rule->GetOperandNumber() - 1) or
 	    (not rule->GetVariableOperandNumber() and parsedRule->GetOperandNumber() != rule->GetOperandNumber()))
 
@@ -3341,11 +3335,11 @@ boolean ImportParserRuleOperands(const KWDerivationRule* parsedRule, KWDerivatio
 			IntToString(rule->GetOperandNumber()) + ")");
 		bOk = false;
 	}
-	/* Verification et transfert des operandes */
+	// Verification et transfert des operandes
 	else
 	{
-		/* Dans le cas d'un nombre variable d'operandes, on commence par rajouter */
-		/* eventuellement des operandes en fin de regle pour preparer l'instanciation */
+		// Dans le cas d'un nombre variable d'operandes, on commence par rajouter
+		// eventuellement des operandes en fin de regle pour preparer l'instanciation
 		if (parsedRule->GetOperandNumber() > rule->GetOperandNumber())
 		{
 			assert(rule->GetVariableOperandNumber());
@@ -3353,8 +3347,8 @@ boolean ImportParserRuleOperands(const KWDerivationRule* parsedRule, KWDerivatio
 				rule->AddOperand(rule->GetOperandAt(rule->GetOperandNumber() - 1)->Clone());
 		}
 
-		/* Dans le cas d'un nombre variable d'operandes, on supprime eventuellement */
-		/* le dernier operande, qui n'est pas obligatoire */
+		// Dans le cas d'un nombre variable d'operandes, on supprime eventuellement
+		// le dernier operande, qui n'est pas obligatoire
 		if (parsedRule->GetOperandNumber() < rule->GetOperandNumber())
 		{
 			assert(rule->GetVariableOperandNumber());
@@ -3363,14 +3357,14 @@ boolean ImportParserRuleOperands(const KWDerivationRule* parsedRule, KWDerivatio
 		}
 		assert(parsedRule->GetOperandNumber() == rule->GetOperandNumber());
 
-		/* Transfert des operandes */
+		// Transfert des operandes
 		for (i = 0; i < rule->GetOperandNumber(); i++)
 		{
-			/* acces aux operandes */
+			// acces aux operandes
 			operand = rule->GetOperandAt(i);
 			parsedOperand = parsedRule->GetOperandAt(i);
 
-			/* Import de l'operande */
+			// Import de l'operande
 			bOk = ImportParserOperand(rule->GetName(), i, parsedOperand, operand);
 			if (not bOk)
 				break;
@@ -3393,7 +3387,7 @@ boolean ImportParserRuleOutputOperands(const KWDerivationRule* parsedRule, KWDer
 	require(not parsedRule->GetReference());
 	require(not rule->GetReference());
 
-	/* Test du nombre d'operandes en sortie */
+	// Test du nombre d'operandes en sortie
 	if ((rule->GetVariableOutputOperandNumber() and
 	     parsedRule->GetOutputOperandNumber() < rule->GetOutputOperandNumber() - 1) or
 	    (not rule->GetVariableOutputOperandNumber() and
@@ -3405,14 +3399,14 @@ boolean ImportParserRuleOutputOperands(const KWDerivationRule* parsedRule, KWDer
 			IntToString(rule->GetOutputOperandNumber()) + ")");
 		bOk = false;
 	}
-	/* Verification et transfert des operandes en sortie */
+	// Verification et transfert des operandes en sortie
 	else
 	{
-		/* Cast de la regle a alimenter en regle de creation de relation pour acceder a ses methodes dediees */
+		// Cast de la regle a alimenter en regle de creation de relation pour acceder a ses methodes dediees
 		creationRule = cast(KWDRRelationCreationRule*, rule);
 
-		/* Dans le cas d'un nombre variable d'operandes en sortie, on commence par rajouter */
-		/* eventuellement des operandes en fin de regle pour preparer l'instanciation */
+		// Dans le cas d'un nombre variable d'operandes en sortie, on commence par rajouter
+		// eventuellement des operandes en fin de regle pour preparer l'instanciation
 		if (parsedRule->GetOutputOperandNumber() > rule->GetOutputOperandNumber())
 		{
 			assert(rule->GetVariableOutputOperandNumber());
@@ -3421,8 +3415,8 @@ boolean ImportParserRuleOutputOperands(const KWDerivationRule* parsedRule, KWDer
 				    rule->GetOutputOperandAt(rule->GetOutputOperandNumber() - 1)->Clone());
 		}
 
-		/* Dans le cas d'un nombre variable d'operandes en sortie, on supprime eventuellement */
-		/* le dernier operande, qui n'est pas obligatoire */
+		// Dans le cas d'un nombre variable d'operandes en sortie, on supprime eventuellement
+		// le dernier operande, qui n'est pas obligatoire
 		if (parsedRule->GetOutputOperandNumber() < rule->GetOutputOperandNumber())
 		{
 			assert(rule->GetVariableOutputOperandNumber());
@@ -3431,14 +3425,14 @@ boolean ImportParserRuleOutputOperands(const KWDerivationRule* parsedRule, KWDer
 		}
 		assert(parsedRule->GetOutputOperandNumber() == rule->GetOutputOperandNumber());
 
-		/* Transfert des operandes en sortie */
+		// Transfert des operandes en sortie
 		for (i = 0; i < rule->GetOutputOperandNumber(); i++)
 		{
-			/* acces aux operandes en sortie */
+			// acces aux operandes en sortie
 			operand = rule->GetOutputOperandAt(i);
 			parsedOperand = parsedRule->GetOutputOperandAt(i);
 
-			/* Import de l'operande */
+			// Import de l'operande
 			bOk = ImportParserOperand(rule->GetName(), i, parsedOperand, operand);
 			if (not bOk)
 				break;
@@ -3456,7 +3450,7 @@ boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex, KWDeri
 	require(parsedOperand != NULL);
 	require(operand != NULL);
 
-	/* Transfert d'informations de la regle de reference vers la regle a verifier */
+	// Transfert d'informations de la regle de reference vers la regle a verifier
 	if (parsedOperand->GetOrigin() != KWDerivationRuleOperand::OriginConstant)
 	{
 		parsedOperand->SetType(operand->GetType());
@@ -3469,39 +3463,39 @@ boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex, KWDeri
 		parsedOperand->SetStructureName(operand->GetStructureName());
 	}
 
-	/* Test si operande candidate valide */
+	// Test si operande candidate valide
 	if (not parsedOperand->CheckDefinition())
 	{
 		bOk = false;
 		yyerror(sTmp + "Incorrect operand " + IntToString(1 + nOperandIndex) + " for rule " + sRuleName);
 	}
-	/* Test de compatibilite avec la regle enregistree, sauf si regle avec operande de type indetermine */
+	// Test de compatibilite avec la regle enregistree, sauf si regle avec operande de type indetermine
 	else if (operand->GetType() != KWType::Unknown and not parsedOperand->CheckFamily(operand))
 	{
 		bOk = false;
 		yyerror(sTmp + "Operand " + IntToString(1 + nOperandIndex) + " inconsistent with that of rule " +
 			sRuleName);
 	}
-	/* Transfert de l'origine de l'operande */
+	// Transfert de l'origine de l'operande
 	else
 	{
-		/* Transfert du niveau de scope */
+		// Transfert du niveau de scope
 		operand->SetScopeLevel(parsedOperand->GetScopeLevel());
 
-		/* Transfert d'une valeur constante */
+		// Transfert d'une valeur constante
 		operand->SetOrigin(parsedOperand->GetOrigin());
 		if (operand->GetOrigin() == KWDerivationRuleOperand::OriginConstant)
 		{
 			operand->SetType(parsedOperand->GetType());
 			operand->SetStringConstant(parsedOperand->GetStringConstant());
 		}
-		/* Transfert d'un attribut */
+		// Transfert d'un attribut
 		else if (operand->GetOrigin() == KWDerivationRuleOperand::OriginAttribute)
 			operand->SetDataItemName(parsedOperand->GetDataItemName());
 		else
-		/* Transfert d'une regle */
+		// Transfert d'une regle
 		{
-			// Transfert de la regle */
+			// Transfert de la regle
 			if (operand->GetDerivationRule() != NULL)
 			{
 				assert(parsedOperand->GetDerivationRule() != NULL);
@@ -3509,7 +3503,7 @@ boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex, KWDeri
 			}
 			operand->SetDerivationRule(parsedOperand->GetDerivationRule());
 
-			/* Transfert des infos portees par la regle de derivation */
+			// Transfert des infos portees par la regle de derivation
 			if (operand->GetDerivationRule() != NULL)
 			{
 				operand->SetType(operand->GetDerivationRule()->GetType());
@@ -3519,7 +3513,7 @@ boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex, KWDeri
 					operand->SetStructureName(operand->GetDerivationRule()->GetStructureName());
 			}
 
-			/* Dereferencement de la regle de derivation depuis l'operande de travail */
+			// Dereferencement de la regle de derivation depuis l'operande de travail
 			parsedOperand->SetDerivationRule(NULL);
 		}
 	}
@@ -3528,7 +3522,7 @@ boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex, KWDeri
 
 int yyparse();
 
-/* Implementation de la methode de lecture de fichier de KWClassDomain */
+// Implementation de la methode de lecture de fichier de KWClassDomain
 boolean KWClassDomain::ReadFile(const ALString& sFileName)
 {
 	boolean bOk = true;
@@ -3540,29 +3534,29 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 	KWClass* kwcClass;
 	ALString sLocalFileName;
 
-	/* Affichage de stats memoire si log memoire actif */
+	// Affichage de stats memoire si log memoire actif
 	MemoryStatsManager::AddLog(GetClassLabel() + " " + sFileName + " ReadFile Begin");
 
-	/* Initialisation du domaine de classe a utiliser pour le Load */
+	// Initialisation du domaine de classe a utiliser pour le Load
 	assert(kwcdLoadDomain == NULL);
 	kwcdLoadDomain = this;
 
-	/* Initialisation de la classe courante a utiliser pour le Load */
+	// Initialisation de la classe courante a utiliser pour le Load
 	assert(kwcLoadCurrentClass == NULL);
 	kwcLoadCurrentClass = NULL;
 
-	/* Creation du dictionnaire des classes referencees non crees */
+	// Creation du dictionnaire des classes referencees non crees
 	assert(odReferencedUncreatedClasses == NULL);
 	odReferencedUncreatedClasses = new ObjectDictionary;
 
-	/* Erreur si pas de nom de fichier */
+	// Erreur si pas de nom de fichier
 	fFile = NULL;
 	if (sFileName == "")
 	{
 		AddError("Missing file name");
 		bOk = false;
 	}
-	/* Sinon, ouverture du fichier */
+	// Sinon, ouverture du fichier
 	else
 	{
 		// Copie depuis HDFS si necessaire
@@ -3571,39 +3565,39 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 			bOk = FileService::OpenInputBinaryFile(sLocalFileName, fFile);
 	}
 
-	/* On continue si fichier ouvert correctement */
+	// On continue si fichier ouvert correctement
 	if (bOk)
 	{
 		assert(fFile != NULL);
 
-		/* Memorisation de toutes les classes initiales */
+		// Memorisation de toutes les classes initiales
 		kwcdLoadDomain->ExportClassDictionary(&odInitialClasses);
 
-		/* Activation du nombre max d'erreurs a afficher */
+		// Activation du nombre max d'erreurs a afficher
 		nFileParsingErrorNumber = 0;
 		Global::ActivateErrorFlowControl();
 
-		/* Positionnement du fichier a parser par la variable yyin de LEX */
+		// Positionnement du fichier a parser par la variable yyin de LEX
 		yylineno = 1;
 		yyrestart(fFile);
 
-		/* Parsing */
+		// Parsing
 		yyparse();
 
-		/* Cleaning lexer */
+		// Cleaning lexer
 		yylex_destroy();
 
-		/* Fermeture du fichier */
+		// Fermeture du fichier
 		FileService::CloseInputBinaryFile(sLocalFileName, fFile);
 
-		/* Si HDFS on supprime la copie locale */
+		// Si HDFS on supprime la copie locale
 		PLRemoteFileService::CleanInputWorkingFile(sFileName, sLocalFileName);
 
-		/* Completion des informations de type au niveau du domaine */
+		// Completion des informations de type au niveau du domaine
 		if (nFileParsingErrorNumber == 0)
 			kwcdLoadDomain->CompleteTypeInfo();
 
-		/* Lecture des informations privees depuis les meta donnees */
+		// Lecture des informations privees depuis les meta donnees
 		if (nFileParsingErrorNumber == 0)
 		{
 			for (i = 0; i < kwcdLoadDomain->GetClassNumber(); i++)
@@ -3613,7 +3607,7 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 			}
 		}
 
-		/* Messages d'erreur pour les classes referencees non crees */
+		// Messages d'erreur pour les classes referencees non crees
 		if (nFileParsingErrorNumber > 0 or odReferencedUncreatedClasses->GetCount() > 0)
 		{
 			odReferencedUncreatedClasses->ExportObjectArray(&oaReferencedUncreatedClasses);
@@ -3624,19 +3618,19 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 			}
 		}
 
-		/* Desactivation du nombre max d'erreurs a afficher */
+		// Desactivation du nombre max d'erreurs a afficher
 		Global::DesactivateErrorFlowControl();
 
-		/* Destruction des classes crees si au moins une erreur de parsing detectee */
-		/* ou au moins une classe referencee non cree                               */
+		// Destruction des classes crees si au moins une erreur de parsing detectee
+		// ou au moins une classe referencee non cree
 		if (nFileParsingErrorNumber > 0 or odReferencedUncreatedClasses->GetCount() > 0)
 		{
-			/* En cas d'erreur, ajout d'une ligne blanche pour separer des autres logs */
+			// En cas d'erreur, ajout d'une ligne blanche pour separer des autres logs
 			AddError("Errors detected during parsing " + sFileName + ": read operation cancelled");
 			AddSimpleMessage("");
 			bOk = false;
 
-			/* Recherche des nouvelles classes crees */
+			// Recherche des nouvelles classes crees
 			for (i = 0; i < kwcdLoadDomain->GetClassNumber(); i++)
 			{
 				kwcClass = kwcdLoadDomain->GetClassAt(i);
@@ -3644,26 +3638,26 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 					oaNewClasses.Add(kwcClass);
 			}
 
-			/* Destruction des classes nouvellement crees */
+			// Destruction des classes nouvellement crees
 			for (i = 0; i < oaNewClasses.GetSize(); i++)
 			{
 				kwcClass = cast(KWClass*, oaNewClasses.GetAt(i));
 				kwcdLoadDomain->DeleteClass(kwcClass->GetName());
 			}
 
-			/* Destruction des classes referencees non crees */
+			// Destruction des classes referencees non crees
 			odReferencedUncreatedClasses->DeleteAll();
 		}
 		nFileParsingErrorNumber = 0;
 	}
 
-	/* Nettoyage */
+	// Nettoyage
 	kwcdLoadDomain = NULL;
 	kwcLoadCurrentClass = NULL;
 	delete odReferencedUncreatedClasses;
 	odReferencedUncreatedClasses = NULL;
 
-	/* Affichage de stats memoire si log memoire actif */
+	// Affichage de stats memoire si log memoire actif
 	MemoryStatsManager::AddLog(GetClassLabel() + " " + sFileName + " ReadFile End");
 
 	return bOk;

--- a/src/Learning/KWData/KWCYac.cpp
+++ b/src/Learning/KWData/KWCYac.cpp
@@ -565,11 +565,11 @@ static const yytype_int8 yytranslate[] = {
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] = {
     0,    142,  142,  146,  153,  157,  161,  165,  169,  173,  177,  181,  185,  189,  193,  197,  201,
-    205,  209,  215,  230,  231,  232,  237,  256,  261,  303,  387,  408,  418,  462,  510,  652,  655,
-    662,  672,  685,  688,  708,  730,  749,  770,  913,  916,  931,  934,  941,  944,  962,  965,  973,
-    991,  994,  1002, 1005, 1013, 1017, 1021, 1025, 1029, 1033, 1037, 1041, 1045, 1049, 1053, 1061, 1064,
-    1072, 1075, 1079, 1083, 1088, 1098, 1104, 1124, 1140, 1248, 1252, 1298, 1305, 1316, 1329, 1342, 1353,
-    1367, 1376, 1385, 1395, 1405, 1416, 1425, 1432, 1435, 1436, 1440, 1447, 1453, 1454, 1458, 1466, 1472};
+    205,  209,  215,  233,  234,  235,  240,  260,  265,  307,  391,  412,  422,  466,  514,  656,  659,
+    666,  676,  690,  693,  713,  735,  753,  774,  923,  926,  941,  944,  951,  954,  971,  974,  984,
+    1001, 1004, 1012, 1015, 1023, 1027, 1031, 1035, 1039, 1043, 1047, 1051, 1055, 1059, 1063, 1071, 1074,
+    1082, 1085, 1089, 1093, 1098, 1110, 1116, 1135, 1150, 1258, 1262, 1305, 1312, 1323, 1336, 1350, 1361,
+    1375, 1386, 1397, 1409, 1421, 1432, 1444, 1451, 1454, 1455, 1459, 1466, 1472, 1473, 1477, 1485, 1491};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -1593,61 +1593,65 @@ yyreduce:
 	case 19: /* kwclassFile: applicationids kwclasses comments  */
 #line 216 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		ALString* sId = (yyvsp[-2].sValue);
+		StringVector* svComments = (yyvsp[0].svValue);
+
 		// On ignore l'identification d'application
-		if ((yyvsp[-2].sValue) != NULL)
-			delete (yyvsp[-2].sValue);
+		if (sId != NULL)
+			delete sId;
 
 		// On interdit les commentaires en fin de fichier
-		if ((yyvsp[0].svValue) != NULL)
+		if (svComments != NULL)
 		{
-			delete (yyvsp[0].svValue);
+			delete svComments;
 			yyerrorWithLineCorrection("Comments at the end of the file are not allowed", -1);
 		}
 	}
-#line 1627 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1630 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 22: /* kwclasses: kwclasses error  */
-#line 233 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 236 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Error outside the definition of a dictionary");
 		YYABORT;
 	}
-#line 1634 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1637 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 23: /* kwclass: kwclassBegin comments '}' semicolon  */
-#line 238 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 241 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-3].kwcValue);
+		StringVector* svComments = (yyvsp[-2].svValue);
 
 		// La completion des informations de type (CompleteTypeInfo) est centralisee
 		// au niveau du domaine en fin de parsing
 
 		// Commentaires internes
-		if ((yyvsp[-2].svValue) != NULL)
+		if (svComments != NULL)
 		{
-			kwcClass->SetInternalComments((yyvsp[-2].svValue));
-			delete (yyvsp[-2].svValue);
+			kwcClass->SetInternalComments(svComments);
+			delete svComments;
 		}
 
 		// Reinitialisation de la classe courante
 		kwcLoadCurrentClass = NULL;
 	}
-#line 1655 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1659 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 24: /* kwclassBegin: kwclassHeader  */
-#line 257 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 261 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		assert(kwcLoadCurrentClass == (yyvsp[0].kwcValue));
 		(yyval.kwcValue) = (yyvsp[0].kwcValue);
 	}
-#line 1664 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1668 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 25: /* kwclassBegin: kwclassBegin kwattributeDeclaration  */
-#line 262 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 266 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-1].kwcValue);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
@@ -1691,49 +1695,49 @@ yyreduce:
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1710 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1714 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 26: /* kwclassBegin: kwclassBegin comments '{' oaAttributeArrayDeclaration comments '}' IDENTIFIER usedDerivationRule semicolon metaData label  */
-#line 304 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 308 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-10].kwcValue);
-		KWAttributeBlock* attributeBlock;
+		StringVector* svComments = (yyvsp[-9].svValue);
 		ObjectArray* oaAttributes = (yyvsp[-7].oaAttributes);
-		ALString sBlockName;
+		StringVector* svInternalComments = (yyvsp[-6].svValue);
+		ALString* sBlockName = (yyvsp[-4].sValue);
+		KWDerivationRule* rule = (yyvsp[-3].kwdrValue);
+		KWMetaData* metaData = (yyvsp[-1].kwmdMetaData);
+		ALString* sLabel = (yyvsp[0].sValue);
+		KWAttributeBlock* attributeBlock;
 		KWAttribute* firstAttribute;
 		KWAttribute* lastAttribute;
-		KWDerivationRule* rule = (yyvsp[-3].kwdrValue);
 		ALString sMessage;
 		assert(kwcLoadCurrentClass == (yyvsp[-10].kwcValue));
 		check(oaAttributes);
-
-		// Nom du bloc
-		if ((yyvsp[-4].sValue) != NULL)
-			sBlockName = *((yyvsp[-4].sValue));
 
 		// Cas d'un bloc avec au moins un attribut valide
 		if (oaAttributes->GetSize() > 0)
 		{
 			// Test de validite du nom de l'attribut
-			if (!kwcClass->CheckNameWithMessage(sBlockName, KWClass::AttributeBlock, sMessage))
+			if (!kwcClass->CheckNameWithMessage(*sBlockName, KWClass::AttributeBlock, sMessage))
 			{
 				yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + ", " + sMessage, -1);
 			}
 			// Test de non existence parmi les attributs
-			else if (kwcClass->LookupAttribute(sBlockName) != NULL)
+			else if (kwcClass->LookupAttribute(*sBlockName) != NULL)
 			{
 				yyerrorWithLineCorrection(
 				    "Dictionary " + kwcClass->GetName() +
-					": Sparse variable block name already used by a variable (" + sBlockName + ")",
+					": Sparse variable block name already used by a variable (" + *sBlockName + ")",
 				    -1);
 			}
 			// Test de non existence parmi les blocs
-			else if (kwcClass->LookupAttributeBlock(sBlockName) != NULL)
+			else if (kwcClass->LookupAttributeBlock(*sBlockName) != NULL)
 			{
 				yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() +
 							      ": Sparse variable block name already used by a block (" +
-							      sBlockName + ")",
+							      *sBlockName + ")",
 							  -1);
 			}
 			// Creation du bloc dans la classe
@@ -1743,18 +1747,18 @@ yyreduce:
 				firstAttribute = cast(KWAttribute*, oaAttributes->GetAt(0));
 				lastAttribute = cast(KWAttribute*, oaAttributes->GetAt(oaAttributes->GetSize() - 1));
 				attributeBlock =
-				    kwcClass->CreateAttributeBlock(sBlockName, firstAttribute, lastAttribute);
+				    kwcClass->CreateAttributeBlock(*sBlockName, firstAttribute, lastAttribute);
 
 				// Parametrage du bloc
 				attributeBlock->SetDerivationRule(rule);
-				if ((yyvsp[-1].kwmdMetaData) != NULL)
-					attributeBlock->GetMetaData()->CopyFrom((yyvsp[-1].kwmdMetaData));
-				if ((yyvsp[0].sValue) != NULL)
-					attributeBlock->SetLabel(*((yyvsp[0].sValue)));
-				if ((yyvsp[-9].svValue) != NULL)
-					attributeBlock->SetComments((yyvsp[-9].svValue));
-				if ((yyvsp[-6].svValue) != NULL)
-					attributeBlock->SetInternalComments((yyvsp[-6].svValue));
+				if (metaData != NULL)
+					attributeBlock->GetMetaData()->CopyFrom(metaData);
+				if (sLabel != NULL)
+					attributeBlock->SetLabel(*(sLabel));
+				if (svComments != NULL)
+					attributeBlock->SetComments(svComments);
+				if (svInternalComments != NULL)
+					attributeBlock->SetInternalComments(svInternalComments);
 
 				// On marque la rule a NULL pour indiquer qu'elle est utilisee
 				rule = NULL;
@@ -1770,24 +1774,24 @@ yyreduce:
 		delete oaAttributes;
 
 		// Nettoyage
-		if ((yyvsp[-9].svValue) != NULL)
-			delete (yyvsp[-9].svValue);
-		if ((yyvsp[-6].svValue) != NULL)
-			delete (yyvsp[-6].svValue);
-		if ((yyvsp[-4].sValue) != NULL)
-			delete (yyvsp[-4].sValue);
-		if ((yyvsp[-1].kwmdMetaData) != NULL)
-			delete (yyvsp[-1].kwmdMetaData);
-		if ((yyvsp[0].sValue) != NULL)
-			delete (yyvsp[0].sValue);
+		if (svComments != NULL)
+			delete svComments;
+		if (svInternalComments != NULL)
+			delete svInternalComments;
+		if (sBlockName != NULL)
+			delete sBlockName;
+		if (metaData != NULL)
+			delete metaData;
+		if (sLabel != NULL)
+			delete sLabel;
 
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1798 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1802 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 27: /* kwclassBegin: kwclassBegin comments '{' comments '}' IDENTIFIER usedDerivationRule semicolon metaData comments  */
-#line 388 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 392 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWClass* kwcClass = (yyvsp[-9].kwcValue);
 
@@ -1808,22 +1812,22 @@ yyreduce:
 			delete (yyvsp[0].svValue);
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 1823 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1827 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 28: /* kwclassBegin: kwclassBegin error  */
-#line 409 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 413 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		// Attention: cette regle qui permet une gestion des erreurs amelioree
 		// genere un conflit reduce/reduce
 		kwcLoadCurrentClass = NULL;
 		YYABORT;
 	}
-#line 1834 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1838 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 29: /* oaAttributeArrayDeclaration: oaAttributeArrayDeclaration kwattributeDeclaration  */
-#line 419 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 423 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaAttributes = (yyvsp[-1].oaAttributes);
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
@@ -1869,14 +1873,14 @@ yyreduce:
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1882 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1886 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 30: /* oaAttributeArrayDeclaration: kwattributeDeclaration  */
-#line 463 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 467 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		ObjectArray* oaAttributes;
 		KWAttribute* attribute = (yyvsp[0].kwaValue);
+		ObjectArray* oaAttributes;
 		KWClass* kwcClass = kwcLoadCurrentClass;
 		ALString sMessage;
 
@@ -1921,11 +1925,11 @@ yyreduce:
 
 		(yyval.oaAttributes) = oaAttributes;
 	}
-#line 1932 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 1936 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 31: /* kwclassHeader: comments rootDeclaration CLASS IDENTIFIER labelOrComments keyFields labelOrComments metaData labelOrComments '{'  */
-#line 515 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 519 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		StringVector* svComments1 = (yyvsp[-9].svValue);
 		boolean bRoot = (yyvsp[-8].bValue);
@@ -2065,191 +2069,198 @@ yyreduce:
 		kwcLoadCurrentClass = kwcClass;
 		(yyval.kwcValue) = kwcClass;
 	}
-#line 2070 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2074 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 32: /* keyFields: %empty  */
-#line 652 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 656 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.svValue) = NULL; // pas de champ cle
 	}
-#line 2078 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2082 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 33: /* keyFields: '(' fieldList ')'  */
-#line 656 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 660 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.svValue) = (yyvsp[-1].svValue);
 	}
-#line 2086 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2090 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 34: /* fieldList: fieldList ',' IDENTIFIER  */
-#line 663 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 667 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		StringVector* svFields;
+		StringVector* svFields = (yyvsp[-2].svValue);
+		ALString* sIdentifier = (yyvsp[0].sValue);
 
 		// Ajout d'un nouveau de champ
-		svFields = cast(StringVector*, (yyvsp[-2].svValue));
-		svFields->Add(*(yyvsp[0].sValue));
-		delete (yyvsp[0].sValue);
+		svFields->Add(*sIdentifier);
+		delete sIdentifier;
 		(yyval.svValue) = svFields;
 	}
-#line 2100 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2104 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 35: /* fieldList: IDENTIFIER  */
-#line 673 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 677 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		ALString* sIdentifier = (yyvsp[0].sValue);
 		StringVector* svFields;
 
 		// Creation d'un tableau de champs, avec un premier champ
 		svFields = new StringVector;
-		svFields->Add(*(yyvsp[0].sValue));
-		delete (yyvsp[0].sValue);
+		svFields->Add(*sIdentifier);
+		delete sIdentifier;
 		(yyval.svValue) = svFields;
 	}
-#line 2114 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2119 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 36: /* metaData: %empty  */
-#line 685 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 690 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwmdMetaData) = NULL; // pas de paires cle valeurs
 	}
-#line 2122 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2127 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 37: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' STRINGLITTERAL '>'  */
-#line 689 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 694 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		KWMetaData* metaData;
+		KWMetaData* metaData = (yyvsp[-5].kwmdMetaData);
+		ALString* sKey = (yyvsp[-3].sValue);
+		ALString* sValue = (yyvsp[-1].sValue);
 
 		// Creation si necessaire d'une ensemble de paires cles valeur
-		if ((yyvsp[-5].kwmdMetaData) == NULL)
+		if (metaData == NULL)
 			metaData = new KWMetaData;
-		else
-			metaData = cast(KWMetaData*, (yyvsp[-5].kwmdMetaData));
 
 		// Erreur si cle deja existante
-		if (metaData->IsKeyPresent(*(yyvsp[-3].sValue)))
-			yyerror("Duplicate key in meta-data for key " + *((yyvsp[-3].sValue)));
+		if (metaData->IsKeyPresent(*sKey))
+			yyerror("Duplicate key in meta-data for key " + *(sKey));
 		// Insertion d'une paire avec valeur chaine de caracteres sinon
 		else
-			metaData->SetStringValueAt(*((yyvsp[-3].sValue)), *((yyvsp[-1].sValue)));
-		delete (yyvsp[-3].sValue);
-		delete (yyvsp[-1].sValue);
+			metaData->SetStringValueAt(*(sKey), *(sValue));
+		delete sKey;
+		delete sValue;
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2146 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2151 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 38: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' CONTINUOUSLITTERAL '>'  */
-#line 709 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 714 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		KWMetaData* metaData;
+		KWMetaData* metaData = (yyvsp[-5].kwmdMetaData);
+		ALString* sKey = (yyvsp[-3].sValue);
+		Continuous cValue = (yyvsp[-1].cValue);
 
 		// Creation si necessaire d'une ensemble de paires cles valeur
-		if ((yyvsp[-5].kwmdMetaData) == NULL)
+		if (metaData == NULL)
 			metaData = new KWMetaData;
-		else
-			metaData = cast(KWMetaData*, (yyvsp[-5].kwmdMetaData));
 
 		// Erreur si cle deja existante
-		if (metaData->IsKeyPresent(*(yyvsp[-3].sValue)))
-			yyerror("Duplicate key in meta-data for key " + *((yyvsp[-3].sValue)));
+		if (metaData->IsKeyPresent(*sKey))
+			yyerror("Duplicate key in meta-data for key " + *(sKey));
 		// Erreur si valeur Missing
-		else if ((yyvsp[-1].cValue) == KWContinuous::GetMissingValue())
-			yyerror("Missing value not allowed in meta-data for key " + *((yyvsp[-3].sValue)));
+		else if (cValue == KWContinuous::GetMissingValue())
+			yyerror("Missing value not allowed in meta-data for key " + *(sKey));
 		// Insertion d'une paire avec valeur numerique sinon
 		else
-			metaData->SetDoubleValueAt(*((yyvsp[-3].sValue)), (yyvsp[-1].cValue));
-		delete (yyvsp[-3].sValue);
+			metaData->SetDoubleValueAt(*(sKey), cValue);
+		delete sKey;
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2172 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2177 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 39: /* metaData: metaData '<' SIMPLEIDENTIFIER '>'  */
-#line 731 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 736 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		KWMetaData* metaData;
+		KWMetaData* metaData = (yyvsp[-3].kwmdMetaData);
+		ALString* sKey = (yyvsp[-1].sValue);
 
 		// Creation si necessaire d'une ensemble de paires cles valeur
-		if ((yyvsp[-3].kwmdMetaData) == NULL)
+		if (metaData == NULL)
 			metaData = new KWMetaData;
-		else
-			metaData = cast(KWMetaData*, (yyvsp[-3].kwmdMetaData));
 
 		// Erreur si cle deja existante
-		if (metaData->IsKeyPresent(*(yyvsp[-1].sValue)))
-			yyerror("Duplicate key in meta-data for key " + *((yyvsp[-1].sValue)));
+		if (metaData->IsKeyPresent(*sKey))
+			yyerror("Duplicate key in meta-data for key " + *(sKey));
 		// Insertion d'une paire avec valeur numerique sinon
 		else
-			metaData->SetNoValueAt(*((yyvsp[-1].sValue)));
-		delete (yyvsp[-1].sValue);
+			metaData->SetNoValueAt(*(sKey));
+		delete sKey;
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2195 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2199 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 40: /* metaData: metaData '<' SIMPLEIDENTIFIER '=' IDENTIFIER '>'  */
-#line 750 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 754 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		KWMetaData* metaData;
+		KWMetaData* metaData = (yyvsp[-5].kwmdMetaData);
+		ALString* sKey = (yyvsp[-3].sValue);
+		ALString* sValue = (yyvsp[-1].sValue);
 
 		// Creation si necessaire d'une ensemble de paires cles valeur
-		if ((yyvsp[-5].kwmdMetaData) == NULL)
+		if (metaData == NULL)
 			metaData = new KWMetaData;
-		else
-			metaData = cast(KWMetaData*, (yyvsp[-5].kwmdMetaData));
 
 		// Erreur car la valeur n'est pas du bon type
-		yyerror("Value (" + *((yyvsp[-1].sValue)) + ") of meta-data for key " + *((yyvsp[-3].sValue)) +
+		yyerror("Value (" + *(sValue) + ") of meta-data for key " + *(sKey) +
 			" should be a string value between double quotes");
-		delete (yyvsp[-3].sValue);
-		delete (yyvsp[-1].sValue);
+		delete sKey;
+		delete sValue;
 		(yyval.kwmdMetaData) = metaData;
 	}
-#line 2215 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2219 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 41: /* kwattributeDeclaration: comments usedDeclaration typeDeclaration refIdentifier IDENTIFIER usedDerivationRule semicolon metaData label  */
-#line 779 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 783 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		StringVector* svComments = (yyvsp[-8].svValue);
+		boolean bUsed = (yyvsp[-7].bValue);
+		int nType = (yyvsp[-6].nValue);
+		ALString* sRefIdentifier = (yyvsp[-5].sValue);
+		ALString* sIdentifier = (yyvsp[-4].sValue);
+		KWDerivationRule* rule = (yyvsp[-3].kwdrValue);
+		KWMetaData* metaData = (yyvsp[-1].kwmdMetaData);
+		ALString* slabel = (yyvsp[0].sValue);
 		KWAttribute* attribute;
-		KWDerivationRule* rule;
 
 		// Creation  et initialisation d'un attribut
 		attribute = new KWAttribute;
-		attribute->SetUsed((yyvsp[-7].bValue));
-		attribute->SetType((yyvsp[-6].nValue));
+		attribute->SetUsed(bUsed);
+		attribute->SetType(nType);
 
 		// Test de coherence entre le type et le complement de type dans le cas d'un type relation
 		if (KWType::IsRelation(attribute->GetType()))
 		{
-			if ((yyvsp[-5].sValue) == NULL)
-				yyerrorWithLineCorrection("Variable " + *((yyvsp[-4].sValue)) + " of type " +
-							      KWType::ToString((yyvsp[-6].nValue)) + ": missing " +
-							      KWType::ToString((yyvsp[-6].nValue)) + " dictionary",
+			if (sRefIdentifier == NULL)
+				yyerrorWithLineCorrection("Variable " + *sIdentifier + " of type " +
+							      KWType::ToString(nType) + ": missing " +
+							      KWType::ToString(nType) + " dictionary",
 							  -1);
 		}
 		// Test de coherence entre le type et le complement de type dans le cas d'un type Structure
 		else if (attribute->GetType() == KWType::Structure)
 		{
-			if ((yyvsp[-5].sValue) == NULL)
-				yyerrorWithLineCorrection("Variable " + *((yyvsp[-4].sValue)) + " of type " +
-							      KWType::ToString((yyvsp[-7].bValue)) + ": missing " +
-							      KWType::ToString((yyvsp[-7].bValue)) + " dictionary",
+			if (sRefIdentifier == NULL)
+				yyerrorWithLineCorrection("Variable " + *sIdentifier + " of type " +
+							      KWType::ToString(nType) + ": missing " +
+							      KWType::ToString(nType) + " dictionary",
 							  -1);
 		}
 		// Test d'absence de complement de type dans les autres cas
 		else
 		{
-			if ((yyvsp[-5].sValue) != NULL)
-				yyerrorWithLineCorrection("Variable " + *((yyvsp[-4].sValue)) + " of type " +
-							      KWType::ToString((yyvsp[-6].nValue)) + ": erroneous (" +
-							      *((yyvsp[-5].sValue)) + ") type complement",
+			if (sRefIdentifier != NULL)
+				yyerrorWithLineCorrection("Variable " + *sIdentifier + " of type " +
+							      KWType::ToString(nType) + ": erroneous (" +
+							      *(sRefIdentifier) + ") type complement",
 							  -1);
 		}
 
@@ -2259,22 +2270,22 @@ yyreduce:
 			KWClass* kwcReferencedClass = NULL;
 
 			// Test d'existence de la classe
-			if ((yyvsp[-5].sValue) != NULL)
-				kwcReferencedClass = kwcdLoadDomain->LookupClass(*((yyvsp[-5].sValue)));
+			if (sRefIdentifier != NULL)
+				kwcReferencedClass = kwcdLoadDomain->LookupClass(*sRefIdentifier);
 
 			// Sinon, test d'existence de la classe en tant que classe referencee uniquement
-			if (kwcReferencedClass == NULL and (yyvsp[-5].sValue) != NULL)
+			if (kwcReferencedClass == NULL and sRefIdentifier != NULL)
 				kwcReferencedClass =
-				    cast(KWClass*, odReferencedUncreatedClasses->Lookup(*((yyvsp[-5].sValue))));
+				    cast(KWClass*, odReferencedUncreatedClasses->Lookup(*sRefIdentifier));
 
 			// Si la classe n'existe pas, on essaie de la creer
-			if (kwcReferencedClass == NULL and (yyvsp[-5].sValue) != NULL)
+			if (kwcReferencedClass == NULL and sRefIdentifier != NULL)
 			{
 				// Test de nom de classe
-				if (KWClass::CheckName(*((yyvsp[-5].sValue)), KWClass::Class, NULL))
+				if (KWClass::CheckName(*sRefIdentifier, KWClass::Class, NULL))
 				{
 					kwcReferencedClass = new KWClass;
-					kwcReferencedClass->SetName(*((yyvsp[-5].sValue)));
+					kwcReferencedClass->SetName(*sRefIdentifier);
 
 					// Memorisation dans le dictionnaire des classe referencees
 					odReferencedUncreatedClasses->SetAt(kwcReferencedClass->GetName(),
@@ -2282,7 +2293,7 @@ yyreduce:
 				}
 				else
 					yyerrorWithLineCorrection(
-					    "Incorrect referenced dictionary name (" + *((yyvsp[-5].sValue)) + ")", -1);
+					    "Incorrect referenced dictionary name (" + *sRefIdentifier + ")", -1);
 			}
 
 			// On memorise la classe referencee
@@ -2291,16 +2302,15 @@ yyreduce:
 		// Structure referencee
 		else if (attribute->GetType() == KWType::Structure)
 		{
-			if ((yyvsp[-5].sValue) != NULL)
-				attribute->SetStructureName(*((yyvsp[-5].sValue)));
+			if (sRefIdentifier != NULL)
+				attribute->SetStructureName(*sRefIdentifier);
 		}
-		if ((yyvsp[-5].sValue) != NULL)
-			delete (yyvsp[-5].sValue);
+		if (sRefIdentifier != NULL)
+			delete sRefIdentifier;
 
 		// Nom de l'attribut
-		attribute->SetName(*((yyvsp[-4].sValue)));
-		delete (yyvsp[-4].sValue); // liberation de la valeur de IDENTIFIER
-		rule = (yyvsp[-3].kwdrValue);
+		attribute->SetName(*sIdentifier);
+		delete sIdentifier;
 		attribute->SetDerivationRule(rule);
 
 		// Completion eventuelle de la regle par les infos de type de l'attribut
@@ -2343,41 +2353,41 @@ yyreduce:
 		}
 
 		// Meta-donnees de l'attribut
-		if ((yyvsp[-1].kwmdMetaData) != NULL)
+		if (metaData != NULL)
 		{
-			attribute->GetMetaData()->CopyFrom((yyvsp[-1].kwmdMetaData));
-			delete (yyvsp[-1].kwmdMetaData);
+			attribute->GetMetaData()->CopyFrom(metaData);
+			delete metaData;
 		}
 
 		// Libelle
-		if ((yyvsp[0].sValue) != NULL)
+		if (slabel != NULL)
 		{
-			attribute->SetLabel(*((yyvsp[0].sValue)));
-			delete (yyvsp[0].sValue);
+			attribute->SetLabel(*slabel);
+			delete slabel;
 		}
 
 		// Commentaires
-		if ((yyvsp[-8].svValue) != NULL)
+		if (svComments != NULL)
 		{
-			attribute->SetComments((yyvsp[-8].svValue));
-			delete (yyvsp[-8].svValue);
+			attribute->SetComments(svComments);
+			delete svComments;
 		}
 
 		(yyval.kwaValue) = attribute;
 	}
-#line 2349 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2359 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 42: /* applicationids: %empty  */
-#line 913 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 923 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL; // pas d'identification d'application
 	}
-#line 2357 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2367 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 43: /* applicationids: applicationids APPLICATIONID  */
-#line 917 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 927 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		// On ne garde que la premiere ligne de chaque identification d'application
 		if ((yyvsp[-1].sValue) == NULL)
@@ -2388,285 +2398,287 @@ yyreduce:
 			(yyval.sValue) = (yyvsp[-1].sValue);
 		}
 	}
-#line 2372 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2382 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 44: /* label: %empty  */
-#line 931 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 941 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL; // pas de libelle
 	}
-#line 2380 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2390 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 45: /* label: LABEL  */
-#line 935 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 945 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 2388 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2398 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 46: /* comments: %empty  */
-#line 941 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 951 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.svValue) = NULL; // pas de commentaire
 	}
-#line 2396 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2406 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 47: /* comments: comments COMMENT  */
-#line 945 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 955 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		StringVector* svComments;
+		StringVector* svComments = (yyvsp[-1].svValue);
+		ALString* sComment = (yyvsp[0].sValue);
 
 		// Creation du vecteur de commentaires si neccesaire
-		if ((yyvsp[-1].svValue) == NULL)
+		if (svComments == NULL)
 			svComments = new StringVector;
-		else
-			svComments = (yyvsp[-1].svValue);
 
 		// Ajout du commentaire
-		svComments->Add(*(yyvsp[0].sValue));
-		delete (yyvsp[0].sValue);
+		svComments->Add(*sComment);
+		delete sComment;
 		(yyval.svValue) = svComments;
 	}
-#line 2415 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2424 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 48: /* labelOrComments: %empty  */
-#line 962 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 971 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.svValue) = NULL; // pas de commentaire
 	}
-#line 2423 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2432 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 49: /* labelOrComments: LABEL  */
-#line 966 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 975 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		ALString* sComment = (yyvsp[0].sValue);
 		StringVector* svComments;
+
 		svComments = new StringVector;
-		svComments->Add(*(yyvsp[0].sValue));
-		delete (yyvsp[0].sValue);
+		svComments->Add(*sComment);
+		delete sComment;
 		(yyval.svValue) = svComments;
 	}
-#line 2435 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2446 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 50: /* labelOrComments: labelOrComments COMMENT  */
-#line 974 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 985 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		StringVector* svComments;
+		StringVector* svComments = (yyvsp[-1].svValue);
+		ALString* sComment = (yyvsp[0].sValue);
 
 		// Creation du vecteur de commentaires si neccesaire
-		if ((yyvsp[-1].svValue) == NULL)
+		if (svComments == NULL)
 			svComments = new StringVector;
-		else
-			svComments = (yyvsp[-1].svValue);
 
 		// Ajout du commentaire
-		svComments->Add(*(yyvsp[0].sValue));
-		delete (yyvsp[0].sValue);
+		svComments->Add(*sComment);
+		delete sComment;
 		(yyval.svValue) = svComments;
 	}
-#line 2454 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2464 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 51: /* rootDeclaration: %empty  */
-#line 991 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1001 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = false; // valeur par defaut
 	}
-#line 2462 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2472 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 52: /* rootDeclaration: ROOT  */
-#line 995 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1005 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = true;
 	}
-#line 2470 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2480 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 53: /* usedDeclaration: %empty  */
-#line 1002 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1012 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = true; // valeur par defaut
 	}
-#line 2478 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2488 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 54: /* usedDeclaration: UNUSED  */
-#line 1006 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1016 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.bValue) = false;
 	}
-#line 2486 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2496 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 55: /* typeDeclaration: CONTINUOUSTYPE  */
-#line 1014 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1024 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Continuous;
 	}
-#line 2494 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2504 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 56: /* typeDeclaration: SYMBOLTYPE  */
-#line 1018 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1028 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Symbol;
 	}
-#line 2502 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2512 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 57: /* typeDeclaration: DATETYPE  */
-#line 1022 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1032 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Date;
 	}
-#line 2510 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2520 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 58: /* typeDeclaration: TIMETYPE  */
-#line 1026 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1036 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Time;
 	}
-#line 2518 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2528 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 59: /* typeDeclaration: TIMESTAMPTYPE  */
-#line 1030 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1040 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Timestamp;
 	}
-#line 2526 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2536 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 60: /* typeDeclaration: TIMESTAMPTZTYPE  */
-#line 1034 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1044 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::TimestampTZ;
 	}
-#line 2534 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2544 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 61: /* typeDeclaration: TEXTTYPE  */
-#line 1038 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1048 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Text;
 	}
-#line 2542 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2552 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 62: /* typeDeclaration: TEXTLISTTYPE  */
-#line 1042 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1052 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::TextList;
 	}
-#line 2550 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2560 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 63: /* typeDeclaration: OBJECTTYPE  */
-#line 1046 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1056 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Object;
 	}
-#line 2558 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2568 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 64: /* typeDeclaration: OBJECTARRAYTYPE  */
-#line 1050 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1060 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::ObjectArray;
 	}
-#line 2566 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2576 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 65: /* typeDeclaration: STRUCTURETYPE  */
-#line 1054 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1064 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.nValue) = KWType::Structure;
 	}
-#line 2574 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2584 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 66: /* refIdentifier: %empty  */
-#line 1061 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1071 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = NULL;
 	}
-#line 2582 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2592 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 67: /* refIdentifier: '(' IDENTIFIER ')'  */
-#line 1065 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1075 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[-1].sValue);
 	}
-#line 2590 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2600 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 68: /* usedDerivationRule: %empty  */
-#line 1072 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1082 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2598 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2608 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 69: /* usedDerivationRule: '=' derivationRule  */
-#line 1076 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1086 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2606 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2616 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 70: /* usedDerivationRule: referenceRule  */
-#line 1080 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1090 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2614 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2624 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 71: /* usedDerivationRule: '=' derivationRule ')'  */
-#line 1084 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1094 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ')'");
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2623 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2633 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 72: /* usedDerivationRule: '(' IDENTIFIER ')'  */
-#line 1089 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1099 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		ALString* sIdentifier = (yyvsp[-1].sValue);
 		ALString sTmp;
-		yyerror(sTmp + "Invalid syntax (" + *(yyvsp[-1].sValue) + ")");
-		if ((yyvsp[-1].sValue) != NULL)
-			delete (yyvsp[-1].sValue);
+
+		yyerror(sTmp + "Invalid syntax (" + *sIdentifier + ")");
+		if (sIdentifier != NULL)
+			delete sIdentifier;
 		(yyval.kwdrValue) = NULL;
 	}
-#line 2635 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2647 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 73: /* referenceRule: referenceRuleBody ']'  */
-#line 1099 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1111 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[-1].kwdrValue);
 	}
-#line 2643 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2655 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 74: /* referenceRuleBody: '[' derivationRuleOperand  */
-#line 1105 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1117 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
 		KWDerivationRule* rule;
-		KWDerivationRuleOperand* operand;
 
 		// Construction d'une regle pour accueillir les specifications
 		rule = KWDerivationRule::CloneDerivationRule(KWDerivationRule::GetReferenceRuleName());
@@ -2675,7 +2687,6 @@ yyreduce:
 		rule->DeleteAllOperands();
 
 		// Ajout d'un premier operande: le premier champ de la cle de reference
-		operand = (yyvsp[0].kwdroValue);
 		if (operand->GetType() == KWType::Unknown)
 			operand->SetType(KWType::Symbol);
 		rule->AddOperand(operand);
@@ -2683,17 +2694,16 @@ yyreduce:
 		// On retourner la regle
 		(yyval.kwdrValue) = rule;
 	}
-#line 2667 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2678 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 75: /* referenceRuleBody: referenceRuleBody ',' derivationRuleOperand  */
-#line 1125 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1136 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
-		KWDerivationRuleOperand* operand;
+		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
 
 		// Ajout d'un autre operande: un autre champ de la cle de reference
-		operand = (yyvsp[0].kwdroValue);
 		if (operand->GetType() == KWType::Unknown)
 			operand->SetType(KWType::Symbol);
 		rule->AddOperand(operand);
@@ -2701,14 +2711,14 @@ yyreduce:
 		// On retourner la regle
 		(yyval.kwdrValue) = rule;
 	}
-#line 2685 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2695 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 76: /* derivationRule: derivationRuleBody closeparenthesis  */
-#line 1141 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1151 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		boolean bOk = true;
 		KWDerivationRule* ruleBody = (yyvsp[-1].kwdrValue);
+		boolean bOk = true;
 		KWDerivationRule* rule;
 		ALString sTmp;
 
@@ -2812,24 +2822,24 @@ yyreduce:
 		delete ruleBody;
 		(yyval.kwdrValue) = rule;
 	}
-#line 2794 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2804 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 77: /* derivationRuleBody: derivationRuleBegin  */
-#line 1249 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1259 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2802 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2812 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 78: /* derivationRuleBody: derivationRuleBegin ':' operandList  */
-#line 1253 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1263 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* ruleBody = (yyvsp[-2].kwdrValue);
+		ObjectArray* oaOutputOperands = (yyvsp[0].oaOperands);
 		KWDRRelationCreationRule* ruleRelationCreationBody;
 		ObjectArray oaOperands;
-		ObjectArray* oaOutputOperands;
 		int nOperand;
 		KWDerivationRuleOperand* operand;
 
@@ -2856,9 +2866,6 @@ yyreduce:
 			ruleRelationCreationBody->AddOperand(operand);
 		}
 
-		// On recupere la liste des operandes en sortie
-		oaOutputOperands = cast(ObjectArray*, (yyvsp[0].oaOperands));
-
 		// Parametrage des operandes en sortie
 		assert(ruleRelationCreationBody->GetOutputOperandNumber() == 0);
 		for (nOperand = 0; nOperand < oaOutputOperands->GetSize(); nOperand++)
@@ -2870,19 +2877,19 @@ yyreduce:
 
 		(yyval.kwdrValue) = ruleRelationCreationBody;
 	}
-#line 2852 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2859 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 79: /* derivationRuleBody: derivationRuleHeader  */
-#line 1299 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1306 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2860 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2867 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 80: /* operandList: operandList ',' derivationRuleOperand  */
-#line 1306 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1313 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaOperandList = (yyvsp[-2].oaOperands);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2893,14 +2900,14 @@ yyreduce:
 		oaOperandList->Add(operand);
 		(yyval.oaOperands) = oaOperandList;
 	}
-#line 2875 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2882 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 81: /* operandList: derivationRuleOperand  */
-#line 1317 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1324 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
-		ObjectArray* oaOperandList;
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
+		ObjectArray* oaOperandList;
 		check(operand);
 
 		// Creation d'un tableau doperandes, avec un premier operande
@@ -2908,25 +2915,26 @@ yyreduce:
 		oaOperandList->Add(operand);
 		(yyval.oaOperands) = oaOperandList;
 	}
-#line 2890 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2897 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 82: /* derivationRuleHeader: IDENTIFIER openparenthesis  */
-#line 1330 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1337 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		ALString* sIdentifier = (yyvsp[-1].sValue);
 		KWDerivationRule* rule;
 
 		// Construction d'une regle pour accueillir les specification
 		rule = new KWDerivationRule;
-		rule->SetName(*((yyvsp[-1].sValue)));
-		delete (yyvsp[-1].sValue);
+		rule->SetName(*sIdentifier);
+		delete sIdentifier;
 		(yyval.kwdrValue) = rule;
 	}
-#line 2904 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2912 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 83: /* derivationRuleBegin: derivationRuleHeader derivationRuleOperand  */
-#line 1343 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1351 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-1].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2937,11 +2945,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2919 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2927 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 84: /* derivationRuleBegin: derivationRuleBegin ',' derivationRuleOperand  */
-#line 1354 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1362 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2952,158 +2960,169 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2934 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2942 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 85: /* derivationRuleOperand: IDENTIFIER  */
-#line 1368 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1376 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		ALString* sIdentifier = (yyvsp[0].sValue);
 		KWDerivationRuleOperand* operand;
+
 		operand = new KWDerivationRuleOperand;
 		operand->SetOrigin(KWDerivationRuleOperand::OriginAttribute);
-		operand->SetDataItemName(*((yyvsp[0].sValue)));
-		delete (yyvsp[0].sValue);
+		operand->SetDataItemName(*sIdentifier);
+		delete sIdentifier;
 		(yyval.kwdroValue) = operand;
 	}
-#line 2947 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2957 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 86: /* derivationRuleOperand: CONTINUOUSLITTERAL  */
-#line 1377 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1387 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		Continuous cValue = (yyvsp[0].cValue);
 		KWDerivationRuleOperand* operand;
+
 		operand = new KWDerivationRuleOperand;
 		operand->SetType(KWType::Continuous);
 		operand->SetOrigin(KWDerivationRuleOperand::OriginConstant);
-		operand->SetContinuousConstant((yyvsp[0].cValue));
+		operand->SetContinuousConstant(cValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2960 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2972 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 87: /* derivationRuleOperand: bigstring  */
-#line 1386 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1398 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		ALString* sValue = (yyvsp[0].sValue);
 		KWDerivationRuleOperand* operand;
+
 		operand = new KWDerivationRuleOperand;
 		operand->SetType(KWType::Symbol);
 		operand->SetOrigin(KWDerivationRuleOperand::OriginConstant);
-		operand->SetSymbolConstant(Symbol(*((yyvsp[0].sValue))));
-		delete (yyvsp[0].sValue);
-		(yyval.kwdroValue) = operand;
-	}
-#line 2974 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
-	break;
-
-	case 88: /* derivationRuleOperand: derivationRule  */
-#line 1396 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
-	{
-		KWDerivationRuleOperand* operand;
-		operand = new KWDerivationRuleOperand;
-		operand->SetOrigin(KWDerivationRuleOperand::OriginRule);
-		operand->SetDerivationRule((yyvsp[0].kwdrValue));
-		if (operand->GetDerivationRule() != NULL)
-			operand->SetType(operand->GetDerivationRule()->GetType());
+		operand->SetSymbolConstant(Symbol(*sValue));
+		delete sValue;
 		(yyval.kwdroValue) = operand;
 	}
 #line 2988 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-	case 89: /* derivationRuleOperand: '.' derivationRuleOperand  */
-#line 1406 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	case 88: /* derivationRuleOperand: derivationRule  */
+#line 1410 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		KWDerivationRule* rule = (yyvsp[0].kwdrValue);
 		KWDerivationRuleOperand* operand;
-		operand = (yyvsp[0].kwdroValue);
+
+		operand = new KWDerivationRuleOperand;
+		operand->SetOrigin(KWDerivationRuleOperand::OriginRule);
+		operand->SetDerivationRule(rule);
+		if (operand->GetDerivationRule() != NULL)
+			operand->SetType(operand->GetDerivationRule()->GetType());
+		(yyval.kwdroValue) = operand;
+	}
+#line 3004 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+	break;
+
+	case 89: /* derivationRuleOperand: '.' derivationRuleOperand  */
+#line 1422 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+	{
+		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
+
 		operand->SetScopeLevel(operand->GetScopeLevel() + 1);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2999 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3015 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 90: /* bigstring: bigstring '+' STRINGLITTERAL  */
-#line 1417 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1433 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
+		ALString* sValue1 = (yyvsp[-2].sValue);
+		ALString* sValue2 = (yyvsp[0].sValue);
+
 		// Concatenation des deux chaines
-		(yyval.sValue) = new ALString(*(yyvsp[-2].sValue) + *(yyvsp[0].sValue));
+		(yyval.sValue) = new ALString(*sValue1 + *sValue2);
 
 		// Destruction des ancienne chaines
-		delete (yyvsp[-2].sValue);
-		delete (yyvsp[0].sValue);
+		delete sValue1;
+		delete sValue2;
 	}
-#line 3012 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3031 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 91: /* bigstring: STRINGLITTERAL  */
-#line 1426 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1445 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 3020 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3039 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 92: /* semicolon: %empty  */
-#line 1432 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1451 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Missing ';'");
 	}
-#line 3028 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3047 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 94: /* semicolon: ';' ';'  */
-#line 1437 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1456 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous ';'");
 	}
-#line 3036 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3055 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 95: /* semicolon: ';' ';' ';'  */
-#line 1441 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1460 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ';'");
 	}
-#line 3044 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3063 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 96: /* openparenthesis: %empty  */
-#line 1447 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1466 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		// Cette instruction est la pour aider au diagnostic des erreurs
 		// de parenthesage: elle est utile dans ce cas, mais genere (avec
 		// sa consoeur de nombreux shift/reduce et reduce conflicts
 		yyerror("Missing '('");
 	}
-#line 3055 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3074 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 98: /* openparenthesis: '(' '('  */
-#line 1455 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1474 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous '('");
 	}
-#line 3063 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3082 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 99: /* openparenthesis: '(' '(' '('  */
-#line 1459 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1478 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many '('");
 	}
-#line 3071 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3090 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 100: /* closeparenthesis: %empty  */
-#line 1466 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1485 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		// Cette instruction est la pour aider au diagnostic des erreurs
 		// de parenthesage: elle est utile dans ce cas, mais genere (avec
 		// sa consoeur de nombreux shift/reduce et reduce conflicts
 		yyerror("Missing ')'");
 	}
-#line 3082 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3101 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-#line 3086 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3105 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 	default:
 		break;
@@ -3282,7 +3301,7 @@ yyreturnlab:
 	return yyresult;
 }
 
-#line 1476 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1495 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 #include "KWCLex.inc"
 

--- a/src/Learning/KWData/KWCYac.hpp
+++ b/src/Learning/KWData/KWCYac.hpp
@@ -87,7 +87,7 @@ typedef enum yytokentype yytoken_kind_t;
 #if !defined YYSTYPE && !defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 65 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 60 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 	Continuous cValue;
 	ALString* sValue;

--- a/src/Learning/KWData/KWCYac.hpp
+++ b/src/Learning/KWData/KWCYac.hpp
@@ -62,22 +62,23 @@ enum yytokentype
 	EXTENDEDIDENTIFIER = 259, /* EXTENDEDIDENTIFIER  */
 	CONTINUOUSLITTERAL = 260, /* CONTINUOUSLITTERAL  */
 	STRINGLITTERAL = 261,     /* STRINGLITTERAL  */
-	LABEL = 262,              /* LABEL  */
-	APPLICATIONID = 263,      /* APPLICATIONID  */
-	CLASS = 264,              /* CLASS  */
-	CONTINUOUSTYPE = 265,     /* CONTINUOUSTYPE  */
-	SYMBOLTYPE = 266,         /* SYMBOLTYPE  */
-	OBJECTTYPE = 267,         /* OBJECTTYPE  */
-	OBJECTARRAYTYPE = 268,    /* OBJECTARRAYTYPE  */
-	ROOT = 269,               /* ROOT  */
-	UNUSED = 270,             /* UNUSED  */
-	DATETYPE = 271,           /* DATETYPE  */
-	TIMETYPE = 272,           /* TIMETYPE  */
-	TIMESTAMPTYPE = 273,      /* TIMESTAMPTYPE  */
-	TIMESTAMPTZTYPE = 274,    /* TIMESTAMPTZTYPE  */
-	TEXTTYPE = 275,           /* TEXTTYPE  */
-	TEXTLISTTYPE = 276,       /* TEXTLISTTYPE  */
-	STRUCTURETYPE = 277       /* STRUCTURETYPE  */
+	COMMENT = 262,            /* COMMENT  */
+	LABEL = 263,              /* LABEL  */
+	APPLICATIONID = 264,      /* APPLICATIONID  */
+	CLASS = 265,              /* CLASS  */
+	CONTINUOUSTYPE = 266,     /* CONTINUOUSTYPE  */
+	SYMBOLTYPE = 267,         /* SYMBOLTYPE  */
+	OBJECTTYPE = 268,         /* OBJECTTYPE  */
+	OBJECTARRAYTYPE = 269,    /* OBJECTARRAYTYPE  */
+	ROOT = 270,               /* ROOT  */
+	UNUSED = 271,             /* UNUSED  */
+	DATETYPE = 272,           /* DATETYPE  */
+	TIMETYPE = 273,           /* TIMETYPE  */
+	TIMESTAMPTYPE = 274,      /* TIMESTAMPTYPE  */
+	TIMESTAMPTZTYPE = 275,    /* TIMESTAMPTZTYPE  */
+	TEXTTYPE = 276,           /* TEXTTYPE  */
+	TEXTLISTTYPE = 277,       /* TEXTLISTTYPE  */
+	STRUCTURETYPE = 278       /* STRUCTURETYPE  */
 };
 typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -86,7 +87,7 @@ typedef enum yytokentype yytoken_kind_t;
 #if !defined YYSTYPE && !defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 64 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 65 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 	Continuous cValue;
 	ALString* sValue;
@@ -101,7 +102,7 @@ union YYSTYPE
 	KWMetaData* kwmdMetaData;
 	int nValue;
 
-#line 101 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.hpp"
+#line 102 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.hpp"
 };
 typedef union YYSTYPE YYSTYPE;
 #define YYSTYPE_IS_TRIVIAL 1

--- a/src/Learning/KWData/KWCYac.yac
+++ b/src/Learning/KWData/KWCYac.yac
@@ -57,6 +57,7 @@ static int nFileParsingErrorNumber = 0;
 /*
 #define YYDEBUG 1 
 extern char   *yyptok(int i); 
+// Ajouter l'instruction yydebug = 1 dans le code d'une action du fichier .lex ou .yac
 */
 
 %}
@@ -81,6 +82,7 @@ extern char   *yyptok(int i);
 %token <sValue>    EXTENDEDIDENTIFIER
 %token <cValue>    CONTINUOUSLITTERAL
 %token <sValue>    STRINGLITTERAL
+%token <sValue>    COMMENT
 %token <sValue>    LABEL 
 %token <sValue>    APPLICATIONID 
 %token CLASS 
@@ -105,7 +107,9 @@ extern char   *yyptok(int i);
 %type <nValue> OBJECTARRAYTYPE
 %type <sValue> IDENTIFIER
 %type <sValue> SIMPLEIDENTIFIER
-%type <sValue> comments
+%type <sValue> label
+%type <svValue> comments
+%type <svValue> labelOrComments
 %type <sValue> applicationids
 %type <sValue> bigstring
 %type <sValue> refIdentifier
@@ -218,36 +222,44 @@ kwclassFile: applicationids kwclasses comments
 	  /* On ignore l'identification d'application */
 	  if ($1 != NULL)
 	    delete $1;
-
-	  /* On ignore les commentaires en fin de fichier */
+	
+	  /* On interdit les commentaires en fin de fichier */
 	  if ($3 != NULL)
+	  {
 	    delete $3;
+	    yyerrorWithLineCorrection("Comments at the end of the file are not allowed", -1);
+	  }
 	}
 	;
 
-kwclasses:
-    kwclasses kwclass
+kwclasses: /* NULL */
+  | kwclasses kwclass
   | kwclasses error 
       { yyerror("Error outside the definition of a dictionary"); 
 	    YYABORT; }
-  | /* NULL */
   ;
 
-kwclass: kwclassBegin '}' semicolon
+kwclass: kwclassBegin comments '}' semicolon
 		{
+		  KWClass* kwcClass=$1;
+
 		  /* La completion des informations de type (CompleteTypeInfo) est centralisee */
 		  /* au niveau du domaine en fin de parsing */
+
+		  /* Commentaires internes */
+		  if ($2 != NULL)
+		  {
+		    kwcClass->SetInternalComments($2);
+			delete $2;
+		  }
 
 		  /* Reinitialisation de la classe courante */
   		  kwcLoadCurrentClass = NULL;
 		}
 	;
 
-kwclassBegin: kwclassHeader comments
+kwclassBegin: kwclassHeader
 		{
-		  /* On ignore les premiers comemntaires */
-		  if ($2 != NULL)
-		    delete $2;
 		  assert(kwcLoadCurrentClass == $1);
 		  $$ = $1;
 		}
@@ -293,7 +305,7 @@ kwclassBegin: kwclassHeader comments
 
 		  $$ = kwcClass;       
 		 }
-	| kwclassBegin '{' comments oaAttributeArrayDeclaration '}' IDENTIFIER usedDerivationRule semicolon metaData comments
+	| kwclassBegin comments '{'  oaAttributeArrayDeclaration comments '}' IDENTIFIER usedDerivationRule semicolon metaData label
 		{
 		  KWClass* kwcClass=$1;
 		  KWAttributeBlock* attributeBlock;
@@ -301,18 +313,14 @@ kwclassBegin: kwclassHeader comments
   		  ALString sBlockName;
 		  KWAttribute* firstAttribute;
 		  KWAttribute* lastAttribute;
-		  KWDerivationRule* rule = $7;
+		  KWDerivationRule* rule = $8;
 		  ALString sMessage;
 		  assert(kwcLoadCurrentClass == $1);
 		  check(oaAttributes);
 
-		  /* On ignore les premiers comemntaires */
-		  if ($3 != NULL)
-		    delete $3;
-
 		  /* Nom du bloc */
-		  if ($6 != NULL)
-		    sBlockName = *($6);
+		  if ($7 != NULL)
+		    sBlockName = *($7);
 
 		  /* Cas d'un bloc avec au moins un attribut valide */
 		  if (oaAttributes->GetSize() > 0)
@@ -345,10 +353,14 @@ kwclassBegin: kwclassHeader comments
 
 			  /* Parametrage du bloc */
 			  attributeBlock->SetDerivationRule(rule);
-			  if ($9 != NULL)
-			    attributeBlock->GetMetaData()->CopyFrom($9);
-  		      if ($10 != NULL)
-			    attributeBlock->SetLabel(*($10));
+			  if ($10 != NULL)
+			    attributeBlock->GetMetaData()->CopyFrom($10);
+  		      if ($11 != NULL)
+			    attributeBlock->SetLabel(*($11));
+			  if ($2 != NULL)
+			    attributeBlock->SetComments($2);
+			  if ($5 != NULL)
+			    attributeBlock->SetInternalComments($5);
 
 			  /* On marque la rule a NULL pour indiquer qu'elle est utilisee */
 			  rule = NULL;
@@ -364,16 +376,20 @@ kwclassBegin: kwclassHeader comments
 		  delete oaAttributes;
 		  
 		  /* Nettoyage */
-		  if ($6 != NULL)
-		    delete $6;
-		  if ($9 != NULL)
-		    delete $9;
+		  if ($2 != NULL)
+		    delete $2;
+		  if ($5 != NULL)
+		    delete $5;
+		  if ($7 != NULL)
+		    delete $7;
 		  if ($10 != NULL)
 		    delete $10;
+		  if ($11 != NULL)
+		    delete $11;
 		  
 		  $$ = kwcClass;
 		  }
-	| kwclassBegin '{' comments '}' IDENTIFIER usedDerivationRule semicolon metaData comments
+	| kwclassBegin comments '{' comments '}' IDENTIFIER usedDerivationRule semicolon metaData comments
 		{
 		  KWClass* kwcClass=$1;
 
@@ -381,15 +397,17 @@ kwclassBegin: kwclassHeader comments
 		  yyerror("Empty sparse variable block not allowed");
 
 		  /* Nettoyage */
-		  if ($3 != NULL)
-		    delete $3;
-		  delete $5;
-		  if ($6 != NULL)
-		      delete $6;
-		  if ($8 != NULL)
-		    delete $8;
+		  if ($2 != NULL)
+		    delete $2;
+		  if ($4 != NULL)
+		    delete $4;
+		  delete $6;
+		  if ($7 != NULL)
+		      delete $7;
 		  if ($9 != NULL)
 		    delete $9;
+		  if ($10 != NULL)
+		    delete $10;
 		  $$ = kwcClass;
 		  }
 	| kwclassBegin error 
@@ -495,23 +513,39 @@ oaAttributeArrayDeclaration :
 		 }
 		;
 
-kwclassHeader: comments rootDeclaration CLASS IDENTIFIER keyFields metaData '{'
+kwclassHeader: comments 
+       rootDeclaration CLASS IDENTIFIER labelOrComments 
+	   keyFields labelOrComments 
+	   metaData labelOrComments 
+	   '{'
 	   {
+	      StringVector* svComments1 = $1;
+		  boolean bRoot = $2;
+	      ALString* sIdentifier = $4;
+	      StringVector* svComments2 = $5;
+          StringVector* svKeyFields = $6;
+	      StringVector* svComments3 = $7;
+		  KWMetaData* metaData = $8;
+	      StringVector* svComments4 = $9;
           KWClass *kwcClass;
 		  KWClass* kwcReferencedClass;
+		  StringVector svAllComments;
+		  StringVector svClassComments;
+		  int nCommentStartIndex;
+		  int i;
 		  ALString sMessage;
 
           /* Test d'existence de la classe */
-          kwcClass = kwcdLoadDomain->LookupClass(*($4));
+          kwcClass = kwcdLoadDomain->LookupClass(*sIdentifier);
 
           /* Test d'existence de la classe en tant que classe referencee uniquement */
-          kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*($4)));
+          kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*sIdentifier));
 		  assert(kwcReferencedClass == NULL or kwcClass == NULL);
 
           /* Erreur si la classe existe deja */
           if (kwcClass != NULL)
           {
-            yyerror("Dictionary " + *($4) + " already exists");
+            yyerror("Dictionary " + *sIdentifier + " already exists");
    	        kwcClass = NULL;
           }
 		  /* On utilise la classe referencee si elle existe */
@@ -529,10 +563,10 @@ kwclassHeader: comments rootDeclaration CLASS IDENTIFIER keyFields metaData '{'
           else
           {
 		    /* Test de nom de classe */
-		    if (KWClass::CheckNameWithMessage(*($4), KWClass::Class, sMessage))
+		    if (KWClass::CheckNameWithMessage(*sIdentifier, KWClass::Class, sMessage))
 		    {
               kwcClass = new KWClass;
-              kwcClass->SetName(*($4));
+              kwcClass->SetName(*sIdentifier);
               kwcdLoadDomain->InsertClass(kwcClass);
 		    }
 		    else
@@ -542,69 +576,91 @@ kwclassHeader: comments rootDeclaration CLASS IDENTIFIER keyFields metaData '{'
 		  /* Initialisation si necessaire de la classe */
 		  if (kwcClass != NULL)
 		  {
-            /* Class Label */
-            if ($1!=NULL)
-              kwcClass->SetLabel(*($1));
+		    /* Commentaire de la classe en cours */
+			svClassComments.CopyFrom(kwcClass->GetComments());
 
             /* Classe racine */
-            kwcClass->SetRoot($2);
+            kwcClass->SetRoot(bRoot);
             
             /* Attribut key field */
-            if ($5!=NULL)
+            if (svKeyFields!=NULL)
             {
-              StringVector* svKeyFields;
-              int i;
-              
               // Transfert des champs de la cle */ 
-              svKeyFields = cast(StringVector*, $5);
+              svKeyFields = cast(StringVector*, svKeyFields);
               kwcClass->SetKeyAttributeNumber(svKeyFields->GetSize());
               for (i = 0; i < svKeyFields->GetSize(); i++)
                 kwcClass->SetKeyAttributeNameAt(i, svKeyFields->GetAt(i));
             }
 
 			/* Meta-donnees de la classe */
-			if ($6 != NULL)
+			if (metaData != NULL)
+			    kwcClass->GetMetaData()->CopyFrom(metaData);
+
+			/* On recupere les commentaires existants */
+			svAllComments.CopyFrom(kwcClass->GetComments()); 
+
+ 		    /* On recupere tous les commentaires entre le debut et la fin de la declaration de la classe */
+            if (svComments1!=NULL)
 			{
-			    kwcClass->GetMetaData()->CopyFrom($6);
-		    }
+			  for (i = 0; i < svComments1->GetSize(); i++)
+			    svAllComments.Add(svComments1->GetAt(i));
+			}
+            if (svComments2!=NULL)
+			{
+			  for (i = 0; i < svComments2->GetSize(); i++)
+			    svAllComments.Add(svComments2->GetAt(i));
+			}
+            if (svComments3!=NULL)
+			{
+			  for (i = 0; i < svComments3->GetSize(); i++)
+			    svAllComments.Add(svComments3->GetAt(i));
+			}
+            if (svComments4!=NULL)
+			{
+			  for (i = 0; i < svComments4->GetSize(); i++)
+			    svAllComments.Add(svComments4->GetAt(i));
+			}
+
+			/* Libelle de la classe: le premier des commentaires, sauf s'il existe deja */
+			nCommentStartIndex = 0;
+			if (kwcClass->GetLabel() == "" and svAllComments.GetSize() > 0)
+			{
+			  kwcClass->SetLabel(svAllComments.GetAt(0));
+			  nCommentStartIndex = 1;
+			}
+
+			/* Mise a jour des commentaires de la classe, en excluant potentiellement le premier commentaire reserve au libelle */
+			if (svAllComments.GetSize() > 0)
+			{
+  	          for (i = nCommentStartIndex; i < svAllComments.GetSize(); i++)
+			    svClassComments.Add(svAllComments.GetAt(i));
+			  kwcClass->SetComments(&svClassComments);
+			}
           }
 
           /* Liberation des tokens */
-          if ($1!=NULL) delete $1;  /* Label */
-          delete $4;  /* Name */
-          if ($5!=NULL)  /* Key fields */
-          {
-              StringVector* svKeyFields;
-              svKeyFields = cast(StringVector*, $5);
-              delete svKeyFields;
-          }
-          if ($6!=NULL) 
-		  delete $6; /* Key value pairs */
+          delete sIdentifier;
+          if (svKeyFields!=NULL) delete svKeyFields;
+          if (metaData!=NULL) delete metaData;
+          if (svComments1!=NULL) delete svComments1;
+          if (svComments2!=NULL) delete svComments2;
+          if (svComments3!=NULL) delete svComments3;
+          if (svComments4!=NULL) delete svComments4;
 
-		  /* Memorisation dz la classe courante */
+		  /* Memorisation de la classe courante */
 		  kwcLoadCurrentClass = kwcClass;
 		  $$ = kwcClass;
 	   }
 	   ;
+ 
 
-keyFields:
-      '(' fieldList ')' comments
+keyFields: /* NULL */
         {
-		  /* On ignore les comemntaires */
-		  if ($4 != NULL)
-		    delete $4;
-		  $$ = $2;
+          $$ = NULL; /* pas de champ cle */
         }
-	| comments
-		{
-		  /* On ignore les comemntaires */
-		  if ($1 != NULL)
-		    delete $1;
-          $$ = NULL; /* pas de champ cle */
-		}
-    | /* NULL */
+    | '(' fieldList ')'
         {
-          $$ = NULL; /* pas de champ cle */
+		  $$ = $2;
         }
     ;
 
@@ -631,8 +687,11 @@ fieldList:
         }
     ;
 
-metaData:
-	  metaData '<' SIMPLEIDENTIFIER '=' STRINGLITTERAL '>'
+metaData: /* NULL */
+        {
+          $$ = NULL; /* pas de paires cle valeurs */
+        }
+	| metaData '<' SIMPLEIDENTIFIER '=' STRINGLITTERAL '>'
         {
             KWMetaData* metaData;
             
@@ -709,15 +768,12 @@ metaData:
 		    delete $5;
 			$$ = metaData;
         }
-    | /* NULL */
-        {
-          $$ = NULL; /* pas de paires cle valeurs */
-        }
     ;
 
 
 
 kwattributeDeclaration:
+      comments
       usedDeclaration 
 	  typeDeclaration 
 	  refIdentifier 
@@ -725,36 +781,36 @@ kwattributeDeclaration:
 	  usedDerivationRule 
 	  semicolon
 	  metaData
-	  comments
+	  label
         {
           KWAttribute *attribute;
           KWDerivationRule* rule;
 
           /* Creation  et initialisation d'un attribut */
           attribute = new KWAttribute;
-		  attribute->SetUsed($1);
-		  attribute->SetType($2);
+		  attribute->SetUsed($2);
+		  attribute->SetType($3);
 		  
 		  /* Test de coherence entre le type et le complement de type dans le cas d'un type relation */
 		  if (KWType::IsRelation(attribute->GetType()))
 		  {
-			 if ($3 == NULL)
-			    yyerrorWithLineCorrection("Variable " + *($4) + " of type " + KWType::ToString($2) + 
-				": missing " +  KWType::ToString($2) + " dictionary", -1);
+			 if ($4 == NULL)
+			    yyerrorWithLineCorrection("Variable " + *($5) + " of type " + KWType::ToString($3) + 
+				": missing " +  KWType::ToString($3) + " dictionary", -1);
 		  }
 		  /* Test de coherence entre le type et le complement de type dans le cas d'un type Structure */
 		  else if (attribute->GetType() == KWType::Structure)
 		  {
-			 if ($3 == NULL)
-			    yyerrorWithLineCorrection("Variable " + *($4) + " of type " + KWType::ToString($2) + 
+			 if ($4 == NULL)
+			    yyerrorWithLineCorrection("Variable " + *($5) + " of type " + KWType::ToString($2) + 
 				": missing " +  KWType::ToString($2) + " dictionary", -1);
 		  }
 		  /* Test d'absence de complement de type dans les autres cas */
 		  else
 		  {
-			 if ($3 != NULL)
-			    yyerrorWithLineCorrection("Variable " + *($4) + " of type " + KWType::ToString($2) + 
-				": erroneous (" +  *($3) + ") type complement", -1);
+			 if ($4 != NULL)
+			    yyerrorWithLineCorrection("Variable " + *($5) + " of type " + KWType::ToString($3) + 
+				": erroneous (" +  *($4) + ") type complement", -1);
 		  }
 
 		  /* Classe referencee */
@@ -763,27 +819,27 @@ kwattributeDeclaration:
 		    KWClass* kwcReferencedClass = NULL;
 
             /* Test d'existence de la classe */
-            if ($3 != NULL)
-              kwcReferencedClass = kwcdLoadDomain->LookupClass(*($3));
+            if ($4 != NULL)
+              kwcReferencedClass = kwcdLoadDomain->LookupClass(*($4));
 
             /* Sinon, test d'existence de la classe en tant que classe referencee uniquement */
-            if (kwcReferencedClass == NULL and $3 != NULL)
-                kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*($3)));
+            if (kwcReferencedClass == NULL and $4 != NULL)
+                kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*($4)));
 
             /* Si la classe n'existe pas, on essaie de la creer */
-            if (kwcReferencedClass == NULL and $3 != NULL)
+            if (kwcReferencedClass == NULL and $4 != NULL)
 		    {
 		      /* Test de nom de classe */
-		      if (KWClass::CheckName(*($3), KWClass::Class, NULL))
+		      if (KWClass::CheckName(*($4), KWClass::Class, NULL))
 		      {
                 kwcReferencedClass = new KWClass;
-                kwcReferencedClass->SetName(*($3));
+                kwcReferencedClass->SetName(*($4));
 
 				/* Memorisation dans le dictionnaire des classe referencees */
                 odReferencedUncreatedClasses->SetAt(kwcReferencedClass->GetName(), kwcReferencedClass);
 		      }
 		      else
-		        yyerrorWithLineCorrection("Incorrect referenced dictionary name (" + *($3) + ")", -1);
+		        yyerrorWithLineCorrection("Incorrect referenced dictionary name (" + *($4) + ")", -1);
 		    }
 
 		    /* On memorise la classe referencee */
@@ -792,16 +848,16 @@ kwattributeDeclaration:
 		  /* Structure referencee */
 		  else if (attribute->GetType() == KWType::Structure)
 		  {
-		    if ($3 != NULL)
-              attribute->SetStructureName(*($3));
+		    if ($4 != NULL)
+              attribute->SetStructureName(*($4));
           }
-          if ($3 != NULL)
-            delete $3;
+          if ($4 != NULL)
+            delete $4;
 
 		  /* Nom de l'attribut */
-		  attribute->SetName (*($4));
-          delete $4; /* liberation de la valeur de IDENTIFIER */
-          rule = $5;
+		  attribute->SetName (*($5));
+          delete $5; /* liberation de la valeur de IDENTIFIER */
+          rule = $6;
 		  attribute->SetDerivationRule(rule);
 
 		  /* Completion eventuelle de la regle par les infos de type de l'attribut */
@@ -833,17 +889,24 @@ kwattributeDeclaration:
 		  }
 
 		  /* Meta-donnees de l'attribut */
-		  if ($7 != NULL)
+		  if ($8 != NULL)
 		  {
-		    attribute->GetMetaData()->CopyFrom($7);
-		    delete $7;
+		    attribute->GetMetaData()->CopyFrom($8);
+		    delete $8;
+		  }
+
+		  /* Libelle */
+		  if ($9 != NULL)
+		  {
+		    attribute->SetLabel(*($9));
+		    delete $9;
 		  }
 
 		  /* Commentaires */
-		  if ($8 != NULL)
+		  if ($1 != NULL)
 		  {
-		    attribute->SetLabel(*($8));
-		    delete $8;
+		    attribute->SetComments($1);
+		    delete $1;
 		  }
 
 		  $$ = attribute;
@@ -852,8 +915,11 @@ kwattributeDeclaration:
 
 
 
-applicationids:
-      applicationids APPLICATIONID
+applicationids: /* NULL */
+        {
+          $$ = NULL; /* pas d'identification d'application */
+        }
+    | applicationids APPLICATIONID
         {
 		  /* On ne garde que la premiere ligne de chaque identification d'application */
 		  if ($1 == NULL)
@@ -864,52 +930,87 @@ applicationids:
 			$$ = $1;
 		  }
         }
-    | /* NULL */
-        {
-          $$ = NULL; /* pas d'identification d'application */
-        }
     ;
 
 
-comments:
-      comments LABEL
+label: /* NULL */
         {
-		  /* On ne garde que la premiere ligne de chaque commentaire */
-		  if ($1 == NULL)
-            $$ = $2;
-		  else
-		  {
-		    delete $2;
-			$$ = $1;
-		  }
+          $$ = NULL; /* pas de libelle */
         }
-    | /* NULL */
+    | LABEL
+        {
+		  $$ = $1;
+        }
+    ;
+
+comments: /* NULL */
         {
           $$ = NULL; /* pas de commentaire */
         }
+    | comments COMMENT
+        {
+		  StringVector* svComments;
+
+		  /* Creation du vecteur de commentaires si neccesaire */
+		  if ($1 == NULL)
+		    svComments = new StringVector;
+		  else
+		    svComments = $1;
+		  
+		  /* Ajout du commentaire */
+		  svComments->Add(*$2);
+		  delete $2;
+          $$ = svComments;
+        }
     ;
 
-
-rootDeclaration:
-      ROOT
+labelOrComments: /* NULL */
         {
-          $$ = true;
+          $$ = NULL; /* pas de commentaire */
         }
-    | /* NULL */
+    | LABEL
+        {
+		  StringVector* svComments;
+		  svComments = new StringVector;
+		  svComments->Add(*$1);
+		  delete $1;
+          $$ = svComments;
+        }
+    | labelOrComments COMMENT
+        {
+		  StringVector* svComments;
+
+		  /* Creation du vecteur de commentaires si neccesaire */
+		  if ($1 == NULL)
+		    svComments = new StringVector;
+		  else
+		    svComments = $1;
+		  
+		  /* Ajout du commentaire */
+		  svComments->Add(*$2);
+		  delete $2;
+          $$ = svComments;
+        }
+    ;
+
+rootDeclaration: /* NULL */
         {
           $$ = false; /* valeur par defaut */
         }
+    | ROOT
+        {
+          $$ = true;
+        }
     ;
 
 
-usedDeclaration:
-      UNUSED
-        {
-          $$ = false;
-        }
-    | /* NULL */
+usedDeclaration: /* NULL */
         {
           $$ = true; /* valeur par defaut */
+        }
+    | UNUSED
+        {
+          $$ = false;
         }
     ;
 
@@ -962,19 +1063,22 @@ typeDeclaration:
     ;
 
 
-refIdentifier:
-	  '(' IDENTIFIER ')'
-        {
-		  $$ = $2;
-        }
-    | /* NULL */
+refIdentifier:  /* NULL */
         {
 		  $$ = NULL;
+        }
+	 | '(' IDENTIFIER ')'
+        {
+		  $$ = $2;
         }
     ;
 
 
-usedDerivationRule: '=' derivationRule
+usedDerivationRule: /* NULL */
+        {
+		  $$ = NULL;
+        }
+   | '=' derivationRule
 		{
 		  $$ = $2;
 		}
@@ -993,10 +1097,6 @@ usedDerivationRule: '=' derivationRule
 		  yyerror(sTmp + "Invalid syntax (" + *$2 + ")");
 		  if ($2 != NULL)
 		     delete $2;
-		  $$ = NULL;
-        }
-    | /* NULL */
-        {
 		  $$ = NULL;
         }
 		;
@@ -1334,8 +1434,11 @@ bigstring:
 		}
 	;
 
-semicolon:
-      ';'
+semicolon: /* NULL */
+        {
+          yyerror("Missing ';'");
+        }
+   | ';'
    | ';' ';'
         {
           yyerror("There is one superfluous ';'");
@@ -1344,14 +1447,16 @@ semicolon:
         {
           yyerror("Too many ';'");
         }
-   | /* NULL */
-        {
-          yyerror("Missing ';'");
-        }
     ;
 
-openparenthesis:
-      '('
+openparenthesis: /* NULL */
+        {
+		  /* Cette instruction est la pour aider au diagnostique des erreurs */
+		  /* de parenthesage: elle est utile dans ce cas, mais genere (avec  */
+		  /* sa consoeur de nombreux shift/reduce et reduce conflicts        */
+          yyerror("Missing '('");
+        }
+   | '('
    | '(' '('
         {
           yyerror("There is one superfluous '('");
@@ -1360,29 +1465,17 @@ openparenthesis:
         {
           yyerror("Too many '('");
         }
-   | /* NULL */
-        {
-		  /* ERRORMGT */
-		  /* Attention: supprimer cette instruction en cas d'evolution du parser */
-		  /* Cette instruction est la pour aider au diagnostique des erreurs */
-		  /* de parenthesage: elle est utile dans ce cas, mais genere (avec  */
-		  /* sa consoeur 3 shift/reduce conflicts et 12 reduce conflicts     */
-          yyerror("Missing '('");
-        }
     ;
 
 
-closeparenthesis:
-	  ')'
-   | /* NULL */
+closeparenthesis: /* NULL */
         {
-		  /* ERRORMGT */
-		  /* Attention: supprimer cette instruction en cas d'evolution du parser */
 		  /* Cette instruction est la pour aider au diagnostique des erreurs */
 		  /* de parenthesage: elle est utile dans ce cas, mais genere (avec  */
-		  /* sa consoeur 3 shift/reduce conflicts et 12 reduce conflicts     */
+		  /* sa consoeur de nombreux shift/reduce et reduce conflicts        */
           yyerror("Missing ')'");
         }
+   | ')'
 	;
 
 

--- a/src/Learning/KWData/KWCYac.yac
+++ b/src/Learning/KWData/KWCYac.yac
@@ -214,14 +214,17 @@ SIMPLEIDENTIFIER:
     
 kwclassFile: applicationids kwclasses comments
     {
+	  ALString* sId = $1;
+	  StringVector* svComments = $3;
+
 	  // On ignore l'identification d'application
-	  if ($1 != NULL)
-	    delete $1;
+	  if (sId != NULL)
+	    delete sId;
 	
 	  // On interdit les commentaires en fin de fichier
-	  if ($3 != NULL)
+	  if (svComments != NULL)
 	  {
-	    delete $3;
+	    delete svComments;
 	    yyerrorWithLineCorrection("Comments at the end of the file are not allowed", -1);
 	  }
 	}
@@ -237,15 +240,16 @@ kwclasses: // NULL
 kwclass: kwclassBegin comments '}' semicolon
 		{
 		  KWClass* kwcClass=$1;
+		  StringVector* svComments = $2;
 
 		  // La completion des informations de type (CompleteTypeInfo) est centralisee
 		  // au niveau du domaine en fin de parsing
 
 		  // Commentaires internes
-		  if ($2 != NULL)
+		  if (svComments != NULL)
 		  {
-		    kwcClass->SetInternalComments($2);
-			delete $2;
+		    kwcClass->SetInternalComments(svComments);
+			delete svComments;
 		  }
 
 		  // Reinitialisation de la classe courante
@@ -303,40 +307,40 @@ kwclassBegin: kwclassHeader
 	| kwclassBegin comments '{'  oaAttributeArrayDeclaration comments '}' IDENTIFIER usedDerivationRule semicolon metaData label
 		{
 		  KWClass* kwcClass=$1;
-		  KWAttributeBlock* attributeBlock;
+		  StringVector* svComments = $2;
 		  ObjectArray* oaAttributes = $4;
-  		  ALString sBlockName;
+		  StringVector* svInternalComments = $5;
+  		  ALString* sBlockName = $7;
+		  KWDerivationRule* rule = $8;
+		  KWMetaData* metaData = $10;
+		  ALString* sLabel = $11;
+		  KWAttributeBlock* attributeBlock;
 		  KWAttribute* firstAttribute;
 		  KWAttribute* lastAttribute;
-		  KWDerivationRule* rule = $8;
 		  ALString sMessage;
 		  assert(kwcLoadCurrentClass == $1);
 		  check(oaAttributes);
-
-		  // Nom du bloc
-		  if ($7 != NULL)
-		    sBlockName = *($7);
 
 		  // Cas d'un bloc avec au moins un attribut valide
 		  if (oaAttributes->GetSize() > 0)
 		  {
 	        // Test de validite du nom de l'attribut
-		    if (! kwcClass->CheckNameWithMessage(sBlockName, KWClass::AttributeBlock, sMessage))
+		    if (! kwcClass->CheckNameWithMessage(*sBlockName, KWClass::AttributeBlock, sMessage))
 		    {
 		      yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			  ", " + sMessage, -1);
   		    }
 			// Test de non existence parmi les attributs
-		    else if (kwcClass->LookupAttribute(sBlockName) != NULL)
+		    else if (kwcClass->LookupAttribute(*sBlockName) != NULL)
 		    {
 		      yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
-			  ": Sparse variable block name already used by a variable (" + sBlockName + ")", -1);
+			  ": Sparse variable block name already used by a variable (" + *sBlockName + ")", -1);
   		    }
 			// Test de non existence parmi les blocs
-		    else if (kwcClass->LookupAttributeBlock(sBlockName) != NULL)
+		    else if (kwcClass->LookupAttributeBlock(*sBlockName) != NULL)
 		    {
 		      yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
-			  ": Sparse variable block name already used by a block (" + sBlockName + ")", -1);
+			  ": Sparse variable block name already used by a block (" + *sBlockName + ")", -1);
   		    }
  	        // Creation du bloc dans la classe
 			else
@@ -344,18 +348,18 @@ kwclassBegin: kwclassHeader
 			  // Creation du bloc
 		      firstAttribute = cast(KWAttribute*, oaAttributes->GetAt(0));
 		      lastAttribute = cast(KWAttribute*, oaAttributes->GetAt(oaAttributes->GetSize()-1));
-		      attributeBlock = kwcClass->CreateAttributeBlock(sBlockName, firstAttribute, lastAttribute);
+		      attributeBlock = kwcClass->CreateAttributeBlock(*sBlockName, firstAttribute, lastAttribute);
 
 			  // Parametrage du bloc
 			  attributeBlock->SetDerivationRule(rule);
-			  if ($10 != NULL)
-			    attributeBlock->GetMetaData()->CopyFrom($10);
-  		      if ($11 != NULL)
-			    attributeBlock->SetLabel(*($11));
-			  if ($2 != NULL)
-			    attributeBlock->SetComments($2);
-			  if ($5 != NULL)
-			    attributeBlock->SetInternalComments($5);
+			  if (metaData != NULL)
+			    attributeBlock->GetMetaData()->CopyFrom(metaData);
+  		      if (sLabel != NULL)
+			    attributeBlock->SetLabel(*(sLabel));
+			  if (svComments != NULL)
+			    attributeBlock->SetComments(svComments);
+			  if (svInternalComments != NULL)
+			    attributeBlock->SetInternalComments(svInternalComments);
 
 			  // On marque la rule a NULL pour indiquer qu'elle est utilisee
 			  rule = NULL;
@@ -371,16 +375,16 @@ kwclassBegin: kwclassHeader
 		  delete oaAttributes;
 		  
 		  // Nettoyage
-		  if ($2 != NULL)
-		    delete $2;
-		  if ($5 != NULL)
-		    delete $5;
-		  if ($7 != NULL)
-		    delete $7;
-		  if ($10 != NULL)
-		    delete $10;
-		  if ($11 != NULL)
-		    delete $11;
+		  if (svComments != NULL)
+		    delete svComments;
+		  if (svInternalComments != NULL)
+		    delete svInternalComments;
+		  if (sBlockName != NULL)
+		    delete sBlockName;
+		  if (metaData != NULL)
+		    delete metaData;
+		  if (sLabel != NULL)
+		    delete sLabel;
 		  
 		  $$ = kwcClass;
 		  }
@@ -461,8 +465,8 @@ oaAttributeArrayDeclaration :
 		 }
 	| kwattributeDeclaration
         {
-		  ObjectArray* oaAttributes;
 		  KWAttribute* attribute=$1;
+		  ObjectArray* oaAttributes;
 		  KWClass* kwcClass=kwcLoadCurrentClass;
 		  ALString sMessage;
 
@@ -661,22 +665,23 @@ keyFields: // NULL
 fieldList:
 	  fieldList ',' IDENTIFIER
         {
-            StringVector* svFields;
+            StringVector* svFields = $1;
+			ALString* sIdentifier = $3;
             
             // Ajout d'un nouveau de champ
-            svFields = cast(StringVector*, $1);
-            svFields->Add(*$3);
-		    delete $3;
+            svFields->Add(*sIdentifier);
+		    delete sIdentifier;
 			$$ = svFields;
         }
     | IDENTIFIER 
         {
+			ALString* sIdentifier = $1;
             StringVector* svFields;
             
             // Creation d'un tableau de champs, avec un premier champ
             svFields = new StringVector;
-            svFields->Add(*$1);
-		    delete $1;
+            svFields->Add(*sIdentifier);
+		    delete sIdentifier;
 			$$ = svFields;
         }
     ;
@@ -687,79 +692,78 @@ metaData: // NULL
         }
 	| metaData '<' SIMPLEIDENTIFIER '=' STRINGLITTERAL '>'
         {
-            KWMetaData* metaData;
+            KWMetaData* metaData = $1;
+			ALString* sKey = $3;
+			ALString* sValue = $5;
             
             // Creation si necessaire d'une ensemble de paires cles valeur
-			if ($1 == NULL)
+			if (metaData == NULL)
 			    metaData = new KWMetaData;
-			else
-                metaData = cast(KWMetaData*, $1);
 
 			// Erreur si cle deja existante
-			if (metaData->IsKeyPresent(*$3))
-			    yyerror("Duplicate key in meta-data for key " + *($3) );
+			if (metaData->IsKeyPresent(*sKey))
+			    yyerror("Duplicate key in meta-data for key " + *(sKey) );
 			// Insertion d'une paire avec valeur chaine de caracteres sinon
 			else
-			    metaData->SetStringValueAt(*($3), *($5));
-		    delete $3;
-		    delete $5;
+			    metaData->SetStringValueAt(*(sKey), *(sValue));
+		    delete sKey;
+		    delete sValue;
 			$$ = metaData;
         }
 	| metaData '<' SIMPLEIDENTIFIER '=' CONTINUOUSLITTERAL '>'
         {
-            KWMetaData* metaData;
+            KWMetaData* metaData = $1;
+			ALString* sKey = $3;
+			Continuous cValue = $5;
             
             // Creation si necessaire d'une ensemble de paires cles valeur
-			if ($1 == NULL)
+			if (metaData == NULL)
 			    metaData = new KWMetaData;
-			else
-                metaData = cast(KWMetaData*, $1);
 
 			// Erreur si cle deja existante
-			if (metaData->IsKeyPresent(*$3))
-			    yyerror("Duplicate key in meta-data for key " + *($3) );
+			if (metaData->IsKeyPresent(*sKey))
+			    yyerror("Duplicate key in meta-data for key " + *(sKey) );
 			// Erreur si valeur Missing
-			else if ($5 == KWContinuous::GetMissingValue())
-			    yyerror("Missing value not allowed in meta-data for key " + *($3) );
+			else if (cValue == KWContinuous::GetMissingValue())
+			    yyerror("Missing value not allowed in meta-data for key " + *(sKey) );
 			// Insertion d'une paire avec valeur numerique sinon
 			else
-			    metaData->SetDoubleValueAt(*($3), $5);
-		    delete $3;
+			    metaData->SetDoubleValueAt(*(sKey), cValue);
+		    delete sKey;
 			$$ = metaData;
         }
 	| metaData '<' SIMPLEIDENTIFIER '>'
         {
-            KWMetaData* metaData;
+            KWMetaData* metaData = $1;
+			ALString* sKey = $3;
             
             // Creation si necessaire d'une ensemble de paires cles valeur
-			if ($1 == NULL)
+			if (metaData == NULL)
 			    metaData = new KWMetaData;
-			else
-                metaData = cast(KWMetaData*, $1);
 
 			// Erreur si cle deja existante
-			if (metaData->IsKeyPresent(*$3))
-			    yyerror("Duplicate key in meta-data for key " + *($3) );
+			if (metaData->IsKeyPresent(*sKey))
+			    yyerror("Duplicate key in meta-data for key " + *(sKey) );
 			// Insertion d'une paire avec valeur numerique sinon
 			else
-			    metaData->SetNoValueAt(*($3));
-		    delete $3;
+			    metaData->SetNoValueAt(*(sKey));
+		    delete sKey;
 			$$ = metaData;
         }
 	|  metaData '<' SIMPLEIDENTIFIER '=' IDENTIFIER '>'
         {
-            KWMetaData* metaData;
+            KWMetaData* metaData = $1;
+			ALString* sKey = $3;
+			ALString* sValue = $5;
             
             // Creation si necessaire d'une ensemble de paires cles valeur
-			if ($1 == NULL)
+			if (metaData == NULL)
 			    metaData = new KWMetaData;
-			else
-                metaData = cast(KWMetaData*, $1);
 
 			// Erreur car la valeur n'est pas du bon type
-		    yyerror("Value (" + *($5) + ") of meta-data for key " + *($3) + " should be a string value between double quotes");
-		    delete $3;
-		    delete $5;
+		    yyerror("Value (" + *(sValue) + ") of meta-data for key " + *(sKey) + " should be a string value between double quotes");
+		    delete sKey;
+		    delete sValue;
 			$$ = metaData;
         }
     ;
@@ -777,34 +781,41 @@ kwattributeDeclaration:
 	  metaData
 	  label
         {
+		  StringVector* svComments = $1;
+		  boolean bUsed = $2;
+		  int nType = $3;
+		  ALString* sRefIdentifier = $4;
+		  ALString* sIdentifier = $5;
+          KWDerivationRule* rule = $6;
+		  KWMetaData* metaData = $8;
+		  ALString* slabel = $9;
           KWAttribute *attribute;
-          KWDerivationRule* rule;
 
           // Creation  et initialisation d'un attribut
           attribute = new KWAttribute;
-		  attribute->SetUsed($2);
-		  attribute->SetType($3);
+		  attribute->SetUsed(bUsed);
+		  attribute->SetType(nType);
 		  
 		  // Test de coherence entre le type et le complement de type dans le cas d'un type relation
 		  if (KWType::IsRelation(attribute->GetType()))
 		  {
-			 if ($4 == NULL)
-			    yyerrorWithLineCorrection("Variable " + *($5) + " of type " + KWType::ToString($3) + 
-				": missing " +  KWType::ToString($3) + " dictionary", -1);
+			 if (sRefIdentifier == NULL)
+			    yyerrorWithLineCorrection("Variable " + *sIdentifier + " of type " + KWType::ToString(nType) + 
+				": missing " +  KWType::ToString(nType) + " dictionary", -1);
 		  }
 		  // Test de coherence entre le type et le complement de type dans le cas d'un type Structure
 		  else if (attribute->GetType() == KWType::Structure)
 		  {
-			 if ($4 == NULL)
-			    yyerrorWithLineCorrection("Variable " + *($5) + " of type " + KWType::ToString($2) + 
-				": missing " +  KWType::ToString($2) + " dictionary", -1);
+			 if (sRefIdentifier == NULL)
+			    yyerrorWithLineCorrection("Variable " + *sIdentifier + " of type " + KWType::ToString(nType) + 
+				": missing " +  KWType::ToString(nType) + " dictionary", -1);
 		  }
 		  // Test d'absence de complement de type dans les autres cas
 		  else
 		  {
-			 if ($4 != NULL)
-			    yyerrorWithLineCorrection("Variable " + *($5) + " of type " + KWType::ToString($3) + 
-				": erroneous (" +  *($4) + ") type complement", -1);
+			 if (sRefIdentifier != NULL)
+			    yyerrorWithLineCorrection("Variable " + *sIdentifier + " of type " + KWType::ToString(nType) + 
+				": erroneous (" +  *(sRefIdentifier) + ") type complement", -1);
 		  }
 
 		  // Classe referencee
@@ -813,27 +824,27 @@ kwattributeDeclaration:
 		    KWClass* kwcReferencedClass = NULL;
 
             // Test d'existence de la classe
-            if ($4 != NULL)
-              kwcReferencedClass = kwcdLoadDomain->LookupClass(*($4));
+            if (sRefIdentifier != NULL)
+              kwcReferencedClass = kwcdLoadDomain->LookupClass(*sRefIdentifier);
 
             // Sinon, test d'existence de la classe en tant que classe referencee uniquement
-            if (kwcReferencedClass == NULL and $4 != NULL)
-                kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*($4)));
+            if (kwcReferencedClass == NULL and sRefIdentifier != NULL)
+                kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*sRefIdentifier));
 
             // Si la classe n'existe pas, on essaie de la creer
-            if (kwcReferencedClass == NULL and $4 != NULL)
+            if (kwcReferencedClass == NULL and sRefIdentifier != NULL)
 		    {
 		      // Test de nom de classe
-		      if (KWClass::CheckName(*($4), KWClass::Class, NULL))
+		      if (KWClass::CheckName(*sRefIdentifier, KWClass::Class, NULL))
 		      {
                 kwcReferencedClass = new KWClass;
-                kwcReferencedClass->SetName(*($4));
+                kwcReferencedClass->SetName(*sRefIdentifier);
 
 				// Memorisation dans le dictionnaire des classe referencees
                 odReferencedUncreatedClasses->SetAt(kwcReferencedClass->GetName(), kwcReferencedClass);
 		      }
 		      else
-		        yyerrorWithLineCorrection("Incorrect referenced dictionary name (" + *($4) + ")", -1);
+		        yyerrorWithLineCorrection("Incorrect referenced dictionary name (" + *sRefIdentifier + ")", -1);
 		    }
 
 		    // On memorise la classe referencee
@@ -842,16 +853,15 @@ kwattributeDeclaration:
 		  // Structure referencee
 		  else if (attribute->GetType() == KWType::Structure)
 		  {
-		    if ($4 != NULL)
-              attribute->SetStructureName(*($4));
+		    if (sRefIdentifier != NULL)
+              attribute->SetStructureName(*sRefIdentifier);
           }
-          if ($4 != NULL)
-            delete $4;
+          if (sRefIdentifier != NULL)
+            delete sRefIdentifier;
 
 		  // Nom de l'attribut
-		  attribute->SetName (*($5));
-          delete $5; // liberation de la valeur de IDENTIFIER
-          rule = $6;
+		  attribute->SetName (*sIdentifier);
+          delete sIdentifier;
 		  attribute->SetDerivationRule(rule);
 
 		  // Completion eventuelle de la regle par les infos de type de l'attribut
@@ -883,24 +893,24 @@ kwattributeDeclaration:
 		  }
 
 		  // Meta-donnees de l'attribut
-		  if ($8 != NULL)
+		  if (metaData != NULL)
 		  {
-		    attribute->GetMetaData()->CopyFrom($8);
-		    delete $8;
+		    attribute->GetMetaData()->CopyFrom(metaData);
+		    delete metaData;
 		  }
 
 		  // Libelle
-		  if ($9 != NULL)
+		  if (slabel != NULL)
 		  {
-		    attribute->SetLabel(*($9));
-		    delete $9;
+		    attribute->SetLabel(*slabel);
+		    delete slabel;
 		  }
 
 		  // Commentaires
-		  if ($1 != NULL)
+		  if (svComments != NULL)
 		  {
-		    attribute->SetComments($1);
-		    delete $1;
+		    attribute->SetComments(svComments);
+		    delete svComments;
 		  }
 
 		  $$ = attribute;
@@ -943,17 +953,16 @@ comments: // NULL
         }
     | comments COMMENT
         {
-		  StringVector* svComments;
+		  StringVector* svComments = $1;
+		  ALString* sComment = $2;
 
 		  // Creation du vecteur de commentaires si neccesaire
-		  if ($1 == NULL)
+		  if (svComments == NULL)
 		    svComments = new StringVector;
-		  else
-		    svComments = $1;
 		  
 		  // Ajout du commentaire
-		  svComments->Add(*$2);
-		  delete $2;
+		  svComments->Add(*sComment);
+		  delete sComment;
           $$ = svComments;
         }
     ;
@@ -964,25 +973,26 @@ labelOrComments: // NULL
         }
     | LABEL
         {
+		  ALString* sComment = $1;
 		  StringVector* svComments;
+
 		  svComments = new StringVector;
-		  svComments->Add(*$1);
-		  delete $1;
+		  svComments->Add(*sComment);
+		  delete sComment;
           $$ = svComments;
         }
     | labelOrComments COMMENT
         {
-		  StringVector* svComments;
+		  StringVector* svComments = $1;
+		  ALString* sComment = $2;
 
 		  // Creation du vecteur de commentaires si neccesaire
-		  if ($1 == NULL)
+		  if (svComments == NULL)
 		    svComments = new StringVector;
-		  else
-		    svComments = $1;
 		  
 		  // Ajout du commentaire
-		  svComments->Add(*$2);
-		  delete $2;
+		  svComments->Add(*sComment);
+		  delete sComment;
           $$ = svComments;
         }
     ;
@@ -1087,10 +1097,12 @@ usedDerivationRule: // NULL
         }
     |  '(' IDENTIFIER ')'
         { 
+		  ALString* sIdentifier = $2;
 		  ALString sTmp;
-		  yyerror(sTmp + "Invalid syntax (" + *$2 + ")");
-		  if ($2 != NULL)
-		     delete $2;
+
+		  yyerror(sTmp + "Invalid syntax (" + *sIdentifier + ")");
+		  if (sIdentifier != NULL)
+		     delete sIdentifier;
 		  $$ = NULL;
         }
 		;
@@ -1103,8 +1115,8 @@ referenceRule: referenceRuleBody ']'
 
 referenceRuleBody: '[' derivationRuleOperand
 		{
+		  KWDerivationRuleOperand* operand = $2;
 		  KWDerivationRule* rule;
-		  KWDerivationRuleOperand* operand;
 
 		  // Construction d'une regle pour accueillir les specifications
 		  rule = KWDerivationRule::CloneDerivationRule(KWDerivationRule::GetReferenceRuleName());
@@ -1113,7 +1125,6 @@ referenceRuleBody: '[' derivationRuleOperand
 		  rule->DeleteAllOperands();
 		  
 		  // Ajout d'un premier operande: le premier champ de la cle de reference
-		  operand = $2;
 		  if (operand->GetType() == KWType::Unknown)
 		      operand->SetType(KWType::Symbol);
 		  rule->AddOperand(operand);
@@ -1124,10 +1135,9 @@ referenceRuleBody: '[' derivationRuleOperand
 	| referenceRuleBody ',' derivationRuleOperand
 		{
 		  KWDerivationRule* rule = $1;
-		  KWDerivationRuleOperand* operand;
+		  KWDerivationRuleOperand* operand = $3;
 
 		  // Ajout d'un autre operande: un autre champ de la cle de reference
-		  operand = $3;
 		  if (operand->GetType() == KWType::Unknown)
 		      operand->SetType(KWType::Symbol);
 		  rule->AddOperand(operand);
@@ -1139,8 +1149,8 @@ referenceRuleBody: '[' derivationRuleOperand
 
 derivationRule: derivationRuleBody closeparenthesis
 		{
-			boolean bOk = true;
 			KWDerivationRule* ruleBody = $1;
+			boolean bOk = true;
 			KWDerivationRule* rule;
 			ALString sTmp;
 
@@ -1252,9 +1262,9 @@ derivationRuleBody: derivationRuleBegin
 	| derivationRuleBegin ':' operandList
 		{
 		  KWDerivationRule* ruleBody = $1;
+		  ObjectArray* oaOutputOperands = $3;
 		  KWDRRelationCreationRule* ruleRelationCreationBody;
 		  ObjectArray oaOperands;
-		  ObjectArray* oaOutputOperands;
 		  int nOperand;
 		  KWDerivationRuleOperand* operand;
           
@@ -1280,9 +1290,6 @@ derivationRuleBody: derivationRuleBegin
 		      operand = cast(KWDerivationRuleOperand*, oaOperands.GetAt(nOperand));
 			  ruleRelationCreationBody->AddOperand(operand);
 		  }
-
-          // On recupere la liste des operandes en sortie
-          oaOutputOperands = cast(ObjectArray*, $3);
 
 		  // Parametrage des operandes en sortie
 		  assert(ruleRelationCreationBody->GetOutputOperandNumber() == 0);
@@ -1315,8 +1322,8 @@ operandList:
 		}
     | derivationRuleOperand 
 		{
-		  ObjectArray* oaOperandList;
 		  KWDerivationRuleOperand* operand = $1;
+		  ObjectArray* oaOperandList;
 		  check(operand);
 		  
 		  // Creation d'un tableau doperandes, avec un premier operande
@@ -1328,12 +1335,13 @@ operandList:
 
 derivationRuleHeader: IDENTIFIER openparenthesis
 		{
+		  ALString* sIdentifier = $1;
 		  KWDerivationRule* rule;
 
 		  // Construction d'une regle pour accueillir les specification
 		  rule = new KWDerivationRule;
-		  rule->SetName(*($1));
-		  delete $1;
+		  rule->SetName(*sIdentifier);
+		  delete sIdentifier;
 		  $$ = rule;
 		}
 		;
@@ -1366,46 +1374,54 @@ derivationRuleBegin: derivationRuleHeader derivationRuleOperand
 
 derivationRuleOperand: IDENTIFIER 
 		{
+		  ALString* sIdentifier = $1;
 		  KWDerivationRuleOperand* operand;
+
 		  operand = new KWDerivationRuleOperand;
 		  operand->SetOrigin(KWDerivationRuleOperand::OriginAttribute);
-		  operand->SetDataItemName(*($1));
-		  delete $1;
+		  operand->SetDataItemName(*sIdentifier);
+		  delete sIdentifier;
 		  $$ = operand;
 		}
 	| CONTINUOUSLITTERAL
 		{
+		  Continuous cValue = $1;
 		  KWDerivationRuleOperand* operand;
+
 		  operand = new KWDerivationRuleOperand;
 		  operand->SetType(KWType::Continuous);
 		  operand->SetOrigin(KWDerivationRuleOperand::OriginConstant);
-		  operand->SetContinuousConstant($1);
+		  operand->SetContinuousConstant(cValue);
 		  $$ = operand;
 		}
 	| bigstring
 		{
+		  ALString* sValue = $1;
 		  KWDerivationRuleOperand* operand;
+
 		  operand = new KWDerivationRuleOperand;
 		  operand->SetType(KWType::Symbol);
 		  operand->SetOrigin(KWDerivationRuleOperand::OriginConstant);
-		  operand->SetSymbolConstant(Symbol(*($1)));
-		  delete $1;
+		  operand->SetSymbolConstant(Symbol(*sValue));
+		  delete sValue;
 		  $$ = operand;
 		}
 	| derivationRule
 		{
+		  KWDerivationRule* rule = $1;
 		  KWDerivationRuleOperand* operand;
+
 		  operand = new KWDerivationRuleOperand;
 		  operand->SetOrigin(KWDerivationRuleOperand::OriginRule);
-		  operand->SetDerivationRule($1);
+		  operand->SetDerivationRule(rule);
 		  if (operand->GetDerivationRule() != NULL)
 		      operand->SetType(operand->GetDerivationRule()->GetType());
 		  $$ = operand;
 		}
 	| '.' derivationRuleOperand
 		{
-		  KWDerivationRuleOperand* operand;
-		  operand = $2;
+		  KWDerivationRuleOperand* operand = $2;
+
 		  operand->SetScopeLevel(operand->GetScopeLevel()+1);
 		  $$ = operand;
 		}
@@ -1415,12 +1431,15 @@ derivationRuleOperand: IDENTIFIER
 bigstring:
 	  bigstring '+' STRINGLITTERAL
         {
+		  ALString* sValue1 = $1;
+		  ALString* sValue2 = $3;
+
 		  // Concatenation des deux chaines
-          $$ = new ALString (*$1 + *$3);
+          $$ = new ALString (*sValue1 + *sValue2);
 
 		  // Destruction des ancienne chaines
-		  delete $1;
-		  delete $3;
+		  delete sValue1;
+		  delete sValue2;
         }
 	|	STRINGLITTERAL
 		{

--- a/src/Learning/KWData/KWCYac.yac
+++ b/src/Learning/KWData/KWCYac.yac
@@ -1,13 +1,9 @@
 %{
 
-/* ATTENTION: les regles openparenthesis et closeparenthesis generent             */
-/* 3 shift/reduce conflicts et 15 reduce/reduce conflicts                         */
-/* La regle kwclassBegin genere 1 reduce/reduce conflict supplementaire           */
-/* Attention: modifier ces regles en cas d'evolution du parser                    */
-/* Ces regles ne sont utiles que pour le diagnostique des erreurs de parenthesage */
-/* ou de rattrapage sur declaration d'attribut erronee                            */
-/* Ces regles sont reperables par le mot cle ERRORMGT                             */
-
+// ATTENTION: les regles openparenthesis et closeparenthesis generent
+// de nombreux shift/reduce et reduce/reduce conflicts
+// D'autre regles, notamment pour le gestion des commentaires, generent
+// egalement des conflits                   
 
 #include "KWClassDomain.h"
 #include "KWClass.h"
@@ -17,48 +13,47 @@
 #include "KWStructureRule.h"
 #include "KWMetaData.h"
 
-/* Declaration du lexer utilise */
+// Declaration du lexer utilise
 void yyerror(char const *fmt);
 void yyerrorWithLineCorrection(char const *fmt, int nDeltaLineNumber);
 int yylex();
 
-/* Fonctions utilitaires pour rappatrier les information du parser vers une regle */
+// Fonctions utilitaires pour rappatrier les information du parser vers une regle
 boolean ImportParserRuleOperands(const KWDerivationRule* parsedRule, KWDerivationRule* rule);
 boolean ImportParserRuleOutputOperands(const KWDerivationRule* parsedRule, KWDerivationRule* rule);
 boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex, 
                             KWDerivationRuleOperand* parsedOperand, KWDerivationRuleOperand* operand);
 
-/* Work around a bug in the relation between bison and GCC 3.x: */
+// Work around a bug in the relation between bison and GCC 3.x:
 #if defined (__GNUC__) && 3 <= __GNUC__
 #define __attribute__(arglist)
 #endif
 
-/* Domaine de classe courant a utiliser pendant la lecture d'un fichier. */
-/* Ce domaine est positionner par la methode Load de KWClassDomain       */
+// Domaine de classe courant a utiliser pendant la lecture d'un fichier.
+// Ce domaine est positionner par la methode Load de KWClassDomain
 static KWClassDomain* kwcdLoadDomain=NULL;
 
-/* Classe courante a utiliser pendant la lecture d'un fichier.     */
-/* Ce domaine est positionner par la methode Load de KWClassDomain */
+// Classe courante a utiliser pendant la lecture d'un fichier.
+// Ce domaine est positionner par la methode Load de KWClassDomain
 static KWClass* kwcLoadCurrentClass=NULL;
 
-/* Dictionnaire des classes referencees creees a la volee lorsqu'elles sont      */
-/* utilisees, mais non crees.                                                    */
-/* On rajoute les classes referencees non crees, et on retire les classes crees. */
+// Dictionnaire des classes referencees creees a la volee lorsqu'elles sont
+// utilisees, mais non crees.              
+// On rajoute les classes referencees non crees, et on retire les classes crees.
 static ObjectDictionary* odReferencedUncreatedClasses=NULL;
 
-/* Nombre total d'erreurs de parsing */
+// Nombre total d'erreurs de parsing
 static int nFileParsingErrorNumber = 0;
 
 
 #define YY_STATIC
 
-/* Debugging YAC */
-
-/*
-#define YYDEBUG 1 
-extern char   *yyptok(int i); 
+// Debugging YAC
+// Ajouter ici les instruction suivantes
+//   #define YYDEBUG 1 
+//   extern char   *yyptok(int i); 
 // Ajouter l'instruction yydebug = 1 dans le code d'une action du fichier .lex ou .yac
-*/
+
 
 %}
 
@@ -134,7 +129,7 @@ extern char   *yyptok(int i);
 %type <kwmdMetaData> metaData
 
 
-/* Parametrage du destructeur a appeler en cas d'erreur, sauf pour les KWClass <kwcValue> qui sont integree dans des KWClassDomain */
+// Parametrage du destructeur a appeler en cas d'erreur, sauf pour les KWClass <kwcValue> qui sont integree dans des KWClassDomain
 %destructor {if ($$ != NULL) delete $$; $$=NULL;} <sValue> <svValue> <kwdrValue> <kwdroValue> <oaAttributes> <oaOperands> <kwmdMetaData> <kwaValue>
 
 
@@ -219,11 +214,11 @@ SIMPLEIDENTIFIER:
     
 kwclassFile: applicationids kwclasses comments
     {
-	  /* On ignore l'identification d'application */
+	  // On ignore l'identification d'application
 	  if ($1 != NULL)
 	    delete $1;
 	
-	  /* On interdit les commentaires en fin de fichier */
+	  // On interdit les commentaires en fin de fichier
 	  if ($3 != NULL)
 	  {
 	    delete $3;
@@ -232,7 +227,7 @@ kwclassFile: applicationids kwclasses comments
 	}
 	;
 
-kwclasses: /* NULL */
+kwclasses: // NULL
   | kwclasses kwclass
   | kwclasses error 
       { yyerror("Error outside the definition of a dictionary"); 
@@ -243,17 +238,17 @@ kwclass: kwclassBegin comments '}' semicolon
 		{
 		  KWClass* kwcClass=$1;
 
-		  /* La completion des informations de type (CompleteTypeInfo) est centralisee */
-		  /* au niveau du domaine en fin de parsing */
+		  // La completion des informations de type (CompleteTypeInfo) est centralisee
+		  // au niveau du domaine en fin de parsing
 
-		  /* Commentaires internes */
+		  // Commentaires internes
 		  if ($2 != NULL)
 		  {
 		    kwcClass->SetInternalComments($2);
 			delete $2;
 		  }
 
-		  /* Reinitialisation de la classe courante */
+		  // Reinitialisation de la classe courante
   		  kwcLoadCurrentClass = NULL;
 		}
 	;
@@ -270,34 +265,34 @@ kwclassBegin: kwclassHeader
 		  ALString sMessage;
 		  assert(kwcLoadCurrentClass == $1);
 
-		  /* Si attribut non valide: on ne fait rien */
+		  // Si attribut non valide: on ne fait rien
 		  if (attribute == NULL)
 		    ; 
-		  /* Si classe non valide, supression de l'attribut */
+		  // Si classe non valide, supression de l'attribut
 		  else if (kwcClass == NULL)
 		    delete attribute;
-	      /* Sinon, test de validite du nom de l'attribut */
+	      // Sinon, test de validite du nom de l'attribut
 		  else if (! kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			", " + sMessage, -1);
 			delete attribute;
 		  }
-		  /* Test de non existence parmi les attributs */
+		  // Test de non existence parmi les attributs
 		  else if (kwcClass->LookupAttribute(attribute->GetName()) != NULL)
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			": Variable name already used (" + attribute->GetName() + ")", -1);
 			delete attribute;
   		  }
-		  /* Test de non existence parmi les blocs */
+		  // Test de non existence parmi les blocs
 		  else if (kwcClass->LookupAttributeBlock(attribute->GetName()) != NULL)
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			": Variable name already used by a block (" + attribute->GetName() + ")", -1);
 			delete attribute;
   		  }
-		  /* Si OK, d'insertion */
+		  // Si OK, d'insertion
 		  else
 		  {
 		    kwcClass->InsertAttribute(attribute);
@@ -318,40 +313,40 @@ kwclassBegin: kwclassHeader
 		  assert(kwcLoadCurrentClass == $1);
 		  check(oaAttributes);
 
-		  /* Nom du bloc */
+		  // Nom du bloc
 		  if ($7 != NULL)
 		    sBlockName = *($7);
 
-		  /* Cas d'un bloc avec au moins un attribut valide */
+		  // Cas d'un bloc avec au moins un attribut valide
 		  if (oaAttributes->GetSize() > 0)
 		  {
-	        /* Test de validite du nom de l'attribut */
+	        // Test de validite du nom de l'attribut
 		    if (! kwcClass->CheckNameWithMessage(sBlockName, KWClass::AttributeBlock, sMessage))
 		    {
 		      yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			  ", " + sMessage, -1);
   		    }
-			/* Test de non existence parmi les attributs */
+			// Test de non existence parmi les attributs
 		    else if (kwcClass->LookupAttribute(sBlockName) != NULL)
 		    {
 		      yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			  ": Sparse variable block name already used by a variable (" + sBlockName + ")", -1);
   		    }
-			/* Test de non existence parmi les blocs */
+			// Test de non existence parmi les blocs
 		    else if (kwcClass->LookupAttributeBlock(sBlockName) != NULL)
 		    {
 		      yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			  ": Sparse variable block name already used by a block (" + sBlockName + ")", -1);
   		    }
- 	        /* Creation du bloc dans la classe */
+ 	        // Creation du bloc dans la classe
 			else
 			{
-			  /* Creation du bloc */
+			  // Creation du bloc
 		      firstAttribute = cast(KWAttribute*, oaAttributes->GetAt(0));
 		      lastAttribute = cast(KWAttribute*, oaAttributes->GetAt(oaAttributes->GetSize()-1));
 		      attributeBlock = kwcClass->CreateAttributeBlock(sBlockName, firstAttribute, lastAttribute);
 
-			  /* Parametrage du bloc */
+			  // Parametrage du bloc
 			  attributeBlock->SetDerivationRule(rule);
 			  if ($10 != NULL)
 			    attributeBlock->GetMetaData()->CopyFrom($10);
@@ -362,20 +357,20 @@ kwclassBegin: kwclassHeader
 			  if ($5 != NULL)
 			    attributeBlock->SetInternalComments($5);
 
-			  /* On marque la rule a NULL pour indiquer qu'elle est utilisee */
+			  // On marque la rule a NULL pour indiquer qu'elle est utilisee
 			  rule = NULL;
 			}
 		  }
 
-	      /* Destruction de l'eventuelle regle si non utilisee */
+	      // Destruction de l'eventuelle regle si non utilisee
 		  if (rule != NULL)
 		    delete rule;
 
-		  /* Tous les attributs du tableau ont deja ete inseres dans la classe */
-		  // On se contente de detruire le tableau */
+		  // Tous les attributs du tableau ont deja ete inseres dans la classe
+		  // On se contente de detruire le tableau
 		  delete oaAttributes;
 		  
-		  /* Nettoyage */
+		  // Nettoyage
 		  if ($2 != NULL)
 		    delete $2;
 		  if ($5 != NULL)
@@ -393,10 +388,10 @@ kwclassBegin: kwclassHeader
 		{
 		  KWClass* kwcClass=$1;
 
-		  /* Message d'erreur */
+		  // Message d'erreur
 		  yyerror("Empty sparse variable block not allowed");
 
-		  /* Nettoyage */
+		  // Nettoyage
 		  if ($2 != NULL)
 		    delete $2;
 		  if ($4 != NULL)
@@ -412,9 +407,8 @@ kwclassBegin: kwclassHeader
 		  }
 	| kwclassBegin error 
 	    {
-		  /* ERRORMGT */
-		  /* Attention: cette regle qui permet une gestion des erreurs amelioree */
-		  /* genere un conflit reduce/reduce */
+		  // Attention: cette regle qui permet une gestion des erreurs amelioree
+		  // genere un conflit reduce/reduce
 		  kwcLoadCurrentClass = NULL;
 		  YYABORT;
 		}
@@ -429,34 +423,34 @@ oaAttributeArrayDeclaration :
 		  ALString sMessage;
 		  check(oaAttributes);
 
-		  /* Si attribut non valide: on ne fait rien */
+		  // Si attribut non valide: on ne fait rien
 		  if (attribute == NULL)
 		    ; 
-		  /* Si classe non valide, supression de l'attribut */
+		  // Si classe non valide, supression de l'attribut
 		  else if (kwcClass == NULL)
 		    delete attribute;
-	      /* Sinon, test de validite du nom de l'attribut */
+	      // Sinon, test de validite du nom de l'attribut
 		  else if (! kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			", " + sMessage, -1);
 			delete attribute;
 		  }
-		  /* Test de non existence parmi les attributs */
+		  // Test de non existence parmi les attributs
 		  else if (kwcClass->LookupAttribute(attribute->GetName()) != NULL)
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			": Variable name already used (" + attribute->GetName() + ")", -1);
 			delete attribute;
   		  }
-		  /* Test de non existence parmi les blocs */
+		  // Test de non existence parmi les blocs
 		  else if (kwcClass->LookupAttributeBlock(attribute->GetName()) != NULL)
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			": Variable name already used by a block (" + attribute->GetName() + ")", -1);
 			delete attribute;
   		  }
-		  /* Si OK, d'insertion */
+		  // Si OK, d'insertion
 		  else
 		  {
 		    kwcClass->InsertAttribute(attribute);
@@ -472,37 +466,37 @@ oaAttributeArrayDeclaration :
 		  KWClass* kwcClass=kwcLoadCurrentClass;
 		  ALString sMessage;
 
-		  /* Creation d'un tableau */
+		  // Creation d'un tableau
 		  oaAttributes = new ObjectArray;
 
-		  /* Si attribut non valide: on ne fait rien */
+		  // Si attribut non valide: on ne fait rien
 		  if (attribute == NULL)
 		    ; 
-		  /* Si classe non valide, supression de l'attribut */
+		  // Si classe non valide, supression de l'attribut
 		  else if (kwcClass == NULL)
 		    delete attribute;
-	      /* Sinon, test de validite du nom de l'attribut */
+	      // Sinon, test de validite du nom de l'attribut
 		  else if (! kwcClass->CheckNameWithMessage(attribute->GetName(), KWClass::Attribute, sMessage))
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			", " + sMessage, -1);
 			delete attribute;
 		  }
-		  /* Test de non existence parmi les attributs */
+		  // Test de non existence parmi les attributs
 		  else if (kwcClass->LookupAttribute(attribute->GetName()) != NULL)
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			": Variable name already used (" + attribute->GetName() + ")", -1);
 			delete attribute;
   		  }
-		  /* Test de non existence parmi les blocs */
+		  // Test de non existence parmi les blocs
 		  else if (kwcClass->LookupAttributeBlock(attribute->GetName()) != NULL)
 		  {
 		    yyerrorWithLineCorrection("Dictionary " + kwcClass->GetName() + 
 			": Variable name already used by a block (" + attribute->GetName() + ")", -1);
 			delete attribute;
   		  }
-		  /* Si OK, d'insertion */
+		  // Si OK, d'insertion
 		  else
 		  {
 		    kwcClass->InsertAttribute(attribute);
@@ -535,34 +529,34 @@ kwclassHeader: comments
 		  int i;
 		  ALString sMessage;
 
-          /* Test d'existence de la classe */
+          // Test d'existence de la classe
           kwcClass = kwcdLoadDomain->LookupClass(*sIdentifier);
 
-          /* Test d'existence de la classe en tant que classe referencee uniquement */
+          // Test d'existence de la classe en tant que classe referencee uniquement
           kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*sIdentifier));
 		  assert(kwcReferencedClass == NULL or kwcClass == NULL);
 
-          /* Erreur si la classe existe deja */
+          // Erreur si la classe existe deja
           if (kwcClass != NULL)
           {
             yyerror("Dictionary " + *sIdentifier + " already exists");
    	        kwcClass = NULL;
           }
-		  /* On utilise la classe referencee si elle existe */
+		  // On utilise la classe referencee si elle existe
 		  else if (kwcReferencedClass != NULL)
 		  {
-		     /* Insertion dans le domaine */
+		     // Insertion dans le domaine
 		     kwcClass = kwcReferencedClass;
 			 kwcdLoadDomain->InsertClass(kwcClass);
 
-			 /* Supression de la classe referencees */
+			 // Supression de la classe referencees
 			 odReferencedUncreatedClasses->RemoveKey(kwcReferencedClass->GetName());
 			 kwcReferencedClass = NULL;
 		  }
- 		  /* Sinon, on cree la classe et on l'enregistre */
+ 		  // Sinon, on cree la classe et on l'enregistre
           else
           {
-		    /* Test de nom de classe */
+		    // Test de nom de classe
 		    if (KWClass::CheckNameWithMessage(*sIdentifier, KWClass::Class, sMessage))
 		    {
               kwcClass = new KWClass;
@@ -573,33 +567,33 @@ kwclassHeader: comments
 		      yyerror(sMessage);
           }
 
-		  /* Initialisation si necessaire de la classe */
+		  // Initialisation si necessaire de la classe
 		  if (kwcClass != NULL)
 		  {
-		    /* Commentaire de la classe en cours */
+		    // Commentaire de la classe en cours
 			svClassComments.CopyFrom(kwcClass->GetComments());
 
-            /* Classe racine */
+            // Classe racine
             kwcClass->SetRoot(bRoot);
             
-            /* Attribut key field */
+            // Attribut key field
             if (svKeyFields!=NULL)
             {
-              // Transfert des champs de la cle */ 
+              // Transfert des champs de la cle 
               svKeyFields = cast(StringVector*, svKeyFields);
               kwcClass->SetKeyAttributeNumber(svKeyFields->GetSize());
               for (i = 0; i < svKeyFields->GetSize(); i++)
                 kwcClass->SetKeyAttributeNameAt(i, svKeyFields->GetAt(i));
             }
 
-			/* Meta-donnees de la classe */
+			// Meta-donnees de la classe
 			if (metaData != NULL)
 			    kwcClass->GetMetaData()->CopyFrom(metaData);
 
-			/* On recupere les commentaires existants */
+			// On recupere les commentaires existants
 			svAllComments.CopyFrom(kwcClass->GetComments()); 
 
- 		    /* On recupere tous les commentaires entre le debut et la fin de la declaration de la classe */
+ 		    // On recupere tous les commentaires entre le debut et la fin de la declaration de la classe
             if (svComments1!=NULL)
 			{
 			  for (i = 0; i < svComments1->GetSize(); i++)
@@ -621,7 +615,7 @@ kwclassHeader: comments
 			    svAllComments.Add(svComments4->GetAt(i));
 			}
 
-			/* Libelle de la classe: le premier des commentaires, sauf s'il existe deja */
+			// Libelle de la classe: le premier des commentaires, sauf s'il existe deja
 			nCommentStartIndex = 0;
 			if (kwcClass->GetLabel() == "" and svAllComments.GetSize() > 0)
 			{
@@ -629,7 +623,7 @@ kwclassHeader: comments
 			  nCommentStartIndex = 1;
 			}
 
-			/* Mise a jour des commentaires de la classe, en excluant potentiellement le premier commentaire reserve au libelle */
+			// Mise a jour des commentaires de la classe, en excluant potentiellement le premier commentaire reserve au libelle
 			if (svAllComments.GetSize() > 0)
 			{
   	          for (i = nCommentStartIndex; i < svAllComments.GetSize(); i++)
@@ -638,7 +632,7 @@ kwclassHeader: comments
 			}
           }
 
-          /* Liberation des tokens */
+          // Liberation des tokens
           delete sIdentifier;
           if (svKeyFields!=NULL) delete svKeyFields;
           if (metaData!=NULL) delete metaData;
@@ -647,16 +641,16 @@ kwclassHeader: comments
           if (svComments3!=NULL) delete svComments3;
           if (svComments4!=NULL) delete svComments4;
 
-		  /* Memorisation de la classe courante */
+		  // Memorisation de la classe courante
 		  kwcLoadCurrentClass = kwcClass;
 		  $$ = kwcClass;
 	   }
 	   ;
  
 
-keyFields: /* NULL */
+keyFields: // NULL
         {
-          $$ = NULL; /* pas de champ cle */
+          $$ = NULL; // pas de champ cle
         }
     | '(' fieldList ')'
         {
@@ -669,7 +663,7 @@ fieldList:
         {
             StringVector* svFields;
             
-            /* Ajout d'un nouveau de champ */
+            // Ajout d'un nouveau de champ
             svFields = cast(StringVector*, $1);
             svFields->Add(*$3);
 		    delete $3;
@@ -679,7 +673,7 @@ fieldList:
         {
             StringVector* svFields;
             
-            /* Creation d'un tableau de champs, avec un premier champ */
+            // Creation d'un tableau de champs, avec un premier champ
             svFields = new StringVector;
             svFields->Add(*$1);
 		    delete $1;
@@ -687,24 +681,24 @@ fieldList:
         }
     ;
 
-metaData: /* NULL */
+metaData: // NULL
         {
-          $$ = NULL; /* pas de paires cle valeurs */
+          $$ = NULL; // pas de paires cle valeurs
         }
 	| metaData '<' SIMPLEIDENTIFIER '=' STRINGLITTERAL '>'
         {
             KWMetaData* metaData;
             
-            /* Creation si necessaire d'une ensemble de paires cles valeur */
+            // Creation si necessaire d'une ensemble de paires cles valeur
 			if ($1 == NULL)
 			    metaData = new KWMetaData;
 			else
                 metaData = cast(KWMetaData*, $1);
 
-			/* Erreur si cle deja existante */
+			// Erreur si cle deja existante
 			if (metaData->IsKeyPresent(*$3))
 			    yyerror("Duplicate key in meta-data for key " + *($3) );
-			/* Insertion d'une paire avec valeur chaine de caracteres sinon */
+			// Insertion d'une paire avec valeur chaine de caracteres sinon
 			else
 			    metaData->SetStringValueAt(*($3), *($5));
 		    delete $3;
@@ -715,19 +709,19 @@ metaData: /* NULL */
         {
             KWMetaData* metaData;
             
-            /* Creation si necessaire d'une ensemble de paires cles valeur */
+            // Creation si necessaire d'une ensemble de paires cles valeur
 			if ($1 == NULL)
 			    metaData = new KWMetaData;
 			else
                 metaData = cast(KWMetaData*, $1);
 
-			/* Erreur si cle deja existante */
+			// Erreur si cle deja existante
 			if (metaData->IsKeyPresent(*$3))
 			    yyerror("Duplicate key in meta-data for key " + *($3) );
-			/* Erreur si valeur Missing */
+			// Erreur si valeur Missing
 			else if ($5 == KWContinuous::GetMissingValue())
 			    yyerror("Missing value not allowed in meta-data for key " + *($3) );
-			/* Insertion d'une paire avec valeur numerique sinon */
+			// Insertion d'une paire avec valeur numerique sinon
 			else
 			    metaData->SetDoubleValueAt(*($3), $5);
 		    delete $3;
@@ -737,16 +731,16 @@ metaData: /* NULL */
         {
             KWMetaData* metaData;
             
-            /* Creation si necessaire d'une ensemble de paires cles valeur */
+            // Creation si necessaire d'une ensemble de paires cles valeur
 			if ($1 == NULL)
 			    metaData = new KWMetaData;
 			else
                 metaData = cast(KWMetaData*, $1);
 
-			/* Erreur si cle deja existante */
+			// Erreur si cle deja existante
 			if (metaData->IsKeyPresent(*$3))
 			    yyerror("Duplicate key in meta-data for key " + *($3) );
-			/* Insertion d'une paire avec valeur numerique sinon */
+			// Insertion d'une paire avec valeur numerique sinon
 			else
 			    metaData->SetNoValueAt(*($3));
 		    delete $3;
@@ -756,13 +750,13 @@ metaData: /* NULL */
         {
             KWMetaData* metaData;
             
-            /* Creation si necessaire d'une ensemble de paires cles valeur */
+            // Creation si necessaire d'une ensemble de paires cles valeur
 			if ($1 == NULL)
 			    metaData = new KWMetaData;
 			else
                 metaData = cast(KWMetaData*, $1);
 
-			/* Erreur car la valeur n'est pas du bon type */
+			// Erreur car la valeur n'est pas du bon type
 		    yyerror("Value (" + *($5) + ") of meta-data for key " + *($3) + " should be a string value between double quotes");
 		    delete $3;
 		    delete $5;
@@ -786,26 +780,26 @@ kwattributeDeclaration:
           KWAttribute *attribute;
           KWDerivationRule* rule;
 
-          /* Creation  et initialisation d'un attribut */
+          // Creation  et initialisation d'un attribut
           attribute = new KWAttribute;
 		  attribute->SetUsed($2);
 		  attribute->SetType($3);
 		  
-		  /* Test de coherence entre le type et le complement de type dans le cas d'un type relation */
+		  // Test de coherence entre le type et le complement de type dans le cas d'un type relation
 		  if (KWType::IsRelation(attribute->GetType()))
 		  {
 			 if ($4 == NULL)
 			    yyerrorWithLineCorrection("Variable " + *($5) + " of type " + KWType::ToString($3) + 
 				": missing " +  KWType::ToString($3) + " dictionary", -1);
 		  }
-		  /* Test de coherence entre le type et le complement de type dans le cas d'un type Structure */
+		  // Test de coherence entre le type et le complement de type dans le cas d'un type Structure
 		  else if (attribute->GetType() == KWType::Structure)
 		  {
 			 if ($4 == NULL)
 			    yyerrorWithLineCorrection("Variable " + *($5) + " of type " + KWType::ToString($2) + 
 				": missing " +  KWType::ToString($2) + " dictionary", -1);
 		  }
-		  /* Test d'absence de complement de type dans les autres cas */
+		  // Test d'absence de complement de type dans les autres cas
 		  else
 		  {
 			 if ($4 != NULL)
@@ -813,39 +807,39 @@ kwattributeDeclaration:
 				": erroneous (" +  *($4) + ") type complement", -1);
 		  }
 
-		  /* Classe referencee */
+		  // Classe referencee
 		  if (KWType::IsRelation(attribute->GetType()))
 		  {
 		    KWClass* kwcReferencedClass = NULL;
 
-            /* Test d'existence de la classe */
+            // Test d'existence de la classe
             if ($4 != NULL)
               kwcReferencedClass = kwcdLoadDomain->LookupClass(*($4));
 
-            /* Sinon, test d'existence de la classe en tant que classe referencee uniquement */
+            // Sinon, test d'existence de la classe en tant que classe referencee uniquement
             if (kwcReferencedClass == NULL and $4 != NULL)
                 kwcReferencedClass = cast(KWClass*, odReferencedUncreatedClasses->Lookup(*($4)));
 
-            /* Si la classe n'existe pas, on essaie de la creer */
+            // Si la classe n'existe pas, on essaie de la creer
             if (kwcReferencedClass == NULL and $4 != NULL)
 		    {
-		      /* Test de nom de classe */
+		      // Test de nom de classe
 		      if (KWClass::CheckName(*($4), KWClass::Class, NULL))
 		      {
                 kwcReferencedClass = new KWClass;
                 kwcReferencedClass->SetName(*($4));
 
-				/* Memorisation dans le dictionnaire des classe referencees */
+				// Memorisation dans le dictionnaire des classe referencees
                 odReferencedUncreatedClasses->SetAt(kwcReferencedClass->GetName(), kwcReferencedClass);
 		      }
 		      else
 		        yyerrorWithLineCorrection("Incorrect referenced dictionary name (" + *($4) + ")", -1);
 		    }
 
-		    /* On memorise la classe referencee */
+		    // On memorise la classe referencee
 		    attribute->SetClass(kwcReferencedClass);
           }
-		  /* Structure referencee */
+		  // Structure referencee
 		  else if (attribute->GetType() == KWType::Structure)
 		  {
 		    if ($4 != NULL)
@@ -854,13 +848,13 @@ kwattributeDeclaration:
           if ($4 != NULL)
             delete $4;
 
-		  /* Nom de l'attribut */
+		  // Nom de l'attribut
 		  attribute->SetName (*($5));
-          delete $5; /* liberation de la valeur de IDENTIFIER */
+          delete $5; // liberation de la valeur de IDENTIFIER
           rule = $6;
 		  attribute->SetDerivationRule(rule);
 
-		  /* Completion eventuelle de la regle par les infos de type de l'attribut */
+		  // Completion eventuelle de la regle par les infos de type de l'attribut
 		  if (rule != NULL)
 		  {
             // Completion specifique dans le cas de la regle de gestion des references
@@ -888,21 +882,21 @@ kwattributeDeclaration:
                 attribute->GetDerivationRule()->GetName() + " (" + KWType::ToString(attribute->GetDerivationRule()->GetType()) + "(" + rule->GetStructureName() + "))", -1);
 		  }
 
-		  /* Meta-donnees de l'attribut */
+		  // Meta-donnees de l'attribut
 		  if ($8 != NULL)
 		  {
 		    attribute->GetMetaData()->CopyFrom($8);
 		    delete $8;
 		  }
 
-		  /* Libelle */
+		  // Libelle
 		  if ($9 != NULL)
 		  {
 		    attribute->SetLabel(*($9));
 		    delete $9;
 		  }
 
-		  /* Commentaires */
+		  // Commentaires
 		  if ($1 != NULL)
 		  {
 		    attribute->SetComments($1);
@@ -915,13 +909,13 @@ kwattributeDeclaration:
 
 
 
-applicationids: /* NULL */
+applicationids: // NULL
         {
-          $$ = NULL; /* pas d'identification d'application */
+          $$ = NULL; // pas d'identification d'application
         }
     | applicationids APPLICATIONID
         {
-		  /* On ne garde que la premiere ligne de chaque identification d'application */
+		  // On ne garde que la premiere ligne de chaque identification d'application
 		  if ($1 == NULL)
             $$ = $2;
 		  else
@@ -933,9 +927,9 @@ applicationids: /* NULL */
     ;
 
 
-label: /* NULL */
+label: // NULL
         {
-          $$ = NULL; /* pas de libelle */
+          $$ = NULL; // pas de libelle
         }
     | LABEL
         {
@@ -943,30 +937,30 @@ label: /* NULL */
         }
     ;
 
-comments: /* NULL */
+comments: // NULL
         {
-          $$ = NULL; /* pas de commentaire */
+          $$ = NULL; // pas de commentaire
         }
     | comments COMMENT
         {
 		  StringVector* svComments;
 
-		  /* Creation du vecteur de commentaires si neccesaire */
+		  // Creation du vecteur de commentaires si neccesaire
 		  if ($1 == NULL)
 		    svComments = new StringVector;
 		  else
 		    svComments = $1;
 		  
-		  /* Ajout du commentaire */
+		  // Ajout du commentaire
 		  svComments->Add(*$2);
 		  delete $2;
           $$ = svComments;
         }
     ;
 
-labelOrComments: /* NULL */
+labelOrComments: // NULL
         {
-          $$ = NULL; /* pas de commentaire */
+          $$ = NULL; // pas de commentaire
         }
     | LABEL
         {
@@ -980,22 +974,22 @@ labelOrComments: /* NULL */
         {
 		  StringVector* svComments;
 
-		  /* Creation du vecteur de commentaires si neccesaire */
+		  // Creation du vecteur de commentaires si neccesaire
 		  if ($1 == NULL)
 		    svComments = new StringVector;
 		  else
 		    svComments = $1;
 		  
-		  /* Ajout du commentaire */
+		  // Ajout du commentaire
 		  svComments->Add(*$2);
 		  delete $2;
           $$ = svComments;
         }
     ;
 
-rootDeclaration: /* NULL */
+rootDeclaration: // NULL
         {
-          $$ = false; /* valeur par defaut */
+          $$ = false; // valeur par defaut
         }
     | ROOT
         {
@@ -1004,9 +998,9 @@ rootDeclaration: /* NULL */
     ;
 
 
-usedDeclaration: /* NULL */
+usedDeclaration: // NULL
         {
-          $$ = true; /* valeur par defaut */
+          $$ = true; // valeur par defaut
         }
     | UNUSED
         {
@@ -1063,7 +1057,7 @@ typeDeclaration:
     ;
 
 
-refIdentifier:  /* NULL */
+refIdentifier:  // NULL
         {
 		  $$ = NULL;
         }
@@ -1074,7 +1068,7 @@ refIdentifier:  /* NULL */
     ;
 
 
-usedDerivationRule: /* NULL */
+usedDerivationRule: // NULL
         {
 		  $$ = NULL;
         }
@@ -1112,19 +1106,19 @@ referenceRuleBody: '[' derivationRuleOperand
 		  KWDerivationRule* rule;
 		  KWDerivationRuleOperand* operand;
 
-		  /* Construction d'une regle pour accueillir les specifications */
+		  // Construction d'une regle pour accueillir les specifications
 		  rule = KWDerivationRule::CloneDerivationRule(KWDerivationRule::GetReferenceRuleName());
 		
-		  /* Destruction des operandes */
+		  // Destruction des operandes
 		  rule->DeleteAllOperands();
 		  
-		  /* Ajout d'un premier operande: le premier champ de la cle de reference */
+		  // Ajout d'un premier operande: le premier champ de la cle de reference
 		  operand = $2;
 		  if (operand->GetType() == KWType::Unknown)
 		      operand->SetType(KWType::Symbol);
 		  rule->AddOperand(operand);
 		  
-		  /* On retourner la regle */
+		  // On retourner la regle
 		  $$ = rule;
 		}
 	| referenceRuleBody ',' derivationRuleOperand
@@ -1132,13 +1126,13 @@ referenceRuleBody: '[' derivationRuleOperand
 		  KWDerivationRule* rule = $1;
 		  KWDerivationRuleOperand* operand;
 
-		  /* Ajout d'un autre operande: un autre champ de la cle de reference */
+		  // Ajout d'un autre operande: un autre champ de la cle de reference
 		  operand = $3;
 		  if (operand->GetType() == KWType::Unknown)
 		      operand->SetType(KWType::Symbol);
 		  rule->AddOperand(operand);
 		  
-		  /* On retourner la regle */
+		  // On retourner la regle
 		  $$ = rule;
 		}
 	;
@@ -1150,52 +1144,52 @@ derivationRule: derivationRuleBody closeparenthesis
 			KWDerivationRule* rule;
 			ALString sTmp;
 
-			/* Recherche de la regle de reference */
-			/* On ensuite recuperer au maximum les informations de la regle clonee */
-			/* et rapatrier les informations issues du parsing concernant les operandes */
+			// Recherche de la regle de reference
+			// On ensuite recuperer au maximum les informations de la regle clonee
+			// et rapatrier les informations issues du parsing concernant les operandes
 			check(ruleBody);
 			rule = KWDerivationRule::CloneDerivationRule(ruleBody->GetName());
 
-			/* Erreur si regle inexistante */
+			// Erreur si regle inexistante
 			if (rule == NULL)
 			{
 				yyerror("Unknown derivation rule '" + ruleBody->GetName() + "'");
 				bOk = false;
 			}
-			/* Erreur si regle predefinie de Reference */
+			// Erreur si regle predefinie de Reference
 			else if (rule->GetName() == KWDerivationRule::GetReferenceRuleName())
 			{
 				yyerror("Unknown derivation rule '" + ruleBody->GetName() + "'");
 				bOk = false;
 			}
 
-			/* Import des operandes de la regle */
+			// Import des operandes de la regle
 			if (bOk)
 				bOk = ImportParserRuleOperands(ruleBody, rule);
 
-			/* Gestion des operandes en sortie dans le cas ou le parser a stocke des operandes en sortie */
+			// Gestion des operandes en sortie dans le cas ou le parser a stocke des operandes en sortie
 			if (bOk and KWType::IsRelation(ruleBody->GetType()) and not ruleBody->GetReference())
 			{
-				/* Erreur si la regle en cours n'est pas une regle de creation d'instance */
+				// Erreur si la regle en cours n'est pas une regle de creation d'instance
 				if (not KWType::IsRelation(rule->GetType()) or rule->GetReference())
 				{
 					yyerror(sTmp + "Derivation rule " + rule->GetName() +
 						" does not accept output operands");
 					bOk = false;
 				}
-				/* Sinon, transfert des operandes en sortie */
+				// Sinon, transfert des operandes en sortie
 				else
 				{
-					/* Import des operandes en sortie de la regle */
-					/* On est passe prealablement dans le parser par une regle de creation de relation */
-					/* pour stocker les operandes en sortie, que l'on va ici exploiter */
+					// Import des operandes en sortie de la regle
+					// On est passe prealablement dans le parser par une regle de creation de relation
+					// pour stocker les operandes en sortie, que l'on va ici exploiter
 					bOk = ImportParserRuleOutputOperands(ruleBody, rule);
 				}
 			}
-			/* Gestion des operandes en sortie dans le cas ou le parser n'a stocke des operandes en sortie */
+			// Gestion des operandes en sortie dans le cas ou le parser n'a stocke des operandes en sortie
 			else if (bOk and KWType::IsRelation(rule->GetType()) and not rule->GetReference())
 			{
-				/* Test du nombre d'operandes en sortie */
+				// Test du nombre d'operandes en sortie
 				if ((rule->GetVariableOutputOperandNumber() and rule->GetOutputOperandNumber() > 1) or
     				(not rule->GetVariableOutputOperandNumber() and rule->GetOutputOperandNumber() > 0))
 				{
@@ -1204,19 +1198,19 @@ derivationRule: derivationRuleBody closeparenthesis
 						(rule->GetVariableOutputOperandNumber() ? 1 : 0)) + ")");
 					bOk = false;
 				}
-				/* Supression des eventuels operandes en sortie inutiles */
+				// Supression des eventuels operandes en sortie inutiles
 				else if (rule->GetOutputOperandNumber() > 0)
 					cast(KWDRRelationCreationRule*, rule)->DeleteAllOutputOperands();
 			}
 
-			/* Verification de la definition de la regle */
+			// Verification de la definition de la regle
 			if (bOk and not rule->CheckDefinition())
 			{
 				yyerror(sTmp + "Derivation rule " + rule->GetName() + " incorrectly specified");
 				bOk = false;
 			}
 
-			/* Test si erreur dans le transfert des operandes */
+			// Test si erreur dans le transfert des operandes
 			if (not bOk)
 			{
 				if (rule != NULL)
@@ -1225,18 +1219,18 @@ derivationRule: derivationRuleBody closeparenthesis
 					rule = NULL;
 				}
 			}
-			/* Sinon, on tente de compresser la regle */
+			// Sinon, on tente de compresser la regle
 			else
 			{
 				if (rule->IsStructureRule())
 				{
 					KWDRStructureRule* structureRule;
 
-					/* Acces a la regle de structure, transformation au format structure et nettoyage memoire */
-					/* Cette optimisation memoire des regles structure est critique dans le cas de dictionnaires */
-					/* de tres grande taille. Sinon, des millions d'operandes de regles sont potentiellement crees, */
-					/* puis lors de la compilation des dictionnaire, l'essentiel de la memoire liberee laisse des trous */
-					/* dans les segments de la heap, qui ne peuvent etre rendus au systeme */
+					// Acces a la regle de structure, transformation au format structure et nettoyage memoire
+					// Cette optimisation memoire des regles structure est critique dans le cas de dictionnaires
+					// de tres grande taille. Sinon, des millions d'operandes de regles sont potentiellement crees,
+					// puis lors de la compilation des dictionnaire, l'essentiel de la memoire liberee laisse des trous
+					// dans les segments de la heap, qui ne peuvent etre rendus au systeme
 					assert(rule->CheckDefinition());
 					structureRule = cast(KWDRStructureRule*, rule);
 					structureRule->BuildStructureFromBase(rule);
@@ -1244,7 +1238,7 @@ derivationRule: derivationRuleBody closeparenthesis
 				}
 			}
 
-			/* Finalisation */
+			// Finalisation
 			delete ruleBody;
 			$$ = rule;
 		}
@@ -1264,7 +1258,7 @@ derivationRuleBody: derivationRuleBegin
 		  int nOperand;
 		  KWDerivationRuleOperand* operand;
           
-		  /* On passe par une regle de creation de relation pour stocker les operandes en sortie */
+		  // On passe par une regle de creation de relation pour stocker les operandes en sortie
 		  ruleRelationCreationBody = new KWDRRelationCreationRule;
 
 		  // On transfer les operande initiaux vers un tableau
@@ -1275,22 +1269,22 @@ derivationRuleBody: derivationRuleBegin
 		  }
 		  ruleBody->RemoveAllOperands();
 
-		  /* On copie la regle initiale, maintenant nettoyee de ses operandes */
+		  // On copie la regle initiale, maintenant nettoyee de ses operandes
 		  ruleBody->SetType(KWType::ObjectArray);
 		  ruleRelationCreationBody->CopyFrom(ruleBody);
 		  delete ruleBody;
 
-		  /* On recupere les operandes initiaux */
+		  // On recupere les operandes initiaux
 		  for (nOperand = 0; nOperand < oaOperands.GetSize(); nOperand++)
 		  {
 		      operand = cast(KWDerivationRuleOperand*, oaOperands.GetAt(nOperand));
 			  ruleRelationCreationBody->AddOperand(operand);
 		  }
 
-          /* On recupere la liste des operandes en sortie */
+          // On recupere la liste des operandes en sortie
           oaOutputOperands = cast(ObjectArray*, $3);
 
-		  /* Parametrage des operandes en sortie */
+		  // Parametrage des operandes en sortie
 		  assert(ruleRelationCreationBody->GetOutputOperandNumber() == 0);
 		  for (nOperand = 0; nOperand < oaOutputOperands->GetSize(); nOperand++)
 		  {
@@ -1315,7 +1309,7 @@ operandList:
 		  check(oaOperandList);
 		  check(operand);
 
-		  /* Ajout d'un operande */
+		  // Ajout d'un operande
 		  oaOperandList->Add(operand);
 		  $$ = oaOperandList;
 		}
@@ -1325,7 +1319,7 @@ operandList:
 		  KWDerivationRuleOperand* operand = $1;
 		  check(operand);
 		  
-		  /* Creation d'un tableau doperandes, avec un premier operande */
+		  // Creation d'un tableau doperandes, avec un premier operande
 		  oaOperandList = new ObjectArray;
 		  oaOperandList->Add(operand);
 		  $$ = oaOperandList;
@@ -1336,7 +1330,7 @@ derivationRuleHeader: IDENTIFIER openparenthesis
 		{
 		  KWDerivationRule* rule;
 
-		  /* Construction d'une regle pour accueillir les specification */
+		  // Construction d'une regle pour accueillir les specification
 		  rule = new KWDerivationRule;
 		  rule->SetName(*($1));
 		  delete $1;
@@ -1421,10 +1415,10 @@ derivationRuleOperand: IDENTIFIER
 bigstring:
 	  bigstring '+' STRINGLITTERAL
         {
-		  /* Concatenation des deux chaines */
+		  // Concatenation des deux chaines
           $$ = new ALString (*$1 + *$3);
 
-		  /* Destruction des ancienne chaines */
+		  // Destruction des ancienne chaines
 		  delete $1;
 		  delete $3;
         }
@@ -1434,7 +1428,7 @@ bigstring:
 		}
 	;
 
-semicolon: /* NULL */
+semicolon: // NULL
         {
           yyerror("Missing ';'");
         }
@@ -1449,11 +1443,11 @@ semicolon: /* NULL */
         }
     ;
 
-openparenthesis: /* NULL */
+openparenthesis: // NULL
         {
-		  /* Cette instruction est la pour aider au diagnostique des erreurs */
-		  /* de parenthesage: elle est utile dans ce cas, mais genere (avec  */
-		  /* sa consoeur de nombreux shift/reduce et reduce conflicts        */
+		  // Cette instruction est la pour aider au diagnostic des erreurs
+		  // de parenthesage: elle est utile dans ce cas, mais genere (avec
+		  // sa consoeur de nombreux shift/reduce et reduce conflicts
           yyerror("Missing '('");
         }
    | '('
@@ -1468,11 +1462,11 @@ openparenthesis: /* NULL */
     ;
 
 
-closeparenthesis: /* NULL */
+closeparenthesis: // NULL
         {
-		  /* Cette instruction est la pour aider au diagnostique des erreurs */
-		  /* de parenthesage: elle est utile dans ce cas, mais genere (avec  */
-		  /* sa consoeur de nombreux shift/reduce et reduce conflicts        */
+		  // Cette instruction est la pour aider au diagnostic des erreurs
+		  // de parenthesage: elle est utile dans ce cas, mais genere (avec
+		  // sa consoeur de nombreux shift/reduce et reduce conflicts
           yyerror("Missing ')'");
         }
    | ')'
@@ -1485,20 +1479,20 @@ closeparenthesis: /* NULL */
 #include "KWCLex.inc"
 
 
-/* default yywrap that tells yylex to return 0 */
+// default yywrap that tells yylex to return 0
 int yywrap()
 {
   return 1;
 }
 
 
-/* default yyerror for YACC and LEX */
+// default yyerror for YACC and LEX
 void yyerror(char const *fmt)
 {
    yyerrorWithLineCorrection(fmt, 0);
 }
 
-/* Variante avec une correction du numero de ligne */
+// Variante avec une correction du numero de ligne
 void yyerrorWithLineCorrection(char const *fmt, int nDeltaLineNumber)
 {
   char sErrorLine[20];
@@ -1527,7 +1521,7 @@ boolean ImportParserRuleOperands(const KWDerivationRule* parsedRule, KWDerivatio
 	require(parsedRule != NULL);
 	require(rule != NULL);
 
-	/* Test du nombre d'operandes */
+	// Test du nombre d'operandes
 	if ((rule->GetVariableOperandNumber() and parsedRule->GetOperandNumber() < rule->GetOperandNumber() - 1) or
 	    (not rule->GetVariableOperandNumber() and parsedRule->GetOperandNumber() != rule->GetOperandNumber()))
 
@@ -1537,11 +1531,11 @@ boolean ImportParserRuleOperands(const KWDerivationRule* parsedRule, KWDerivatio
 			IntToString(rule->GetOperandNumber()) + ")");
 		bOk = false;
 	}
-	/* Verification et transfert des operandes */
+	// Verification et transfert des operandes
 	else
 	{
-		/* Dans le cas d'un nombre variable d'operandes, on commence par rajouter */
-		/* eventuellement des operandes en fin de regle pour preparer l'instanciation */
+		// Dans le cas d'un nombre variable d'operandes, on commence par rajouter
+		// eventuellement des operandes en fin de regle pour preparer l'instanciation
 		if (parsedRule->GetOperandNumber() > rule->GetOperandNumber())
 		{
 			assert(rule->GetVariableOperandNumber());
@@ -1549,8 +1543,8 @@ boolean ImportParserRuleOperands(const KWDerivationRule* parsedRule, KWDerivatio
 				rule->AddOperand(rule->GetOperandAt(rule->GetOperandNumber() - 1)->Clone());
 		}
 
-		/* Dans le cas d'un nombre variable d'operandes, on supprime eventuellement */
-		/* le dernier operande, qui n'est pas obligatoire */
+		// Dans le cas d'un nombre variable d'operandes, on supprime eventuellement
+		// le dernier operande, qui n'est pas obligatoire
 		if (parsedRule->GetOperandNumber() < rule->GetOperandNumber())
 		{
 			assert(rule->GetVariableOperandNumber());
@@ -1559,14 +1553,14 @@ boolean ImportParserRuleOperands(const KWDerivationRule* parsedRule, KWDerivatio
 		}
 		assert(parsedRule->GetOperandNumber() == rule->GetOperandNumber());
 
-		/* Transfert des operandes */
+		// Transfert des operandes
 		for (i = 0; i < rule->GetOperandNumber(); i++)
 		{
-			/* acces aux operandes */
+			// acces aux operandes
 			operand = rule->GetOperandAt(i);
 			parsedOperand = parsedRule->GetOperandAt(i);
 
-			/* Import de l'operande */
+			// Import de l'operande
 			bOk = ImportParserOperand(rule->GetName(), i, parsedOperand, operand);
 			if (not bOk)
 				break;
@@ -1589,7 +1583,7 @@ boolean ImportParserRuleOutputOperands(const KWDerivationRule* parsedRule, KWDer
 	require(not parsedRule->GetReference());
 	require(not rule->GetReference());
 
-	/* Test du nombre d'operandes en sortie */
+	// Test du nombre d'operandes en sortie
 	if ((rule->GetVariableOutputOperandNumber() and parsedRule->GetOutputOperandNumber() < rule->GetOutputOperandNumber() - 1) or
 	    (not rule->GetVariableOutputOperandNumber() and parsedRule->GetOutputOperandNumber() != rule->GetOutputOperandNumber()))
 
@@ -1599,14 +1593,14 @@ boolean ImportParserRuleOutputOperands(const KWDerivationRule* parsedRule, KWDer
 			IntToString(rule->GetOutputOperandNumber()) + ")");
 		bOk = false;
 	}
-	/* Verification et transfert des operandes en sortie */
+	// Verification et transfert des operandes en sortie
 	else
 	{
-		/* Cast de la regle a alimenter en regle de creation de relation pour acceder a ses methodes dediees */
+		// Cast de la regle a alimenter en regle de creation de relation pour acceder a ses methodes dediees
 		creationRule = cast(KWDRRelationCreationRule*, rule);
 
-		/* Dans le cas d'un nombre variable d'operandes en sortie, on commence par rajouter */
-		/* eventuellement des operandes en fin de regle pour preparer l'instanciation */
+		// Dans le cas d'un nombre variable d'operandes en sortie, on commence par rajouter
+		// eventuellement des operandes en fin de regle pour preparer l'instanciation
 		if (parsedRule->GetOutputOperandNumber() > rule->GetOutputOperandNumber())
 		{
 			assert(rule->GetVariableOutputOperandNumber());
@@ -1614,8 +1608,8 @@ boolean ImportParserRuleOutputOperands(const KWDerivationRule* parsedRule, KWDer
 				creationRule->AddOutputOperand(rule->GetOutputOperandAt(rule->GetOutputOperandNumber() - 1)->Clone());
 		}
 
-		/* Dans le cas d'un nombre variable d'operandes en sortie, on supprime eventuellement */
-		/* le dernier operande, qui n'est pas obligatoire */
+		// Dans le cas d'un nombre variable d'operandes en sortie, on supprime eventuellement
+		// le dernier operande, qui n'est pas obligatoire
 		if (parsedRule->GetOutputOperandNumber() < rule->GetOutputOperandNumber())
 		{
 			assert(rule->GetVariableOutputOperandNumber());
@@ -1624,14 +1618,14 @@ boolean ImportParserRuleOutputOperands(const KWDerivationRule* parsedRule, KWDer
 		}
 		assert(parsedRule->GetOutputOperandNumber() == rule->GetOutputOperandNumber());
 
-		/* Transfert des operandes en sortie */
+		// Transfert des operandes en sortie
 		for (i = 0; i < rule->GetOutputOperandNumber(); i++)
 		{
-			/* acces aux operandes en sortie */
+			// acces aux operandes en sortie
 			operand = rule->GetOutputOperandAt(i);
 			parsedOperand = parsedRule->GetOutputOperandAt(i);
 
-			/* Import de l'operande */
+			// Import de l'operande
 			bOk = ImportParserOperand(rule->GetName(), i, parsedOperand, operand);
 			if (not bOk)
 				break;
@@ -1649,7 +1643,7 @@ boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex,
 	require(parsedOperand != NULL);
 	require(operand != NULL);
 
-	/* Transfert d'informations de la regle de reference vers la regle a verifier */
+	// Transfert d'informations de la regle de reference vers la regle a verifier
 	if (parsedOperand->GetOrigin() != KWDerivationRuleOperand::OriginConstant)
 	{
 		parsedOperand->SetType(operand->GetType());
@@ -1662,39 +1656,39 @@ boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex,
 		parsedOperand->SetStructureName(operand->GetStructureName());
 	}
 
-	/* Test si operande candidate valide */
+	// Test si operande candidate valide
 	if (not parsedOperand->CheckDefinition())
 	{
 		bOk = false;
 		yyerror(sTmp + "Incorrect operand " + IntToString(1 + nOperandIndex) + " for rule " + sRuleName);
 	}
-	/* Test de compatibilite avec la regle enregistree, sauf si regle avec operande de type indetermine */
+	// Test de compatibilite avec la regle enregistree, sauf si regle avec operande de type indetermine
 	else if (operand->GetType() != KWType::Unknown and not parsedOperand->CheckFamily(operand))
 	{
 		bOk = false;
 		yyerror(sTmp + "Operand " + IntToString(1 + nOperandIndex) + " inconsistent with that of rule " +
 			sRuleName);
 	}
-	/* Transfert de l'origine de l'operande */
+	// Transfert de l'origine de l'operande
 	else
 	{
-		/* Transfert du niveau de scope */
+		// Transfert du niveau de scope
 		operand->SetScopeLevel(parsedOperand->GetScopeLevel());
 
-		/* Transfert d'une valeur constante */
+		// Transfert d'une valeur constante
 		operand->SetOrigin(parsedOperand->GetOrigin());
 		if (operand->GetOrigin() == KWDerivationRuleOperand::OriginConstant)
 		{
 			operand->SetType(parsedOperand->GetType());
 			operand->SetStringConstant(parsedOperand->GetStringConstant());
 		}
-		/* Transfert d'un attribut */
+		// Transfert d'un attribut
 		else if (operand->GetOrigin() == KWDerivationRuleOperand::OriginAttribute)
 			operand->SetDataItemName(parsedOperand->GetDataItemName());
 		else
-		/* Transfert d'une regle */
+		// Transfert d'une regle
 		{
-			// Transfert de la regle */
+			// Transfert de la regle
 			if (operand->GetDerivationRule() != NULL)
 			{
 				assert(parsedOperand->GetDerivationRule() != NULL);
@@ -1702,7 +1696,7 @@ boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex,
 			}
 			operand->SetDerivationRule(parsedOperand->GetDerivationRule());
 
-			/* Transfert des infos portees par la regle de derivation */
+			// Transfert des infos portees par la regle de derivation
 			if (operand->GetDerivationRule() != NULL)
 			{
 				operand->SetType(operand->GetDerivationRule()->GetType());
@@ -1712,7 +1706,7 @@ boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex,
 					operand->SetStructureName(operand->GetDerivationRule()->GetStructureName());
 			}
 
-			/* Dereferencement de la regle de derivation depuis l'operande de travail */
+			// Dereferencement de la regle de derivation depuis l'operande de travail
 			parsedOperand->SetDerivationRule(NULL);
 		}
 	}
@@ -1723,7 +1717,7 @@ boolean ImportParserOperand(const ALString& sRuleName, int nOperandIndex,
 int yyparse();
 
 
-/* Implementation de la methode de lecture de fichier de KWClassDomain */
+// Implementation de la methode de lecture de fichier de KWClassDomain
 boolean KWClassDomain::ReadFile(const ALString& sFileName)
 {
   boolean bOk = true;
@@ -1735,29 +1729,29 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
   KWClass* kwcClass;
   ALString sLocalFileName;
 
-  /* Affichage de stats memoire si log memoire actif */
+  // Affichage de stats memoire si log memoire actif
   MemoryStatsManager::AddLog(GetClassLabel() + " " + sFileName + " ReadFile Begin");
 
-  /* Initialisation du domaine de classe a utiliser pour le Load */
+  // Initialisation du domaine de classe a utiliser pour le Load
   assert(kwcdLoadDomain == NULL);
   kwcdLoadDomain = this;
 
-  /* Initialisation de la classe courante a utiliser pour le Load */
+  // Initialisation de la classe courante a utiliser pour le Load
   assert(kwcLoadCurrentClass == NULL);
   kwcLoadCurrentClass = NULL;
 
-  /* Creation du dictionnaire des classes referencees non crees */
+  // Creation du dictionnaire des classes referencees non crees
   assert(odReferencedUncreatedClasses == NULL);
   odReferencedUncreatedClasses = new ObjectDictionary;
 
-  /* Erreur si pas de nom de fichier */
+  // Erreur si pas de nom de fichier
   fFile = NULL;
   if (sFileName == "")
   {
      AddError("Missing file name");
 	 bOk = false;
   }
-  /* Sinon, ouverture du fichier */
+  // Sinon, ouverture du fichier
   else
   { 
 		// Copie depuis HDFS si necessaire
@@ -1766,39 +1760,39 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 			bOk = FileService::OpenInputBinaryFile(sLocalFileName, fFile);
   }
 
-  /* On continue si fichier ouvert correctement */
+  // On continue si fichier ouvert correctement
   if (bOk)
   {
     assert(fFile != NULL);
 
-    /* Memorisation de toutes les classes initiales */
+    // Memorisation de toutes les classes initiales
     kwcdLoadDomain->ExportClassDictionary(&odInitialClasses);
 
-	/* Activation du nombre max d'erreurs a afficher */
+	// Activation du nombre max d'erreurs a afficher
 	nFileParsingErrorNumber = 0;
 	Global::ActivateErrorFlowControl();
 
-    /* Positionnement du fichier a parser par la variable yyin de LEX */
+    // Positionnement du fichier a parser par la variable yyin de LEX
     yylineno = 1;
     yyrestart(fFile);
     
-	/* Parsing */
+	// Parsing
     yyparse();
 
-	/* Cleaning lexer */
+	// Cleaning lexer
 	yylex_destroy();
 
-    /* Fermeture du fichier */
+    // Fermeture du fichier
 	FileService::CloseInputBinaryFile(sLocalFileName, fFile);
 	
-	/* Si HDFS on supprime la copie locale */
+	// Si HDFS on supprime la copie locale
 	PLRemoteFileService::CleanInputWorkingFile(sFileName, sLocalFileName);
 
-	/* Completion des informations de type au niveau du domaine */
+	// Completion des informations de type au niveau du domaine
 	if (nFileParsingErrorNumber == 0)
 	  kwcdLoadDomain->CompleteTypeInfo();
 
-	/* Lecture des informations privees depuis les meta donnees */
+	// Lecture des informations privees depuis les meta donnees
 	if (nFileParsingErrorNumber == 0)
 	{
 		for (i = 0; i < kwcdLoadDomain->GetClassNumber(); i++)
@@ -1808,7 +1802,7 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 		}
 	}
 
-    /* Messages d'erreur pour les classes referencees non crees */
+    // Messages d'erreur pour les classes referencees non crees
 	if (nFileParsingErrorNumber > 0 or odReferencedUncreatedClasses->GetCount() > 0)
 	{
 	  odReferencedUncreatedClasses->ExportObjectArray(&oaReferencedUncreatedClasses);
@@ -1819,19 +1813,19 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 	  }
 	}
 
-	/* Desactivation du nombre max d'erreurs a afficher */
+	// Desactivation du nombre max d'erreurs a afficher
 	Global::DesactivateErrorFlowControl();
 
-    /* Destruction des classes crees si au moins une erreur de parsing detectee */
-	/* ou au moins une classe referencee non cree                               */
+    // Destruction des classes crees si au moins une erreur de parsing detectee
+	// ou au moins une classe referencee non cree
 	if (nFileParsingErrorNumber > 0 or odReferencedUncreatedClasses->GetCount() > 0)
     {
-	  /* En cas d'erreur, ajout d'une ligne blanche pour separer des autres logs */
+	  // En cas d'erreur, ajout d'une ligne blanche pour separer des autres logs
       AddError("Errors detected during parsing " + sFileName + ": read operation cancelled");
 	  AddSimpleMessage("");
 	  bOk = false;
 
- 	  /* Recherche des nouvelles classes crees */
+ 	  // Recherche des nouvelles classes crees
 	  for (i = 0; i < kwcdLoadDomain->GetClassNumber(); i++)
 	  {
 	    kwcClass = kwcdLoadDomain->GetClassAt(i);
@@ -1839,26 +1833,26 @@ boolean KWClassDomain::ReadFile(const ALString& sFileName)
 	      oaNewClasses.Add(kwcClass);
 	  }
 
-	  /* Destruction des classes nouvellement crees */
+	  // Destruction des classes nouvellement crees
 	  for (i = 0; i < oaNewClasses.GetSize(); i++)
 	  {
 	    kwcClass = cast(KWClass*, oaNewClasses.GetAt(i));
 	    kwcdLoadDomain->DeleteClass(kwcClass->GetName());
 	  }
 
-	  /* Destruction des classes referencees non crees */
+	  // Destruction des classes referencees non crees
       odReferencedUncreatedClasses->DeleteAll();
 	}
 	nFileParsingErrorNumber = 0;
   }
 
-  /* Nettoyage */
+  // Nettoyage
   kwcdLoadDomain = NULL;
   kwcLoadCurrentClass = NULL;
   delete odReferencedUncreatedClasses;
   odReferencedUncreatedClasses = NULL;
 
-  /* Affichage de stats memoire si log memoire actif */
+  // Affichage de stats memoire si log memoire actif
   MemoryStatsManager::AddLog(GetClassLabel() + " " + sFileName + " ReadFile End");
 
   return bOk;

--- a/src/Learning/KWData/KWClass.cpp
+++ b/src/Learning/KWData/KWClass.cpp
@@ -1950,7 +1950,7 @@ void KWClass::WriteJSONKeyReport(JSONFile* fJSON, const ALString& sKey)
 
 int KWClass::GetNameMaxLength()
 {
-	return 128;
+	return nNameMaxLength;
 }
 
 const ALString KWClass::EntityToString(int nEntity)
@@ -2073,16 +2073,15 @@ boolean KWClass::CheckNameWithMessage(const ALString& sValue, int nEntity, ALStr
 
 boolean KWClass::CheckLabelWithMessage(const ALString& sValue, int nEntity, ALString& sMessage)
 {
-	const int nMaxLabelLength = 100000;
 	boolean bOk = true;
 
 	require(0 <= nEntity and nEntity < Unknown);
 
 	// Test de la taille maximale
-	bOk = sValue.GetLength() <= nMaxLabelLength;
+	bOk = sValue.GetLength() <= nLabelMaxLength;
 	if (not bOk)
 		sMessage = "Incorrect " + EntityToString(nEntity) + " label : length > " +
-			   IntToString(nMaxLabelLength) + " (" + GetShortValue(sValue) + ")";
+			   IntToString(nLabelMaxLength) + " (" + GetShortValue(sValue) + ")";
 
 	// Test de caractere fin de ligne
 	if (bOk)
@@ -2098,8 +2097,6 @@ boolean KWClass::CheckLabelWithMessage(const ALString& sValue, int nEntity, ALSt
 
 boolean KWClass::CheckCommentsWithMessage(const StringVector* svValue, int nEntity, ALString& sMessage)
 {
-	const int nMaxCommentNumber = 100000;
-	const int nMaxCommentLength = 100000;
 	boolean bOk = true;
 	int i;
 
@@ -2107,10 +2104,10 @@ boolean KWClass::CheckCommentsWithMessage(const StringVector* svValue, int nEnti
 	require(0 <= nEntity and nEntity < Unknown);
 
 	// Test de la taille maximale
-	bOk = svValue->GetSize() <= nMaxCommentNumber;
+	bOk = svValue->GetSize() <= nCommentMaxNumber;
 	if (not bOk)
 		sMessage = "Incorrect " + EntityToString(nEntity) + " comments : comment line number " +
-			   IntToString(svValue->GetSize()) + " > " + IntToString(nMaxCommentNumber);
+			   IntToString(svValue->GetSize()) + " > " + IntToString(nCommentMaxNumber);
 
 	// Test des commentaires
 	if (bOk)
@@ -2118,10 +2115,10 @@ boolean KWClass::CheckCommentsWithMessage(const StringVector* svValue, int nEnti
 		for (i = 0; i < svValue->GetSize(); i++)
 		{
 			// Test de la taille maximale
-			bOk = svValue->GetAt(i).GetLength() <= nMaxCommentLength;
+			bOk = svValue->GetAt(i).GetLength() <= nCommentMaxLength;
 			if (not bOk)
 				sMessage = "Incorrect " + EntityToString(nEntity) + " comment line " +
-					   IntToString(i + 1) + " : length > " + IntToString(nMaxCommentLength) + " (" +
+					   IntToString(i + 1) + " : length > " + IntToString(nCommentMaxLength) + " (" +
 					   GetShortValue(svValue->GetAt(i)) + ")";
 
 			// Test de caractere fin de ligne

--- a/src/Learning/KWData/KWClass.cpp
+++ b/src/Learning/KWData/KWClass.cpp
@@ -1583,6 +1583,8 @@ void KWClass::CopyFrom(const KWClass* aSource)
 					    attributeBlock->GetDerivationRule()->Clone());
 				copyAttributeBlock->GetMetaData()->CopyFrom(attributeBlock->GetConstMetaData());
 				copyAttributeBlock->SetLabel(attributeBlock->GetLabel());
+				copyAttributeBlock->SetComments(attributeBlock->GetComments());
+				copyAttributeBlock->SetInternalComments(attributeBlock->GetInternalComments());
 			}
 		}
 
@@ -1816,7 +1818,7 @@ void KWClass::Write(ostream& ost) const
 	KWAttributeBlock* attributeBlock;
 	int i;
 
-	// Impression de l'entete de la classe
+	// Entete de la classe
 	ost << "\n";
 	if (GetLabel() != "")
 		ost << "// " << GetLabel() << "\n";
@@ -1847,59 +1849,22 @@ void KWClass::Write(ostream& ost) const
 	}
 	ost << "{\n";
 
-	// Impression de tous les attributs
+	// Attributs et blocs d'attributs
 	attribute = GetHeadAttribute();
 	while (attribute != NULL)
 	{
-		// Debut de bloc si necessaire
+		// Bloc, au moment du premier attribut du bloc
 		if (attribute->IsFirstInBlock())
-			ost << "\t{\n";
-
-		// Impression de l'attribut
-		ost << *attribute << "\n";
-
-		// Fin de bloc si necessaire
-		if (attribute->IsLastInBlock())
-		{
-			ost << "\t}";
-
-			// Nom du bloc
-			attributeBlock = attribute->GetAttributeBlock();
-			ost << "\t" << KWClass::GetExternalName(attributeBlock->GetName());
-			ost << "\t";
-
-			// Regle de derivation
-			if (attributeBlock->GetDerivationRule() != NULL)
-			{
-				// Dans le cas de la regle predefinie de Reference, on n'utilise pas le signe '='
-				if (attributeBlock->GetDerivationRule()->GetName() !=
-				    KWDerivationRule::GetReferenceRuleName())
-					ost << " = ";
-				attributeBlock->GetDerivationRule()->WriteUsedRule(ost);
-			}
-
-			// Fin de declaration
-			ost << "\t;";
-
-			// Meta-donnees
-			if (attributeBlock->GetConstMetaData()->GetKeyNumber() > 0)
-			{
-				ost << ' ';
-				attributeBlock->GetConstMetaData()->Write(ost);
-			}
-			ost << "\t";
-
-			// Commentaire
-			if (attributeBlock->GetLabel() != "")
-				ost << "// " << attributeBlock->GetLabel();
-			ost << "\n";
-		}
+			ost << *attribute->GetAttributeBlock() << "\n";
+		// Attribut, s'il n'est pas dans un bloc
+		else if (not attribute->IsInBlock())
+			ost << *attribute << "\n";
 
 		// Attribut suivant
 		GetNextAttribute(attribute);
 	}
 
-	// Impression de la fin de la classe
+	// Commentaire internes
 	for (i = 0; i < GetInternalComments()->GetSize(); i++)
 		ost << "\t// " << GetInternalComments()->GetAt(i) << "\n";
 	ost << "};\n";
@@ -1948,10 +1913,10 @@ void KWClass::WriteJSONFields(JSONFile* fJSON)
 	attribute = GetHeadAttribute();
 	while (attribute != NULL)
 	{
-		// Debut de bloc si necessaire
+		// Bloc, au moment du premier attribut du bloc
 		if (attribute->IsFirstInBlock())
 			attribute->GetAttributeBlock()->WriteJSONReport(fJSON);
-		// Impression de l'attribut s'il n'est pas dans un bloc
+		// Attribut, s'il n'est pas dans un bloc
 		else if (not attribute->IsInBlock())
 			attribute->WriteJSONReport(fJSON);
 

--- a/src/Learning/KWData/KWClass.cpp
+++ b/src/Learning/KWData/KWClass.cpp
@@ -1815,7 +1815,6 @@ longint KWClass::ComputeHashValue() const
 void KWClass::Write(ostream& ost) const
 {
 	KWAttribute* attribute;
-	KWAttributeBlock* attributeBlock;
 	int i;
 
 	// Entete de la classe

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -68,14 +68,14 @@ public:
 	KWMetaData* GetMetaData();
 
 	// Libelle
-	// Premiere ligne prefixee par '//' precedent la declaration du dictionnaire
+	// Premiere ligne prefixee par '//' precedant la declaration du dictionnaire
 	// dans le fichier dictionnaire
 	const ALString& GetLabel() const;
 	void SetLabel(const ALString& sValue);
 
 	// Commentaires
 	// Ensemble des lignes prefixees par '//', entre le libelle et le debut de la declaration du dictionnaire
-	// Par tolerance du parser, on accepte egalement tout commentaire situee apres la partie obligatoire
+	// Par tolerance du parser, on accepte egalement tout commentaire situe apres la partie obligatoire
 	// de la declaration du dictionnaire (("Root") "Dictionary" <Name>)
 	// - avant la declaration de cle
 	// - avant la declaration de meta-donnees
@@ -724,6 +724,12 @@ protected:
 	int nFreshness;
 	int nIndexFreshness;
 	int nCompileFreshness;
+
+	// Limites sur la longueur des noms de variables, libelles et commentaires
+	static const int nNameMaxLength = 128;
+	static const int nLabelMaxLength = 100000;
+	static const int nCommentMaxNumber = 100000;
+	static const int nCommentMaxLength = 100000;
 };
 
 #include "KWAttribute.h"

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -68,8 +68,28 @@ public:
 	KWMetaData* GetMetaData();
 
 	// Libelle
+	// Premiere ligne prefixee par '//' precedent la declaration du dictionnaire
+	// dans le fichier dictionnaire
 	const ALString& GetLabel() const;
 	void SetLabel(const ALString& sValue);
+
+	// Commentaires
+	// Ensemble des lignes prefixees par '//', entre le libelle et le debut de la declaration du dictionnaire
+	// Par tolerance du parser, on accepte egalement tout commentaire situee apres la partie obligatoire
+	// de la declaration du dictionnaire (("Root") "Dictionary" <Name>)
+	// - avant la declaration de cle
+	// - avant la declaration de meta-donnees
+	// - avant le tout debut du bloc '{'
+	// Il s'agit uniquement d'une tolerance: tous les commentaires presents avant, au milieu, ou apres la
+	// declaration seront concatenes et re-ecrit apres le libelle, avant le debut de la declaration du dictionnaire
+	const StringVector* GetComments() const;
+	void SetComments(const StringVector* svValue);
+
+	// Commentaires internes
+	// Ensemble des lignes prefixees par '//', precedents la fin du bloc '}'
+	// de declaration des variables dans le fichier dictionnaire
+	const StringVector* GetInternalComments() const;
+	void SetInternalComments(const StringVector* svValue);
 
 	// Classe racine ou composant(par defaut: false -> component)
 	// Une classe racine gere sa destruction memoire, alors qu'une
@@ -427,10 +447,15 @@ public:
 	// par la classe passee en parametre (pas de message si NULL)
 	static boolean CheckName(const ALString& sValue, int nEntity, const Object* errorSender);
 	static boolean CheckLabel(const ALString& sValue, int nEntity, const Object* errorSender);
+	static boolean CheckComments(const StringVector* svValue, int nEntity, const Object* errorSender);
 
 	// Methode similaire avec message est alimente avec la cause de l'erreur
 	static boolean CheckNameWithMessage(const ALString& sValue, int nEntity, ALString& sMessage);
 	static boolean CheckLabelWithMessage(const ALString& sValue, int nEntity, ALString& sMessage);
+	static boolean CheckCommentsWithMessage(const StringVector* svValue, int nEntity, ALString& sMessage);
+
+	// Renvoie une version courte d'une chaine de caractere en entree, avec "..." en fin de chaine si necessaire
+	static const ALString GetShortValue(const ALString& sValue);
 
 	// Extraction d'une sous-chaine valide pour le format utf8
 	static ALString BuildUTF8SubString(const ALString sValue);
@@ -619,6 +644,12 @@ protected:
 	// Libelle
 	KWCDUniqueString usLabel;
 
+	// Commentaires
+	StringVector svComments;
+
+	// Commentaires internes
+	StringVector svInternalComments;
+
 	// Statut racine ou composant
 	boolean bRoot;
 
@@ -732,8 +763,27 @@ inline const ALString& KWClass::GetLabel() const
 
 inline void KWClass::SetLabel(const ALString& sValue)
 {
-	require(CheckLabel(sValue, KWClass::Class, this));
 	usLabel.SetValue(sValue);
+}
+
+inline const StringVector* KWClass::GetComments() const
+{
+	return &svComments;
+}
+
+inline void KWClass::SetComments(const StringVector* svValue)
+{
+	svComments.CopyFrom(svValue);
+}
+
+inline const StringVector* KWClass::GetInternalComments() const
+{
+	return &svInternalComments;
+}
+
+inline void KWClass::SetInternalComments(const StringVector* svValue)
+{
+	svInternalComments.CopyFrom(svValue);
 }
 
 inline boolean KWClass::GetRoot() const

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -106,10 +106,10 @@ void KWMTDatabase::CopyFrom(const KWDatabase* kwdSource)
 
 			// Insertion de la copie du mapping composant correspondant
 			mappingCopy->GetComponentTableMappings()->Add(
-			    LookupMultiTableMapping(mappingComponent->GetDataPath()));
+				LookupMultiTableMapping(mappingComponent->GetDataPath()));
 		}
 		assert(mappingCopy->GetComponentTableMappings()->GetSize() ==
-		       mapping->GetComponentTableMappings()->GetSize());
+			mapping->GetComponentTableMappings()->GetSize());
 	}
 
 	// Memorisation des warnings pour les dictionnaires racines non utilises
@@ -343,8 +343,8 @@ void KWMTDatabase::UpdateMultiTableMappings()
 		// Creation du mapping de la table principale
 		assert(svAttributeName.GetSize() == 0);
 		mainMultiTableMapping =
-		    CreateMapping(&odReferenceClasses, &oaRankedReferenceClasses, &odAnalysedCreatedClasses, mainClass,
-				  false, mainClass->GetName(), &svAttributeName, &oaMultiTableMappings);
+			CreateMapping(&odReferenceClasses, &oaRankedReferenceClasses, &odAnalysedCreatedClasses, mainClass,
+				false, mainClass->GetName(), &svAttributeName, &oaMultiTableMappings);
 		assert(svAttributeName.GetSize() == 0);
 		if (bTrace)
 			WriteMapingArray(cout, "- main mappings " + mainClass->GetName(), &oaMultiTableMappings);
@@ -369,9 +369,9 @@ void KWMTDatabase::UpdateMultiTableMappings()
 				oaWorkingCreatedMappings.RemoveAll();
 				assert(svAttributeName.GetSize() == 0);
 				mapping = CreateMapping(&odWorkingReferenceClasses, &oaWorkingRankedReferenceClasses,
-							&odWorkingAnalysedCreatedClasses, referenceClass, true,
-							referenceClass->GetName(), &svAttributeName,
-							&oaWorkingCreatedMappings);
+					&odWorkingAnalysedCreatedClasses, referenceClass, true,
+					referenceClass->GetName(), &svAttributeName,
+					&oaWorkingCreatedMappings);
 				assert(svAttributeName.GetSize() == 0);
 
 				// On determine si le dictionnaire de reference est utilisable, c'est a dire s'il n'utilise
@@ -404,24 +404,24 @@ void KWMTDatabase::UpdateMultiTableMappings()
 					// Et il n'y a aucun enjeu d'optimisation
 					assert(svAttributeName.GetSize() == 0);
 					mapping = CreateMapping(&odReferenceClasses, &oaRankedReferenceClasses,
-								&odAnalysedCreatedClasses, referenceClass, true,
-								referenceClass->GetName(), &svAttributeName,
-								oaCreatedMappings);
+						&odAnalysedCreatedClasses, referenceClass, true,
+						referenceClass->GetName(), &svAttributeName,
+						oaCreatedMappings);
 					assert(svAttributeName.GetSize() == 0);
 					if (bTrace)
 						WriteMapingArray(cout,
-								 "- external mappings " + referenceClass->GetName(),
-								 oaCreatedMappings);
+							"- external mappings " + referenceClass->GetName(),
+							oaCreatedMappings);
 				}
 				// Sinon, memorisation d'un warning expliquant pourquoi on ne garde le dictionnaire racine en reference
 				else
 				{
 					sWarning =
-					    "Root dictionary " + referenceClass->GetName() +
-					    " referenced from the main dictionary " + mainClass->GetName() +
-					    " is not kept to specify database files in order to avoid circular "
-					    "references in the schema, as it itself uses the main dictionary in its "
-					    "secondary tables";
+						"Root dictionary " + referenceClass->GetName() +
+						" referenced from the main dictionary " + mainClass->GetName() +
+						" is not kept to specify database files in order to avoid circular "
+						"references in the schema, as it itself uses the main dictionary in its "
+						"secondary tables";
 					svUnusedRootDictionaryWarnings.Add(sWarning);
 					if (bTrace)
 						cout << "- " << sWarning << "\n";
@@ -481,7 +481,7 @@ void KWMTDatabase::UpdateMultiTableMappings()
 
 				// Transfert des specifications de la table mappee si comparaison positive
 				if (mapping->GetOriginClassName() == previousMapping->GetOriginClassName() and
-				    mapping->GetDataPathAttributeNames() ==
+					mapping->GetDataPathAttributeNames() ==
 					previousMapping->GetDataPathAttributeNames())
 				{
 					mapping->SetDataTableName(previousMapping->GetDataTableName());
@@ -500,10 +500,10 @@ void KWMTDatabase::UpdateMultiTableMappings()
 	// Affichage des mappings finaux
 	if (bTrace)
 		WriteMapingArray(cout, "Database " + GetDatabaseName() + " " + GetClassName() + " mappings",
-				 &oaMultiTableMappings);
+			&oaMultiTableMappings);
 	ensure(mainClass == NULL or
-	       mainClass->ComputeOverallNativeRelationAttributeNumber(true) == oaMultiTableMappings.GetSize() - 1 or
-	       svUnusedRootDictionaryWarnings.GetSize() > 0);
+		mainClass->ComputeOverallNativeRelationAttributeNumber(true) == oaMultiTableMappings.GetSize() - 1 or
+		svUnusedRootDictionaryWarnings.GetSize() > 0);
 	ensure(oaMultiTableMappings.GetAt(0) == mainMultiTableMapping);
 }
 
@@ -579,7 +579,7 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 
 		// Message synthetique
 		AddError("Dictionary " + GetClassName() +
-			 " cannot be used to read multi-table data from data table files");
+			" cannot be used to read multi-table data from data table files");
 	}
 
 	// Verification de la validite des specifications de mapping
@@ -605,7 +605,7 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 				{
 					bOk = false;
 					AddError("Data path " + mapping->GetObjectLabel() + " : Data table " +
-						 mapping->GetDataTableName() + " already used");
+						mapping->GetDataTableName() + " already used");
 				}
 				odDataTableNames.SetAt(mapping->GetDataTableName(), mapping);
 			}
@@ -615,7 +615,7 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 			{
 				bOk = false;
 				AddError("Data path " + mapping->GetObjectLabel() + " : External data table " +
-					 mapping->GetDataTableName() + " should not be specified for output database");
+					mapping->GetDataTableName() + " should not be specified for output database");
 			}
 
 			// Recherche de la classe principale du chemin de mapping
@@ -631,7 +631,7 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 				else
 					sOriginLabel = "Root";
 				AddError("Data path " + mapping->GetObjectLabel() + " : " + sOriginLabel +
-					 " dictionary " + mapping->GetOriginClassName() + " does not exist");
+					" dictionary " + mapping->GetOriginClassName() + " does not exist");
 			}
 
 			// Validite du chemin de donnee
@@ -653,17 +653,17 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 					{
 						bOk = false;
 						AddError("Data path " + mapping->GetObjectLabel() + " : Variable " +
-							 sAttributeName + " not found in dictionary " +
-							 pathClass->GetName());
+							sAttributeName + " not found in dictionary " +
+							pathClass->GetName());
 					}
 					// Son type doit etre Object ou ObjectArray
 					else if (not KWType::IsRelation(attribute->GetType()))
 					{
 						bOk = false;
 						AddError("Data path " + mapping->GetObjectLabel() +
-							 " : Type of variable " + sAttributeName + " should be " +
-							 KWType::ToString(KWType::Object) + " or " +
-							 KWType::ToString(KWType::ObjectArray));
+							" : Type of variable " + sAttributeName + " should be " +
+							KWType::ToString(KWType::Object) + " or " +
+							KWType::ToString(KWType::ObjectArray));
 					}
 					// Sa classe doit etre coherente avec celle du mapping,
 					// pour le dernier attribut du chemin
@@ -673,9 +673,9 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 						{
 							bOk = false;
 							AddError("Data path " + mapping->GetObjectLabel() +
-								 " : Dictionary of variable " + sAttributeName + " (" +
-								 mapping->GetClassName() + ") should be " +
-								 attribute->GetClass()->GetName());
+								" : Dictionary of variable " + sAttributeName + " (" +
+								mapping->GetClassName() + ") should be " +
+								attribute->GetClass()->GetName());
 						}
 					}
 					// La classe utilisante doit avoir une cle
@@ -683,32 +683,32 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 					{
 						bOk = false;
 						AddError("Dictionary (" + pathClass->GetName() +
-							 ") should have a key to use variable " + sAttributeName);
+							") should have a key to use variable " + sAttributeName);
 					}
 					// Sa classe doit avoir une cle
 					else if (attribute->GetClass()->GetKeyAttributeNumber() == 0)
 					{
 						bOk = false;
 						AddError("Data path " + mapping->GetObjectLabel() +
-							 " : Dictionary of variable " + sAttributeName + " (" +
-							 mapping->GetClassName() + ") should have a key");
+							" : Dictionary of variable " + sAttributeName + " (" +
+							mapping->GetClassName() + ") should have a key");
 					}
 					// La cle de la classe utilisee doit etre au moins aussi longue que
 					// celle de la classe utilisante dans le cas d'un lien de composition
 					else if (not attribute->GetReference() and
-						 attribute->GetDerivationRule() == NULL and
-						 attribute->GetClass()->GetKeyAttributeNumber() <
-						     pathClass->GetKeyAttributeNumber())
+						attribute->GetDerivationRule() == NULL and
+						attribute->GetClass()->GetKeyAttributeNumber() <
+						pathClass->GetKeyAttributeNumber())
 					{
 						bOk = false;
 						AddError("Data path " + mapping->GetObjectLabel() +
-							 " : In dictionary " + mapping->GetClassName() +
-							 " of variable " + sAttributeName + ", the key length (" +
-							 IntToString(attribute->GetClass()->GetKeyAttributeNumber()) +
-							 ") must not be less than that of its parent "
-							 "dictionary " +
-							 pathClass->GetName() + "(" +
-							 IntToString(pathClass->GetKeyAttributeNumber()) + ")");
+							" : In dictionary " + mapping->GetClassName() +
+							" of variable " + sAttributeName + ", the key length (" +
+							IntToString(attribute->GetClass()->GetKeyAttributeNumber()) +
+							") must not be less than that of its parent "
+							"dictionary " +
+							pathClass->GetName() + "(" +
+							IntToString(pathClass->GetKeyAttributeNumber()) + ")");
 					}
 
 					// Passage a la classe suivante dans le path
@@ -752,20 +752,20 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 			for (nMapping = 0; nMapping < checkDatabase.GetMultiTableMappings()->GetSize(); nMapping++)
 			{
 				checkMapping =
-				    cast(KWMTDatabaseMapping*, checkDatabase.GetMultiTableMappings()->GetAt(nMapping));
+					cast(KWMTDatabaseMapping*, checkDatabase.GetMultiTableMappings()->GetAt(nMapping));
 
 				// Recherche du mapping correspondant, puis verification
 				mapping = LookupMultiTableMapping(checkMapping->GetDataPath());
 				if (mapping == NULL)
 				{
 					AddError("Data path " + checkMapping->GetObjectLabel() +
-						 " : No data path specification");
+						" : No data path specification");
 					bOk = false;
 				}
 				else if (mapping->GetDataTableName() == "")
 				{
 					AddError("Data path " + checkMapping->GetObjectLabel() +
-						 " : No data table file specified");
+						" : No data table file specified");
 					bOk = false;
 				}
 			}
@@ -891,7 +891,7 @@ longint KWMTDatabase::GetUsedMemory() const
 	{
 		cout << "KWMTDatabase::GetUsedMemory, base memory: " << KWDatabase::GetUsedMemory() << endl;
 		cout << "KWMTDatabase::GetUsedMemory, reference memory: " << objectReferenceResolver.GetUsedMemory()
-		     << endl;
+			<< endl;
 		cout << "KWMTDatabase::GetUsedMemory, total memory: " << lUsedMemory << endl;
 	}
 	return lUsedMemory;
@@ -1007,10 +1007,10 @@ boolean KWMTDatabase::CheckObjectConsistency() const
 						if (not bOk)
 						{
 							AddError("Native entities used as operand in rule " +
-								 rule->GetName() + " to build variable " +
-								 attribute->GetName() + " in dictionary " +
-								 secondaryClass->GetName() +
-								 " should be loaded in memory");
+								rule->GetName() + " to build variable " +
+								attribute->GetName() + " in dictionary " +
+								secondaryClass->GetName() +
+								" should be loaded in memory");
 							break;
 						}
 					}
@@ -1055,14 +1055,14 @@ boolean KWMTDatabase::CheckObjectRuleConsistency(KWDerivationRule* rule) const
 					if (attributeOperand->GetDerivationRule() == NULL)
 					{
 						if (not attributeOperand->GetLoaded() and
-						    not attributeOperand->GetInternalLoadIndex().IsValid())
+							not attributeOperand->GetInternalLoadIndex().IsValid())
 						{
 							AddError("Variable " + attributeOperand->GetName() +
-								 " of dictionary " +
-								 attributeOperand->GetParentClass()->GetName() +
-								 " used as operand " + IntToString(nOperand + 1) +
-								 " in rule " + rule->GetName() +
-								 " should be loaded in memory");
+								" of dictionary " +
+								attributeOperand->GetParentClass()->GetName() +
+								" used as operand " + IntToString(nOperand + 1) +
+								" in rule " + rule->GetName() +
+								" should be loaded in memory");
 							bOk = false;
 						}
 					}
@@ -1211,7 +1211,7 @@ void KWMTDatabase::PhysicalReadAfterEndOfDatabase()
 		// Lecture dans la sous base
 		mappedDataTableDriver = componentMapping->GetDataTableDriver();
 		if (mappedDataTableDriver != NULL and mappedDataTableDriver->GetDataTableName() != "" and
-		    mappedDataTableDriver->IsOpenedForRead())
+			mappedDataTableDriver->IsOpenedForRead())
 		{
 			// On recupere le dernier objet non traite
 			kwoLastSubObject = componentMapping->GetLastReadObject();
@@ -1229,9 +1229,9 @@ void KWMTDatabase::PhysicalReadAfterEndOfDatabase()
 				{
 					lastSubObjectKey.InitializeFromObject(kwoLastSubObject);
 					mappedDataTableDriver->AddWarning(
-					    sTmp + "Ignored record" + ", orphan record " +
-					    componentMapping->GetClassName() + lastSubObjectKey.GetObjectLabel() +
-					    " found beyond the key of the last record of the main table");
+						sTmp + "Ignored record" + ", orphan record " +
+						componentMapping->GetClassName() + lastSubObjectKey.GetObjectLabel() +
+						" found beyond the key of the last record of the main table");
 				}
 			}
 
@@ -1268,12 +1268,12 @@ void KWMTDatabase::PhysicalReadAfterEndOfDatabase()
 					if (subObjectKey.StrictCompare(&lastSubObjectKey) < 0)
 					{
 						mappedDataTableDriver->AddError(
-						    sTmp + "Unsorted record " + componentMapping->GetClassName() +
-						    subObjectKey.GetObjectLabel() +
-						    ", with key inferior to that of the preceding record " +
-						    componentMapping->GetClassName() +
-						    lastSubObjectKey.GetObjectLabel() +
-						    ", beyond the key of the last record of the main table");
+							sTmp + "Unsorted record " + componentMapping->GetClassName() +
+							subObjectKey.GetObjectLabel() +
+							", with key inferior to that of the preceding record " +
+							componentMapping->GetClassName() +
+							lastSubObjectKey.GetObjectLabel() +
+							", beyond the key of the last record of the main table");
 						bIsError = true;
 					}
 				}
@@ -1283,9 +1283,9 @@ void KWMTDatabase::PhysicalReadAfterEndOfDatabase()
 				{
 					subObjectKey.InitializeFromObject(kwoSubObject);
 					mappedDataTableDriver->AddWarning(
-					    sTmp + "Ignored record" + ", orphan record " +
-					    componentMapping->GetClassName() + subObjectKey.GetObjectLabel() +
-					    " found beyond the key of the last record of the main table");
+						sTmp + "Ignored record" + ", orphan record " +
+						componentMapping->GetClassName() + subObjectKey.GetObjectLabel() +
+						" found beyond the key of the last record of the main table");
 				}
 
 				// Memorisation du dernier sous-objet lu
@@ -1320,9 +1320,9 @@ void KWMTDatabase::PhysicalSkip()
 	if (kwcClass->IsUnique())
 	{
 		assert(mainMultiTableMapping->GetDataTableDriver()->GetLastReadMainKey()->GetSize() ==
-		       mainMultiTableMapping->GetDataTableDriver()->GetClass()->GetKeyAttributeNumber());
+			mainMultiTableMapping->GetDataTableDriver()->GetClass()->GetKeyAttributeNumber());
 		mainMultiTableMapping->SetLastReadKey(
-		    mainMultiTableMapping->GetDataTableDriver()->GetLastReadMainKey());
+			mainMultiTableMapping->GetDataTableDriver()->GetLastReadMainKey());
 	}
 
 	// Attention, il n'est pas possible de propager les skip sur les sous-tables
@@ -1371,7 +1371,7 @@ longint KWMTDatabase::GetPhysicalEstimatedObjectNumber()
 	mainMultiTableMapping->SetDataTableDriver(CreateDataTableDriver(mainMultiTableMapping));
 	mainMultiTableMapping->GetDataTableDriver()->SetDataTableName(mainMultiTableMapping->GetDataTableName());
 	mainMultiTableMapping->GetDataTableDriver()->SetClass(
-	    KWClassDomain::GetCurrentDomain()->LookupClass(GetClassName()));
+		KWClassDomain::GetCurrentDomain()->LookupClass(GetClassName()));
 
 	// Appel de la methode du driver
 	lPhysicalEstimatedObjectNumber = mainMultiTableMapping->GetDataTableDriver()->GetEstimatedObjectNumber();
@@ -1417,15 +1417,15 @@ void KWMTDatabase::CollectPhysicalStatsMessages(ObjectArray* oaPhysicalMessages)
 		// Nombre d'enregistrements lus par mapping
 		mappedDataTableDriver = mapping->GetDataTableDriver();
 		if (mappedDataTableDriver != NULL and mappedDataTableDriver->GetDataTableName() != "" and
-		    not mappedDataTableDriver->GetSilentMode() and mappedDataTableDriver->GetVerboseMode())
+			not mappedDataTableDriver->GetSilentMode() and mappedDataTableDriver->GetVerboseMode())
 		{
 			errorMessage = new Error;
 
 			// On ne passe par mappedDataTableDriver->GetObjectLabel() pour eviter d'avoir un numero de
 			// record
 			errorMessage->Initialize(
-			    Error::GravityMessage, "", "",
-			    sTmp + "  Table " + mappedDataTableDriver->GetDataTableName() + " " +
+				Error::GravityMessage, "", "",
+				sTmp + "  Table " + mappedDataTableDriver->GetDataTableName() + " " +
 				"Records: " + LongintToReadableString(mappedDataTableDriver->GetUsedRecordNumber()));
 			oaPhysicalMessages->Add(errorMessage);
 		}
@@ -1467,7 +1467,7 @@ void KWMTDatabase::MutatePhysicalObject(KWObject* kwoPhysicalObject) const
 	// Referencement du nouvel objet principal lu depuis le resolveur de reference, s'il est Root
 	if (kwcPhysicalClass->GetRoot() and not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
 		objectReferenceResolver.AddObject(kwcPhysicalClass, mainMultiTableMapping->GetLastReadKey(),
-						  kwoPhysicalObject);
+			kwoPhysicalObject);
 
 	// Appel de la methode ancetre
 	KWDatabase::MutatePhysicalObject(kwoPhysicalObject);
@@ -1507,15 +1507,15 @@ boolean KWMTDatabase::IsPhysicalObjectSelected(KWObject* kwoPhysicalObject)
 		// Referencement du nouvel objet principal lu depuis le resolveur de reference
 		if (kwcPhysicalClass->GetRoot() and not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
 			objectReferenceResolver.AddObject(kwcPhysicalClass, mainMultiTableMapping->GetLastReadKey(),
-							  kwoPhysicalObject);
+				kwoPhysicalObject);
 
 		// Calcul du critere de selection
 		if (nSelectionAttributeType == KWType::Symbol)
 			bSelected =
-			    kwoPhysicalObject->ComputeSymbolValueAt(liSelectionAttributeLoadIndex) == sSelectionSymbol;
+			kwoPhysicalObject->ComputeSymbolValueAt(liSelectionAttributeLoadIndex) == sSelectionSymbol;
 		else if (nSelectionAttributeType == KWType::Continuous)
 			bSelected = kwoPhysicalObject->ComputeContinuousValueAt(liSelectionAttributeLoadIndex) ==
-				    cSelectionContinuous;
+			cSelectionContinuous;
 		else
 			bSelected = false;
 
@@ -1532,10 +1532,10 @@ boolean KWMTDatabase::IsPhysicalObjectSelected(KWObject* kwoPhysicalObject)
 }
 
 KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceClasses,
-						 ObjectArray* oaRankedReferenceClasses,
-						 ObjectDictionary* odAnalysedCreatedClasses, KWClass* mappedClass,
-						 boolean bIsExternalTable, const ALString& sOriginClassName,
-						 StringVector* svAttributeNames, ObjectArray* oaCreatedMappings)
+	ObjectArray* oaRankedReferenceClasses,
+	ObjectDictionary* odAnalysedCreatedClasses, KWClass* mappedClass,
+	boolean bIsExternalTable, const ALString& sOriginClassName,
+	StringVector* svAttributeNames, ObjectArray* oaCreatedMappings)
 {
 	const KWDRReference referenceRule;
 	KWMTDatabaseMapping* mapping;
@@ -1582,9 +1582,9 @@ KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceCl
 
 				// Creation du mapping dans une nouvelle table de mapping temporaire
 				subMapping =
-				    CreateMapping(odReferenceClasses, oaRankedReferenceClasses,
-						  odAnalysedCreatedClasses, attribute->GetClass(), bIsExternalTable,
-						  sOriginClassName, svAttributeNames, oaCreatedMappings);
+					CreateMapping(odReferenceClasses, oaRankedReferenceClasses,
+						odAnalysedCreatedClasses, attribute->GetClass(), bIsExternalTable,
+						sOriginClassName, svAttributeNames, oaCreatedMappings);
 
 				// Supression de l'attribut ajoute temporairement
 				svAttributeNames->SetSize(svAttributeNames->GetSize() - 1);
@@ -1600,7 +1600,7 @@ KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceCl
 
 				// Recherche de la classe cible
 				kwcTargetClass = mappedClass->GetDomain()->LookupClass(
-				    attribute->GetDerivationRule()->GetObjectClassName());
+					attribute->GetDerivationRule()->GetObjectClassName());
 				assert(kwcTargetClass != NULL);
 
 				// Analyse uniquement si la classe cible na pas deja ete analysees
@@ -1623,7 +1623,7 @@ KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceCl
 							if (odReferenceClasses->Lookup(kwcUsedClass->GetName()) == NULL)
 							{
 								odReferenceClasses->SetAt(kwcUsedClass->GetName(),
-											  kwcUsedClass);
+									kwcUsedClass);
 								oaRankedReferenceClasses->Add(kwcUsedClass);
 							}
 						}
@@ -1637,7 +1637,7 @@ KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceCl
 				if (odReferenceClasses->Lookup(attribute->GetClass()->GetName()) == NULL)
 				{
 					odReferenceClasses->SetAt(attribute->GetClass()->GetName(),
-								  attribute->GetClass());
+						attribute->GetClass());
 					oaRankedReferenceClasses->Add(attribute->GetClass());
 				}
 			}
@@ -1700,7 +1700,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 		// Acces aux classes physique et logique referencees, en passant par le domaine de la classe principale
 		kwcReferenceClass = kwcClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 		kwcReferencePhysicalClass =
-		    kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
+			kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 		check(kwcReferenceClass);
 		check(kwcReferencePhysicalClass);
 
@@ -1714,7 +1714,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 		// Les etapes precedentes ont determine si la table etait utile, et dans le cas inverse
 		// la cle n'est pas chargee
 		if (referenceMapping->GetDataTableDriver()->GetDataTableName() != "" and
-		    kwcReferencePhysicalClass->IsKeyLoaded())
+			kwcReferencePhysicalClass->IsKeyLoaded())
 		{
 			bOk = DMTMPhysicalOpenForRead(referenceMapping, kwcReferenceClass);
 
@@ -1748,7 +1748,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 						assert(kwoObject->GetClass() == kwcReferencePhysicalClass);
 						objectKey.InitializeFromObject(kwoObject);
 						objectReferenceResolver.AddObject(kwcReferencePhysicalClass, &objectKey,
-										  kwoObject);
+							kwoObject);
 						lObjectNumber++;
 					}
 
@@ -1757,8 +1757,8 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 					{
 						bOk = false;
 						AddError(sTmp + "Read external data table " +
-							 referenceMapping->GetDataTableName() +
-							 " interrupted because of errors");
+							referenceMapping->GetDataTableName() +
+							" interrupted because of errors");
 						break;
 					}
 
@@ -1771,7 +1771,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 
 					// Arret si pourcentage atteint
 					if (dSamplePercentage < 1 and
-					    referenceMapping->GetDataTableDriver()->GetReadPercentage() >
+						referenceMapping->GetDataTableDriver()->GetReadPercentage() >
 						dSamplePercentage)
 						break;
 
@@ -1779,10 +1779,10 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 					if (bIsInTask and TaskProgression::IsRefreshNecessary())
 					{
 						TaskProgression::DisplayLabel(sMessage + ": " +
-									      LongintToReadableString(lObjectNumber) +
-									      " records");
+							LongintToReadableString(lObjectNumber) +
+							" records");
 						TaskProgression::DisplayProgression(int(
-						    100 * referenceMapping->GetDataTableDriver()->GetReadPercentage()));
+							100 * referenceMapping->GetDataTableDriver()->GetReadPercentage()));
 					}
 				}
 
@@ -1834,13 +1834,13 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 		{
 			referenceMapping = cast(KWMTDatabaseMapping*, oaRootReferenceTableMappings.GetAt(nReference));
 			assert(referenceMapping->GetDataTableDriver() == NULL or
-			       not referenceMapping->GetDataTableDriver()->IsOpenedForRead());
+				not referenceMapping->GetDataTableDriver()->IsOpenedForRead());
 
 			// Acces aux classes physique et logique referencees, en passant par le domaine de la classe
 			// principale
 			kwcReferenceClass = kwcClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 			kwcReferencePhysicalClass =
-			    kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
+				kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 
 			// Traitement si la classe existe dans le resolveur de reference
 			if (objectReferenceResolver.LookupClass(kwcReferencePhysicalClass->GetName()) != NULL)
@@ -1963,7 +1963,7 @@ longint KWMTDatabase::ComputeSamplingBasedNecessaryMemoryForReferenceObjects()
 	lSamplingBasedNecessaryMemory = longint(lSamplingBasedNecessaryMemory / (1 + MemGetAllocatorOverhead()));
 	if (bDisplay)
 		cout << "\tSampling based estimation\t" << LongintToHumanReadableString(lSamplingBasedNecessaryMemory)
-		     << endl;
+		<< endl;
 	ensure(lSamplingBasedNecessaryMemory >= 0);
 	return lSamplingBasedNecessaryMemory;
 }
@@ -1999,7 +1999,7 @@ longint KWMTDatabase::ComputeNecessaryMemoryForReferenceObjects()
 		// Acces aux classes physique et logique referencees, en passant par le domaine de la classe principale
 		kwcReferenceClass = kwcClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 		kwcReferencePhysicalClass =
-		    kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
+			kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 		check(kwcReferenceClass);
 		check(kwcReferencePhysicalClass);
 
@@ -2028,13 +2028,13 @@ longint KWMTDatabase::ComputeNecessaryMemoryForReferenceObjects()
 
 				// Calcul de la memoire, en tenant compte du nombre d'attributs natifs
 				lNecessaryMemory =
-				    mapping->GetDataTableDriver()->ComputeNecessaryMemoryForFullExternalRead(
-					kwcMappingLogicalClass);
+					mapping->GetDataTableDriver()->ComputeNecessaryMemoryForFullExternalRead(
+						kwcMappingLogicalClass);
 			}
 			lTotalNecessaryMemory += lNecessaryMemory;
 			if (bDisplay)
 				cout << "Necessary memory for " << mapping->GetObjectLabel() << ": "
-				     << LongintToHumanReadableString(lNecessaryMemory) << endl;
+				<< LongintToHumanReadableString(lNecessaryMemory) << endl;
 		}
 
 		// Nettoyage final
@@ -2042,7 +2042,7 @@ longint KWMTDatabase::ComputeNecessaryMemoryForReferenceObjects()
 	}
 	if (bDisplay)
 		cout << "Necessary memory for reference objects for database " << GetDatabaseName() << ": "
-		     << LongintToHumanReadableString(lTotalNecessaryMemory) << endl;
+		<< LongintToHumanReadableString(lTotalNecessaryMemory) << endl;
 	return lTotalNecessaryMemory;
 }
 
@@ -2076,7 +2076,7 @@ void KWMTDatabase::DMTMPhysicalInitializeMapping(KWMTDatabaseMapping* mapping, K
 	}
 	// En lecture (dans le domaine classe physique), la classe mappee doit avoir les attributs cle en load
 	assert(nDataPathAttributeNumber == 0 or mappedClass->GetDomain() == kwcClass->GetDomain() or
-	       mapping->GetDataTableDriver()->GetClass()->IsKeyLoaded());
+		mapping->GetDataTableDriver()->GetClass()->IsKeyLoaded());
 
 	// Parametrage du mapping de la composition, si necessaire en lecture, toujours en ecriture
 	if (mappedClass->IsKeyLoaded() or not bRead)
@@ -2095,7 +2095,7 @@ void KWMTDatabase::DMTMPhysicalInitializeMapping(KWMTDatabaseMapping* mapping, K
 
 			// Parametrage du mapping si base specifiee et si la classe mappe est indexable
 			if (componentMapping->GetDataTableName() != "" and attribute != NULL and
-			    attribute->GetClass()->GetKeyAttributeNumber() > 0 and attribute->GetLoaded())
+				attribute->GetClass()->GetKeyAttributeNumber() > 0 and attribute->GetLoaded())
 			{
 				// Creation d'un driver de table ayant par defaut les memes caracteristiques que la base
 				// courante
@@ -2130,7 +2130,7 @@ void KWMTDatabase::DMTMPhysicalTerminateMapping(KWMTDatabaseMapping* mapping)
 	if (mapping->GetDataTableDriver() != NULL)
 	{
 		assert(not mapping->GetDataTableDriver()->IsOpenedForRead() and
-		       not mapping->GetDataTableDriver()->IsOpenedForWrite());
+			not mapping->GetDataTableDriver()->IsOpenedForWrite());
 		mapping->GetDataTableDriver()->SetClass(NULL);
 		delete mapping->GetDataTableDriver();
 		mapping->SetDataTableDriver(NULL);
@@ -2202,37 +2202,37 @@ boolean KWMTDatabase::DMTMPhysicalOpenForRead(KWMTDatabaseMapping* mapping, cons
 			for (i = 0; i < mapping->GetComponentTableMappings()->GetSize(); i++)
 			{
 				componentMapping =
-				    cast(KWMTDatabaseMapping*, mapping->GetComponentTableMappings()->GetAt(i));
+					cast(KWMTDatabaseMapping*, mapping->GetComponentTableMappings()->GetAt(i));
 
 				// Ouverture de la table du mapping composant
 				if (componentMapping->GetDataTableDriver() != NULL and
-				    componentMapping->GetDataTableDriver()->GetDataTableName() != "")
+					componentMapping->GetDataTableDriver()->GetDataTableName() != "")
 				{
 					// Ouverture physique de la sous-base si necessaire
 					sAttributeName =
-					    componentMapping->GetDataPathAttributeNameAt(nDataPathAttributeNumber);
+						componentMapping->GetDataPathAttributeNameAt(nDataPathAttributeNumber);
 					physicalAttribute =
-					    mapping->GetDataTableDriver()->GetClass()->LookupAttribute(sAttributeName);
+						mapping->GetDataTableDriver()->GetClass()->LookupAttribute(sAttributeName);
 					attribute = kwcLogicalClass->LookupAttribute(sAttributeName);
 					if (physicalAttribute != NULL)
 					{
 						assert(KWType::IsRelation(physicalAttribute->GetType()));
 						assert(physicalAttribute->GetClass()->IsCompiled());
 						assert(componentMapping->GetDataTableDriver()->GetClass() ==
-						       physicalAttribute->GetClass());
+							physicalAttribute->GetClass());
 						assert(attribute->GetClass() != NULL);
 						assert(attribute->GetClass()->GetName() ==
-						       physicalAttribute->GetClass()->GetName());
+							physicalAttribute->GetClass()->GetName());
 
 						// Ouverture de la sous-table
 						componentMapping->GetDataTableDriver()->OpenForRead(
-						    attribute->GetClass());
+							attribute->GetClass());
 						bOk = bOk and componentMapping->GetDataTableDriver()->IsOpenedForRead();
 
 						// Propagation si OK
 						if (bOk)
 							bOk = DMTMPhysicalOpenForRead(componentMapping,
-										      attribute->GetClass());
+								attribute->GetClass());
 						// Arret sinon
 						else
 							break;
@@ -2291,18 +2291,18 @@ boolean KWMTDatabase::DMTMPhysicalOpenForWrite(KWMTDatabaseMapping* mapping)
 
 			// Ouverture de la table du mapping composant
 			if (componentMapping->GetDataTableDriver() != NULL and
-			    componentMapping->GetDataTableDriver()->GetDataTableName() != "")
+				componentMapping->GetDataTableDriver()->GetDataTableName() != "")
 			{
 				// Ouverture physique de la sous-base si necessaire
 				sAttributeName = componentMapping->GetDataPathAttributeNameAt(nDataPathAttributeNumber);
 				physicalAttribute =
-				    mapping->GetDataTableDriver()->GetClass()->LookupAttribute(sAttributeName);
+					mapping->GetDataTableDriver()->GetClass()->LookupAttribute(sAttributeName);
 				if (physicalAttribute != NULL)
 				{
 					assert(KWType::IsRelation(physicalAttribute->GetType()));
 					assert(physicalAttribute->GetClass()->IsCompiled());
 					assert(componentMapping->GetDataTableDriver()->GetClass() ==
-					       physicalAttribute->GetClass());
+						physicalAttribute->GetClass());
 
 					// Ouverture de la sous-table
 					componentMapping->GetDataTableDriver()->OpenForWrite();
@@ -2422,7 +2422,7 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 		if (mapping->GetDataTableDriver()->GetClass()->IsUnique())
 		{
 			assert(mapping->GetDataTableDriver()->GetLastReadMainKey()->GetSize() ==
-			       mapping->GetDataTableDriver()->GetClass()->GetKeyAttributeNumber());
+				mapping->GetDataTableDriver()->GetClass()->GetKeyAttributeNumber());
 			mapping->SetLastReadKey(mapping->GetDataTableDriver()->GetLastReadMainKey());
 		}
 		return NULL;
@@ -2448,12 +2448,12 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 				// Warning si la cle egale dans le cas d'une classe principale, et supression de
 				// l'enregistrement
 				if (kwoObject->GetClass()->IsUnique() and
-				    objectKey.StrictCompare(mapping->GetLastReadKey()) == 0)
+					objectKey.StrictCompare(mapping->GetLastReadKey()) == 0)
 				{
 					// Warning de lecture
 					mapping->GetDataTableDriver()->AddWarning(
-					    sTmp + "Ignored record" + ", duplicate key " + mapping->GetClassName() +
-					    objectKey.GetObjectLabel());
+						sTmp + "Ignored record" + ", duplicate key " + mapping->GetClassName() +
+						objectKey.GetObjectLabel());
 
 					// On ignore l'enregistrement
 					delete kwoObject;
@@ -2464,10 +2464,10 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 				{
 					// Erreur de lecture
 					mapping->GetDataTableDriver()->AddError(
-					    sTmp + "Unsorted record " + mapping->GetClassName() +
-					    objectKey.GetObjectLabel() +
-					    ", with key inferior to that of the preceding record " +
-					    mapping->GetClassName() + mapping->GetLastReadKey()->GetObjectLabel());
+						sTmp + "Unsorted record " + mapping->GetClassName() +
+						objectKey.GetObjectLabel() +
+						", with key inferior to that of the preceding record " +
+						mapping->GetClassName() + mapping->GetLastReadKey()->GetObjectLabel());
 					bIsError = true;
 
 					// On ignore l'enregistrement
@@ -2487,7 +2487,7 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 			// L'incrementation pour les mappings de la composition est effectuee par la suite
 			if (mapping == mainMultiTableMapping)
 				mapping->GetDataTableDriver()->SetUsedRecordNumber(
-				    mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
+					mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
 		}
 
 		// Parcours des mappings de la composition  pour completer la lecture de l'objet
@@ -2498,13 +2498,13 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 			// Lecture dans la sous base
 			mappedDataTableDriver = componentMapping->GetDataTableDriver();
 			if (mappedDataTableDriver != NULL and mappedDataTableDriver->GetDataTableName() != "" and
-			    mappedDataTableDriver->IsOpenedForRead())
+				mappedDataTableDriver->IsOpenedForRead())
 			{
 				// Lecture des sous-objets
 				oaSubObjects = NULL;
 				kwoSubObject = NULL;
 				while (componentMapping->GetLastReadObject() != NULL or
-				       not mappedDataTableDriver->IsEnd())
+					not mappedDataTableDriver->IsEnd())
 				{
 					bNewSubObject = false;
 
@@ -2538,12 +2538,12 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 						// Verification de la coherence entre la classe du sous-objet, et sa
 						// classe attendue depuis son objet englobant
 						assert(componentMapping != mainMultiTableMapping and
-						       not kwoSubObject->GetClass()->GetRoot());
+							not kwoSubObject->GetClass()->GetRoot());
 						assert(kwoSubObject->GetClass() ==
-						       kwoObject->GetClass()
-							   ->GetAttributeAtLoadIndex(
-							       componentMapping->GetMappedAttributeLoadIndex())
-							   ->GetClass());
+							kwoObject->GetClass()
+							->GetAttributeAtLoadIndex(
+								componentMapping->GetMappedAttributeLoadIndex())
+							->GetClass());
 
 						// Recherche de la cle de l'objet secondaire
 						subObjectKey.InitializeFromObject(kwoSubObject);
@@ -2568,19 +2568,19 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 							// Pour un attribut de type Object, on associe le sous-objet a
 							// son incluant et c'est fini
 							else if (componentMapping->GetMappedAttributeType() ==
-								 KWType::Object)
+								KWType::Object)
 							{
 								kwoObject->SetObjectValueAt(
-								    componentMapping->GetMappedAttributeLoadIndex(),
-								    kwoSubObject);
+									componentMapping->GetMappedAttributeLoadIndex(),
+									kwoSubObject);
 
 								// Incrementation du compteur d'objet utilise au niveau
 								// physique
 								componentMapping->GetDataTableDriver()
-								    ->SetUsedRecordNumber(
-									componentMapping->GetDataTableDriver()
-									    ->GetUsedRecordNumber() +
-									1);
+									->SetUsedRecordNumber(
+										componentMapping->GetDataTableDriver()
+										->GetUsedRecordNumber() +
+										1);
 
 								// Memorisation de la derniere cle lue
 								componentMapping->SetLastReadKey(&subObjectKey);
@@ -2593,16 +2593,16 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 							else
 							{
 								assert(componentMapping->GetMappedAttributeType() ==
-								       KWType::ObjectArray);
+									KWType::ObjectArray);
 
 								// Creation si necessaire du tableau
 								if (oaSubObjects == NULL)
 								{
 									oaSubObjects = new ObjectArray;
 									kwoObject->SetObjectArrayValueAt(
-									    componentMapping
+										componentMapping
 										->GetMappedAttributeLoadIndex(),
-									    oaSubObjects);
+										oaSubObjects);
 								}
 
 								// Rangement du sous-objet dans le tableau
@@ -2611,10 +2611,10 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 								// Incrementation du compteur d'objet utilise au niveau
 								// physique
 								componentMapping->GetDataTableDriver()
-								    ->SetUsedRecordNumber(
-									componentMapping->GetDataTableDriver()
-									    ->GetUsedRecordNumber() +
-									1);
+									->SetUsedRecordNumber(
+										componentMapping->GetDataTableDriver()
+										->GetUsedRecordNumber() +
+										1);
 							}
 
 							// Memorisation de la derniere cle lue
@@ -2631,36 +2631,36 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 							// ete lu
 							bWarningEmmited = false;
 							if (componentMapping->GetLastReadKey()->GetSize() > 0 and
-							    bNewSubObject)
+								bNewSubObject)
 							{
 								// Erreur si probleme d'ordonnancement
 								if (subObjectKey.StrictCompare(
 									componentMapping->GetLastReadKey()) < 0)
 								{
 									mappedDataTableDriver->AddError(
-									    sTmp + "Unsorted record " +
-									    componentMapping->GetClassName() +
-									    subObjectKey.GetObjectLabel() +
-									    ", with key inferior to that of the "
-									    "preceding record " +
-									    componentMapping->GetClassName() +
-									    componentMapping->GetLastReadKey()
+										sTmp + "Unsorted record " +
+										componentMapping->GetClassName() +
+										subObjectKey.GetObjectLabel() +
+										", with key inferior to that of the "
+										"preceding record " +
+										componentMapping->GetClassName() +
+										componentMapping->GetLastReadKey()
 										->GetObjectLabel());
 									bIsError = true;
 								}
 								// Warning si probleme de duplication dans le cas d'un
 								// sous-objet
 								else if (componentMapping->GetMappedAttributeType() ==
-									     KWType::Object and
-									 subObjectKey.StrictCompare(
-									     componentMapping->GetLastReadKey()) == 0)
+									KWType::Object and
+									subObjectKey.StrictCompare(
+										componentMapping->GetLastReadKey()) == 0)
 								{
 									bWarningEmmited = true;
 									mappedDataTableDriver->AddWarning(
-									    sTmp + "Ignored record" +
-									    ", duplicate key " +
-									    componentMapping->GetClassName() +
-									    subObjectKey.GetObjectLabel());
+										sTmp + "Ignored record" +
+										", duplicate key " +
+										componentMapping->GetClassName() +
+										subObjectKey.GetObjectLabel());
 								}
 							}
 
@@ -2670,17 +2670,17 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 							// enregistrement secondaires non rattachable a l'objet
 							// principal
 							if (not bIsError and not bWarningEmmited and
-							    nSkippedRecordNumber == 0)
+								nSkippedRecordNumber == 0)
 							{
 								bWarningEmmited = true;
 								mappedDataTableDriver->AddWarning(
-								    sTmp + "Ignored record" + ", orphan record " +
-								    componentMapping->GetClassName() +
-								    subObjectKey.GetObjectLabel() +
-								    " with key inferior to that of the including "
-								    "record " +
-								    mapping->GetClassName() +
-								    objectKey.GetObjectLabel());
+									sTmp + "Ignored record" + ", orphan record " +
+									componentMapping->GetClassName() +
+									subObjectKey.GetObjectLabel() +
+									" with key inferior to that of the including "
+									"record " +
+									mapping->GetClassName() +
+									objectKey.GetObjectLabel());
 							}
 
 							// Destruction du sous-objet non utilise
@@ -2727,7 +2727,7 @@ void KWMTDatabase::DMTMPhysicalWrite(KWMTDatabaseMapping* mapping, const KWObjec
 	// Incrementation du compteur d'objet utilise au niveau physique
 	if (not bIsError)
 		mapping->GetDataTableDriver()->SetUsedRecordNumber(
-		    mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
+			mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
 
 	// Positionnement du flag d'erreur
 	bIsError = bIsError or mapping->GetDataTableDriver()->IsError();
@@ -2741,13 +2741,13 @@ void KWMTDatabase::DMTMPhysicalWrite(KWMTDatabaseMapping* mapping, const KWObjec
 		// Ecriture si necessaire
 		mappedDataTableDriver = componentMapping->GetDataTableDriver();
 		if (mappedDataTableDriver != NULL and mappedDataTableDriver->GetDataTableName() != "" and
-		    mappedDataTableDriver->IsOpenedForWrite())
+			mappedDataTableDriver->IsOpenedForWrite())
 		{
 			// Ecriture de l'attribut mappe
 			if (componentMapping->GetMappedAttributeType() == KWType::Object)
 			{
 				kwoSubObject =
-				    kwoObject->GetObjectValueAt(componentMapping->GetMappedAttributeLoadIndex());
+					kwoObject->GetObjectValueAt(componentMapping->GetMappedAttributeLoadIndex());
 				// Propagation au reste de la composition par appel recursif a DMTMPhysicalWrite
 				if (kwoSubObject != NULL)
 					DMTMPhysicalWrite(componentMapping, kwoSubObject);
@@ -2755,7 +2755,7 @@ void KWMTDatabase::DMTMPhysicalWrite(KWMTDatabaseMapping* mapping, const KWObjec
 			else if (componentMapping->GetMappedAttributeType() == KWType::ObjectArray)
 			{
 				oaSubObjectArray =
-				    kwoObject->GetObjectArrayValueAt(componentMapping->GetMappedAttributeLoadIndex());
+					kwoObject->GetObjectArrayValueAt(componentMapping->GetMappedAttributeLoadIndex());
 				if (oaSubObjectArray != NULL)
 				{
 					// Ecriture des sous-objet du tableau
@@ -2787,6 +2787,6 @@ void KWMTDatabase::WriteMapingArray(ostream& ost, const ALString& sTitle, const 
 	{
 		mapping = cast(KWMTDatabaseMapping*, oaMappings->GetAt(n));
 		ost << "\t" << n + 1 << "\t" << mapping->GetDataPath() << "\t" << mapping->GetClassName() << "\t"
-		    << mapping->GetDataTableName() << "\n";
+			<< mapping->GetDataTableName() << "\n";
 	}
 }

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -709,6 +709,8 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 							"dictionary " +
 							pathClass->GetName() + "(" +
 							IntToString(pathClass->GetKeyAttributeNumber()) + ")");
+							 " variables)");
+							 " variables)");
 					}
 
 					// Passage a la classe suivante dans le path

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -106,10 +106,10 @@ void KWMTDatabase::CopyFrom(const KWDatabase* kwdSource)
 
 			// Insertion de la copie du mapping composant correspondant
 			mappingCopy->GetComponentTableMappings()->Add(
-				LookupMultiTableMapping(mappingComponent->GetDataPath()));
+			    LookupMultiTableMapping(mappingComponent->GetDataPath()));
 		}
 		assert(mappingCopy->GetComponentTableMappings()->GetSize() ==
-			mapping->GetComponentTableMappings()->GetSize());
+		       mapping->GetComponentTableMappings()->GetSize());
 	}
 
 	// Memorisation des warnings pour les dictionnaires racines non utilises
@@ -343,8 +343,8 @@ void KWMTDatabase::UpdateMultiTableMappings()
 		// Creation du mapping de la table principale
 		assert(svAttributeName.GetSize() == 0);
 		mainMultiTableMapping =
-			CreateMapping(&odReferenceClasses, &oaRankedReferenceClasses, &odAnalysedCreatedClasses, mainClass,
-				false, mainClass->GetName(), &svAttributeName, &oaMultiTableMappings);
+		    CreateMapping(&odReferenceClasses, &oaRankedReferenceClasses, &odAnalysedCreatedClasses, mainClass,
+				  false, mainClass->GetName(), &svAttributeName, &oaMultiTableMappings);
 		assert(svAttributeName.GetSize() == 0);
 		if (bTrace)
 			WriteMapingArray(cout, "- main mappings " + mainClass->GetName(), &oaMultiTableMappings);
@@ -369,9 +369,9 @@ void KWMTDatabase::UpdateMultiTableMappings()
 				oaWorkingCreatedMappings.RemoveAll();
 				assert(svAttributeName.GetSize() == 0);
 				mapping = CreateMapping(&odWorkingReferenceClasses, &oaWorkingRankedReferenceClasses,
-					&odWorkingAnalysedCreatedClasses, referenceClass, true,
-					referenceClass->GetName(), &svAttributeName,
-					&oaWorkingCreatedMappings);
+							&odWorkingAnalysedCreatedClasses, referenceClass, true,
+							referenceClass->GetName(), &svAttributeName,
+							&oaWorkingCreatedMappings);
 				assert(svAttributeName.GetSize() == 0);
 
 				// On determine si le dictionnaire de reference est utilisable, c'est a dire s'il n'utilise
@@ -404,24 +404,24 @@ void KWMTDatabase::UpdateMultiTableMappings()
 					// Et il n'y a aucun enjeu d'optimisation
 					assert(svAttributeName.GetSize() == 0);
 					mapping = CreateMapping(&odReferenceClasses, &oaRankedReferenceClasses,
-						&odAnalysedCreatedClasses, referenceClass, true,
-						referenceClass->GetName(), &svAttributeName,
-						oaCreatedMappings);
+								&odAnalysedCreatedClasses, referenceClass, true,
+								referenceClass->GetName(), &svAttributeName,
+								oaCreatedMappings);
 					assert(svAttributeName.GetSize() == 0);
 					if (bTrace)
 						WriteMapingArray(cout,
-							"- external mappings " + referenceClass->GetName(),
-							oaCreatedMappings);
+								 "- external mappings " + referenceClass->GetName(),
+								 oaCreatedMappings);
 				}
 				// Sinon, memorisation d'un warning expliquant pourquoi on ne garde le dictionnaire racine en reference
 				else
 				{
 					sWarning =
-						"Root dictionary " + referenceClass->GetName() +
-						" referenced from the main dictionary " + mainClass->GetName() +
-						" is not kept to specify database files in order to avoid circular "
-						"references in the schema, as it itself uses the main dictionary in its "
-						"secondary tables";
+					    "Root dictionary " + referenceClass->GetName() +
+					    " referenced from the main dictionary " + mainClass->GetName() +
+					    " is not kept to specify database files in order to avoid circular "
+					    "references in the schema, as it itself uses the main dictionary in its "
+					    "secondary tables";
 					svUnusedRootDictionaryWarnings.Add(sWarning);
 					if (bTrace)
 						cout << "- " << sWarning << "\n";
@@ -481,7 +481,7 @@ void KWMTDatabase::UpdateMultiTableMappings()
 
 				// Transfert des specifications de la table mappee si comparaison positive
 				if (mapping->GetOriginClassName() == previousMapping->GetOriginClassName() and
-					mapping->GetDataPathAttributeNames() ==
+				    mapping->GetDataPathAttributeNames() ==
 					previousMapping->GetDataPathAttributeNames())
 				{
 					mapping->SetDataTableName(previousMapping->GetDataTableName());
@@ -500,10 +500,10 @@ void KWMTDatabase::UpdateMultiTableMappings()
 	// Affichage des mappings finaux
 	if (bTrace)
 		WriteMapingArray(cout, "Database " + GetDatabaseName() + " " + GetClassName() + " mappings",
-			&oaMultiTableMappings);
+				 &oaMultiTableMappings);
 	ensure(mainClass == NULL or
-		mainClass->ComputeOverallNativeRelationAttributeNumber(true) == oaMultiTableMappings.GetSize() - 1 or
-		svUnusedRootDictionaryWarnings.GetSize() > 0);
+	       mainClass->ComputeOverallNativeRelationAttributeNumber(true) == oaMultiTableMappings.GetSize() - 1 or
+	       svUnusedRootDictionaryWarnings.GetSize() > 0);
 	ensure(oaMultiTableMappings.GetAt(0) == mainMultiTableMapping);
 }
 
@@ -579,7 +579,7 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 
 		// Message synthetique
 		AddError("Dictionary " + GetClassName() +
-			" cannot be used to read multi-table data from data table files");
+			 " cannot be used to read multi-table data from data table files");
 	}
 
 	// Verification de la validite des specifications de mapping
@@ -605,7 +605,7 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 				{
 					bOk = false;
 					AddError("Data path " + mapping->GetObjectLabel() + " : Data table " +
-						mapping->GetDataTableName() + " already used");
+						 mapping->GetDataTableName() + " already used");
 				}
 				odDataTableNames.SetAt(mapping->GetDataTableName(), mapping);
 			}
@@ -615,7 +615,7 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 			{
 				bOk = false;
 				AddError("Data path " + mapping->GetObjectLabel() + " : External data table " +
-					mapping->GetDataTableName() + " should not be specified for output database");
+					 mapping->GetDataTableName() + " should not be specified for output database");
 			}
 
 			// Recherche de la classe principale du chemin de mapping
@@ -631,7 +631,7 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 				else
 					sOriginLabel = "Root";
 				AddError("Data path " + mapping->GetObjectLabel() + " : " + sOriginLabel +
-					" dictionary " + mapping->GetOriginClassName() + " does not exist");
+					 " dictionary " + mapping->GetOriginClassName() + " does not exist");
 			}
 
 			// Validite du chemin de donnee
@@ -653,17 +653,17 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 					{
 						bOk = false;
 						AddError("Data path " + mapping->GetObjectLabel() + " : Variable " +
-							sAttributeName + " not found in dictionary " +
-							pathClass->GetName());
+							 sAttributeName + " not found in dictionary " +
+							 pathClass->GetName());
 					}
 					// Son type doit etre Object ou ObjectArray
 					else if (not KWType::IsRelation(attribute->GetType()))
 					{
 						bOk = false;
 						AddError("Data path " + mapping->GetObjectLabel() +
-							" : Type of variable " + sAttributeName + " should be " +
-							KWType::ToString(KWType::Object) + " or " +
-							KWType::ToString(KWType::ObjectArray));
+							 " : Type of variable " + sAttributeName + " should be " +
+							 KWType::ToString(KWType::Object) + " or " +
+							 KWType::ToString(KWType::ObjectArray));
 					}
 					// Sa classe doit etre coherente avec celle du mapping,
 					// pour le dernier attribut du chemin
@@ -673,9 +673,9 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 						{
 							bOk = false;
 							AddError("Data path " + mapping->GetObjectLabel() +
-								" : Dictionary of variable " + sAttributeName + " (" +
-								mapping->GetClassName() + ") should be " +
-								attribute->GetClass()->GetName());
+								 " : Dictionary of variable " + sAttributeName + " (" +
+								 mapping->GetClassName() + ") should be " +
+								 attribute->GetClass()->GetName());
 						}
 					}
 					// La classe utilisante doit avoir une cle
@@ -683,34 +683,32 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 					{
 						bOk = false;
 						AddError("Dictionary (" + pathClass->GetName() +
-							") should have a key to use variable " + sAttributeName);
+							 ") should have a key to use variable " + sAttributeName);
 					}
 					// Sa classe doit avoir une cle
 					else if (attribute->GetClass()->GetKeyAttributeNumber() == 0)
 					{
 						bOk = false;
 						AddError("Data path " + mapping->GetObjectLabel() +
-							" : Dictionary of variable " + sAttributeName + " (" +
-							mapping->GetClassName() + ") should have a key");
+							 " : Dictionary of variable " + sAttributeName + " (" +
+							 mapping->GetClassName() + ") should have a key");
 					}
 					// La cle de la classe utilisee doit etre au moins aussi longue que
 					// celle de la classe utilisante dans le cas d'un lien de composition
 					else if (not attribute->GetReference() and
-						attribute->GetDerivationRule() == NULL and
-						attribute->GetClass()->GetKeyAttributeNumber() <
-						pathClass->GetKeyAttributeNumber())
+						 attribute->GetDerivationRule() == NULL and
+						 attribute->GetClass()->GetKeyAttributeNumber() <
+						     pathClass->GetKeyAttributeNumber())
 					{
 						bOk = false;
 						AddError("Data path " + mapping->GetObjectLabel() +
-							" : In dictionary " + mapping->GetClassName() +
-							" of variable " + sAttributeName + ", the key length (" +
-							IntToString(attribute->GetClass()->GetKeyAttributeNumber()) +
-							") must not be less than that of its parent "
-							"dictionary " +
-							pathClass->GetName() + "(" +
-							IntToString(pathClass->GetKeyAttributeNumber()) + ")");
-							 " variables)");
-							 " variables)");
+							 " : In dictionary " + mapping->GetClassName() +
+							 " of variable " + sAttributeName + ", the key length (" +
+							 IntToString(attribute->GetClass()->GetKeyAttributeNumber()) +
+							 ") must not be less than that of its parent "
+							 "dictionary " +
+							 pathClass->GetName() + "(" +
+							 IntToString(pathClass->GetKeyAttributeNumber()) + ")");
 					}
 
 					// Passage a la classe suivante dans le path
@@ -754,20 +752,20 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 			for (nMapping = 0; nMapping < checkDatabase.GetMultiTableMappings()->GetSize(); nMapping++)
 			{
 				checkMapping =
-					cast(KWMTDatabaseMapping*, checkDatabase.GetMultiTableMappings()->GetAt(nMapping));
+				    cast(KWMTDatabaseMapping*, checkDatabase.GetMultiTableMappings()->GetAt(nMapping));
 
 				// Recherche du mapping correspondant, puis verification
 				mapping = LookupMultiTableMapping(checkMapping->GetDataPath());
 				if (mapping == NULL)
 				{
 					AddError("Data path " + checkMapping->GetObjectLabel() +
-						" : No data path specification");
+						 " : No data path specification");
 					bOk = false;
 				}
 				else if (mapping->GetDataTableName() == "")
 				{
 					AddError("Data path " + checkMapping->GetObjectLabel() +
-						" : No data table file specified");
+						 " : No data table file specified");
 					bOk = false;
 				}
 			}
@@ -893,7 +891,7 @@ longint KWMTDatabase::GetUsedMemory() const
 	{
 		cout << "KWMTDatabase::GetUsedMemory, base memory: " << KWDatabase::GetUsedMemory() << endl;
 		cout << "KWMTDatabase::GetUsedMemory, reference memory: " << objectReferenceResolver.GetUsedMemory()
-			<< endl;
+		     << endl;
 		cout << "KWMTDatabase::GetUsedMemory, total memory: " << lUsedMemory << endl;
 	}
 	return lUsedMemory;
@@ -1009,10 +1007,10 @@ boolean KWMTDatabase::CheckObjectConsistency() const
 						if (not bOk)
 						{
 							AddError("Native entities used as operand in rule " +
-								rule->GetName() + " to build variable " +
-								attribute->GetName() + " in dictionary " +
-								secondaryClass->GetName() +
-								" should be loaded in memory");
+								 rule->GetName() + " to build variable " +
+								 attribute->GetName() + " in dictionary " +
+								 secondaryClass->GetName() +
+								 " should be loaded in memory");
 							break;
 						}
 					}
@@ -1057,14 +1055,14 @@ boolean KWMTDatabase::CheckObjectRuleConsistency(KWDerivationRule* rule) const
 					if (attributeOperand->GetDerivationRule() == NULL)
 					{
 						if (not attributeOperand->GetLoaded() and
-							not attributeOperand->GetInternalLoadIndex().IsValid())
+						    not attributeOperand->GetInternalLoadIndex().IsValid())
 						{
 							AddError("Variable " + attributeOperand->GetName() +
-								" of dictionary " +
-								attributeOperand->GetParentClass()->GetName() +
-								" used as operand " + IntToString(nOperand + 1) +
-								" in rule " + rule->GetName() +
-								" should be loaded in memory");
+								 " of dictionary " +
+								 attributeOperand->GetParentClass()->GetName() +
+								 " used as operand " + IntToString(nOperand + 1) +
+								 " in rule " + rule->GetName() +
+								 " should be loaded in memory");
 							bOk = false;
 						}
 					}
@@ -1213,7 +1211,7 @@ void KWMTDatabase::PhysicalReadAfterEndOfDatabase()
 		// Lecture dans la sous base
 		mappedDataTableDriver = componentMapping->GetDataTableDriver();
 		if (mappedDataTableDriver != NULL and mappedDataTableDriver->GetDataTableName() != "" and
-			mappedDataTableDriver->IsOpenedForRead())
+		    mappedDataTableDriver->IsOpenedForRead())
 		{
 			// On recupere le dernier objet non traite
 			kwoLastSubObject = componentMapping->GetLastReadObject();
@@ -1231,9 +1229,9 @@ void KWMTDatabase::PhysicalReadAfterEndOfDatabase()
 				{
 					lastSubObjectKey.InitializeFromObject(kwoLastSubObject);
 					mappedDataTableDriver->AddWarning(
-						sTmp + "Ignored record" + ", orphan record " +
-						componentMapping->GetClassName() + lastSubObjectKey.GetObjectLabel() +
-						" found beyond the key of the last record of the main table");
+					    sTmp + "Ignored record" + ", orphan record " +
+					    componentMapping->GetClassName() + lastSubObjectKey.GetObjectLabel() +
+					    " found beyond the key of the last record of the main table");
 				}
 			}
 
@@ -1270,12 +1268,12 @@ void KWMTDatabase::PhysicalReadAfterEndOfDatabase()
 					if (subObjectKey.StrictCompare(&lastSubObjectKey) < 0)
 					{
 						mappedDataTableDriver->AddError(
-							sTmp + "Unsorted record " + componentMapping->GetClassName() +
-							subObjectKey.GetObjectLabel() +
-							", with key inferior to that of the preceding record " +
-							componentMapping->GetClassName() +
-							lastSubObjectKey.GetObjectLabel() +
-							", beyond the key of the last record of the main table");
+						    sTmp + "Unsorted record " + componentMapping->GetClassName() +
+						    subObjectKey.GetObjectLabel() +
+						    ", with key inferior to that of the preceding record " +
+						    componentMapping->GetClassName() +
+						    lastSubObjectKey.GetObjectLabel() +
+						    ", beyond the key of the last record of the main table");
 						bIsError = true;
 					}
 				}
@@ -1285,9 +1283,9 @@ void KWMTDatabase::PhysicalReadAfterEndOfDatabase()
 				{
 					subObjectKey.InitializeFromObject(kwoSubObject);
 					mappedDataTableDriver->AddWarning(
-						sTmp + "Ignored record" + ", orphan record " +
-						componentMapping->GetClassName() + subObjectKey.GetObjectLabel() +
-						" found beyond the key of the last record of the main table");
+					    sTmp + "Ignored record" + ", orphan record " +
+					    componentMapping->GetClassName() + subObjectKey.GetObjectLabel() +
+					    " found beyond the key of the last record of the main table");
 				}
 
 				// Memorisation du dernier sous-objet lu
@@ -1322,9 +1320,9 @@ void KWMTDatabase::PhysicalSkip()
 	if (kwcClass->IsUnique())
 	{
 		assert(mainMultiTableMapping->GetDataTableDriver()->GetLastReadMainKey()->GetSize() ==
-			mainMultiTableMapping->GetDataTableDriver()->GetClass()->GetKeyAttributeNumber());
+		       mainMultiTableMapping->GetDataTableDriver()->GetClass()->GetKeyAttributeNumber());
 		mainMultiTableMapping->SetLastReadKey(
-			mainMultiTableMapping->GetDataTableDriver()->GetLastReadMainKey());
+		    mainMultiTableMapping->GetDataTableDriver()->GetLastReadMainKey());
 	}
 
 	// Attention, il n'est pas possible de propager les skip sur les sous-tables
@@ -1373,7 +1371,7 @@ longint KWMTDatabase::GetPhysicalEstimatedObjectNumber()
 	mainMultiTableMapping->SetDataTableDriver(CreateDataTableDriver(mainMultiTableMapping));
 	mainMultiTableMapping->GetDataTableDriver()->SetDataTableName(mainMultiTableMapping->GetDataTableName());
 	mainMultiTableMapping->GetDataTableDriver()->SetClass(
-		KWClassDomain::GetCurrentDomain()->LookupClass(GetClassName()));
+	    KWClassDomain::GetCurrentDomain()->LookupClass(GetClassName()));
 
 	// Appel de la methode du driver
 	lPhysicalEstimatedObjectNumber = mainMultiTableMapping->GetDataTableDriver()->GetEstimatedObjectNumber();
@@ -1419,15 +1417,15 @@ void KWMTDatabase::CollectPhysicalStatsMessages(ObjectArray* oaPhysicalMessages)
 		// Nombre d'enregistrements lus par mapping
 		mappedDataTableDriver = mapping->GetDataTableDriver();
 		if (mappedDataTableDriver != NULL and mappedDataTableDriver->GetDataTableName() != "" and
-			not mappedDataTableDriver->GetSilentMode() and mappedDataTableDriver->GetVerboseMode())
+		    not mappedDataTableDriver->GetSilentMode() and mappedDataTableDriver->GetVerboseMode())
 		{
 			errorMessage = new Error;
 
 			// On ne passe par mappedDataTableDriver->GetObjectLabel() pour eviter d'avoir un numero de
 			// record
 			errorMessage->Initialize(
-				Error::GravityMessage, "", "",
-				sTmp + "  Table " + mappedDataTableDriver->GetDataTableName() + " " +
+			    Error::GravityMessage, "", "",
+			    sTmp + "  Table " + mappedDataTableDriver->GetDataTableName() + " " +
 				"Records: " + LongintToReadableString(mappedDataTableDriver->GetUsedRecordNumber()));
 			oaPhysicalMessages->Add(errorMessage);
 		}
@@ -1469,7 +1467,7 @@ void KWMTDatabase::MutatePhysicalObject(KWObject* kwoPhysicalObject) const
 	// Referencement du nouvel objet principal lu depuis le resolveur de reference, s'il est Root
 	if (kwcPhysicalClass->GetRoot() and not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
 		objectReferenceResolver.AddObject(kwcPhysicalClass, mainMultiTableMapping->GetLastReadKey(),
-			kwoPhysicalObject);
+						  kwoPhysicalObject);
 
 	// Appel de la methode ancetre
 	KWDatabase::MutatePhysicalObject(kwoPhysicalObject);
@@ -1509,15 +1507,15 @@ boolean KWMTDatabase::IsPhysicalObjectSelected(KWObject* kwoPhysicalObject)
 		// Referencement du nouvel objet principal lu depuis le resolveur de reference
 		if (kwcPhysicalClass->GetRoot() and not mainMultiTableMapping->GetLastReadKey()->IsEmpty())
 			objectReferenceResolver.AddObject(kwcPhysicalClass, mainMultiTableMapping->GetLastReadKey(),
-				kwoPhysicalObject);
+							  kwoPhysicalObject);
 
 		// Calcul du critere de selection
 		if (nSelectionAttributeType == KWType::Symbol)
 			bSelected =
-			kwoPhysicalObject->ComputeSymbolValueAt(liSelectionAttributeLoadIndex) == sSelectionSymbol;
+			    kwoPhysicalObject->ComputeSymbolValueAt(liSelectionAttributeLoadIndex) == sSelectionSymbol;
 		else if (nSelectionAttributeType == KWType::Continuous)
 			bSelected = kwoPhysicalObject->ComputeContinuousValueAt(liSelectionAttributeLoadIndex) ==
-			cSelectionContinuous;
+				    cSelectionContinuous;
 		else
 			bSelected = false;
 
@@ -1534,10 +1532,10 @@ boolean KWMTDatabase::IsPhysicalObjectSelected(KWObject* kwoPhysicalObject)
 }
 
 KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceClasses,
-	ObjectArray* oaRankedReferenceClasses,
-	ObjectDictionary* odAnalysedCreatedClasses, KWClass* mappedClass,
-	boolean bIsExternalTable, const ALString& sOriginClassName,
-	StringVector* svAttributeNames, ObjectArray* oaCreatedMappings)
+						 ObjectArray* oaRankedReferenceClasses,
+						 ObjectDictionary* odAnalysedCreatedClasses, KWClass* mappedClass,
+						 boolean bIsExternalTable, const ALString& sOriginClassName,
+						 StringVector* svAttributeNames, ObjectArray* oaCreatedMappings)
 {
 	const KWDRReference referenceRule;
 	KWMTDatabaseMapping* mapping;
@@ -1584,9 +1582,9 @@ KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceCl
 
 				// Creation du mapping dans une nouvelle table de mapping temporaire
 				subMapping =
-					CreateMapping(odReferenceClasses, oaRankedReferenceClasses,
-						odAnalysedCreatedClasses, attribute->GetClass(), bIsExternalTable,
-						sOriginClassName, svAttributeNames, oaCreatedMappings);
+				    CreateMapping(odReferenceClasses, oaRankedReferenceClasses,
+						  odAnalysedCreatedClasses, attribute->GetClass(), bIsExternalTable,
+						  sOriginClassName, svAttributeNames, oaCreatedMappings);
 
 				// Supression de l'attribut ajoute temporairement
 				svAttributeNames->SetSize(svAttributeNames->GetSize() - 1);
@@ -1602,7 +1600,7 @@ KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceCl
 
 				// Recherche de la classe cible
 				kwcTargetClass = mappedClass->GetDomain()->LookupClass(
-					attribute->GetDerivationRule()->GetObjectClassName());
+				    attribute->GetDerivationRule()->GetObjectClassName());
 				assert(kwcTargetClass != NULL);
 
 				// Analyse uniquement si la classe cible na pas deja ete analysees
@@ -1625,7 +1623,7 @@ KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceCl
 							if (odReferenceClasses->Lookup(kwcUsedClass->GetName()) == NULL)
 							{
 								odReferenceClasses->SetAt(kwcUsedClass->GetName(),
-									kwcUsedClass);
+											  kwcUsedClass);
 								oaRankedReferenceClasses->Add(kwcUsedClass);
 							}
 						}
@@ -1639,7 +1637,7 @@ KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceCl
 				if (odReferenceClasses->Lookup(attribute->GetClass()->GetName()) == NULL)
 				{
 					odReferenceClasses->SetAt(attribute->GetClass()->GetName(),
-						attribute->GetClass());
+								  attribute->GetClass());
 					oaRankedReferenceClasses->Add(attribute->GetClass());
 				}
 			}
@@ -1702,7 +1700,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 		// Acces aux classes physique et logique referencees, en passant par le domaine de la classe principale
 		kwcReferenceClass = kwcClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 		kwcReferencePhysicalClass =
-			kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
+		    kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 		check(kwcReferenceClass);
 		check(kwcReferencePhysicalClass);
 
@@ -1716,7 +1714,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 		// Les etapes precedentes ont determine si la table etait utile, et dans le cas inverse
 		// la cle n'est pas chargee
 		if (referenceMapping->GetDataTableDriver()->GetDataTableName() != "" and
-			kwcReferencePhysicalClass->IsKeyLoaded())
+		    kwcReferencePhysicalClass->IsKeyLoaded())
 		{
 			bOk = DMTMPhysicalOpenForRead(referenceMapping, kwcReferenceClass);
 
@@ -1750,7 +1748,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 						assert(kwoObject->GetClass() == kwcReferencePhysicalClass);
 						objectKey.InitializeFromObject(kwoObject);
 						objectReferenceResolver.AddObject(kwcReferencePhysicalClass, &objectKey,
-							kwoObject);
+										  kwoObject);
 						lObjectNumber++;
 					}
 
@@ -1759,8 +1757,8 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 					{
 						bOk = false;
 						AddError(sTmp + "Read external data table " +
-							referenceMapping->GetDataTableName() +
-							" interrupted because of errors");
+							 referenceMapping->GetDataTableName() +
+							 " interrupted because of errors");
 						break;
 					}
 
@@ -1773,7 +1771,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 
 					// Arret si pourcentage atteint
 					if (dSamplePercentage < 1 and
-						referenceMapping->GetDataTableDriver()->GetReadPercentage() >
+					    referenceMapping->GetDataTableDriver()->GetReadPercentage() >
 						dSamplePercentage)
 						break;
 
@@ -1781,10 +1779,10 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 					if (bIsInTask and TaskProgression::IsRefreshNecessary())
 					{
 						TaskProgression::DisplayLabel(sMessage + ": " +
-							LongintToReadableString(lObjectNumber) +
-							" records");
+									      LongintToReadableString(lObjectNumber) +
+									      " records");
 						TaskProgression::DisplayProgression(int(
-							100 * referenceMapping->GetDataTableDriver()->GetReadPercentage()));
+						    100 * referenceMapping->GetDataTableDriver()->GetReadPercentage()));
 					}
 				}
 
@@ -1836,13 +1834,13 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 		{
 			referenceMapping = cast(KWMTDatabaseMapping*, oaRootReferenceTableMappings.GetAt(nReference));
 			assert(referenceMapping->GetDataTableDriver() == NULL or
-				not referenceMapping->GetDataTableDriver()->IsOpenedForRead());
+			       not referenceMapping->GetDataTableDriver()->IsOpenedForRead());
 
 			// Acces aux classes physique et logique referencees, en passant par le domaine de la classe
 			// principale
 			kwcReferenceClass = kwcClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 			kwcReferencePhysicalClass =
-				kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
+			    kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 
 			// Traitement si la classe existe dans le resolveur de reference
 			if (objectReferenceResolver.LookupClass(kwcReferencePhysicalClass->GetName()) != NULL)
@@ -1965,7 +1963,7 @@ longint KWMTDatabase::ComputeSamplingBasedNecessaryMemoryForReferenceObjects()
 	lSamplingBasedNecessaryMemory = longint(lSamplingBasedNecessaryMemory / (1 + MemGetAllocatorOverhead()));
 	if (bDisplay)
 		cout << "\tSampling based estimation\t" << LongintToHumanReadableString(lSamplingBasedNecessaryMemory)
-		<< endl;
+		     << endl;
 	ensure(lSamplingBasedNecessaryMemory >= 0);
 	return lSamplingBasedNecessaryMemory;
 }
@@ -2001,7 +1999,7 @@ longint KWMTDatabase::ComputeNecessaryMemoryForReferenceObjects()
 		// Acces aux classes physique et logique referencees, en passant par le domaine de la classe principale
 		kwcReferenceClass = kwcClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 		kwcReferencePhysicalClass =
-			kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
+		    kwcPhysicalClass->GetDomain()->LookupClass(referenceMapping->GetClassName());
 		check(kwcReferenceClass);
 		check(kwcReferencePhysicalClass);
 
@@ -2030,13 +2028,13 @@ longint KWMTDatabase::ComputeNecessaryMemoryForReferenceObjects()
 
 				// Calcul de la memoire, en tenant compte du nombre d'attributs natifs
 				lNecessaryMemory =
-					mapping->GetDataTableDriver()->ComputeNecessaryMemoryForFullExternalRead(
-						kwcMappingLogicalClass);
+				    mapping->GetDataTableDriver()->ComputeNecessaryMemoryForFullExternalRead(
+					kwcMappingLogicalClass);
 			}
 			lTotalNecessaryMemory += lNecessaryMemory;
 			if (bDisplay)
 				cout << "Necessary memory for " << mapping->GetObjectLabel() << ": "
-				<< LongintToHumanReadableString(lNecessaryMemory) << endl;
+				     << LongintToHumanReadableString(lNecessaryMemory) << endl;
 		}
 
 		// Nettoyage final
@@ -2044,7 +2042,7 @@ longint KWMTDatabase::ComputeNecessaryMemoryForReferenceObjects()
 	}
 	if (bDisplay)
 		cout << "Necessary memory for reference objects for database " << GetDatabaseName() << ": "
-		<< LongintToHumanReadableString(lTotalNecessaryMemory) << endl;
+		     << LongintToHumanReadableString(lTotalNecessaryMemory) << endl;
 	return lTotalNecessaryMemory;
 }
 
@@ -2078,7 +2076,7 @@ void KWMTDatabase::DMTMPhysicalInitializeMapping(KWMTDatabaseMapping* mapping, K
 	}
 	// En lecture (dans le domaine classe physique), la classe mappee doit avoir les attributs cle en load
 	assert(nDataPathAttributeNumber == 0 or mappedClass->GetDomain() == kwcClass->GetDomain() or
-		mapping->GetDataTableDriver()->GetClass()->IsKeyLoaded());
+	       mapping->GetDataTableDriver()->GetClass()->IsKeyLoaded());
 
 	// Parametrage du mapping de la composition, si necessaire en lecture, toujours en ecriture
 	if (mappedClass->IsKeyLoaded() or not bRead)
@@ -2097,7 +2095,7 @@ void KWMTDatabase::DMTMPhysicalInitializeMapping(KWMTDatabaseMapping* mapping, K
 
 			// Parametrage du mapping si base specifiee et si la classe mappe est indexable
 			if (componentMapping->GetDataTableName() != "" and attribute != NULL and
-				attribute->GetClass()->GetKeyAttributeNumber() > 0 and attribute->GetLoaded())
+			    attribute->GetClass()->GetKeyAttributeNumber() > 0 and attribute->GetLoaded())
 			{
 				// Creation d'un driver de table ayant par defaut les memes caracteristiques que la base
 				// courante
@@ -2132,7 +2130,7 @@ void KWMTDatabase::DMTMPhysicalTerminateMapping(KWMTDatabaseMapping* mapping)
 	if (mapping->GetDataTableDriver() != NULL)
 	{
 		assert(not mapping->GetDataTableDriver()->IsOpenedForRead() and
-			not mapping->GetDataTableDriver()->IsOpenedForWrite());
+		       not mapping->GetDataTableDriver()->IsOpenedForWrite());
 		mapping->GetDataTableDriver()->SetClass(NULL);
 		delete mapping->GetDataTableDriver();
 		mapping->SetDataTableDriver(NULL);
@@ -2204,37 +2202,37 @@ boolean KWMTDatabase::DMTMPhysicalOpenForRead(KWMTDatabaseMapping* mapping, cons
 			for (i = 0; i < mapping->GetComponentTableMappings()->GetSize(); i++)
 			{
 				componentMapping =
-					cast(KWMTDatabaseMapping*, mapping->GetComponentTableMappings()->GetAt(i));
+				    cast(KWMTDatabaseMapping*, mapping->GetComponentTableMappings()->GetAt(i));
 
 				// Ouverture de la table du mapping composant
 				if (componentMapping->GetDataTableDriver() != NULL and
-					componentMapping->GetDataTableDriver()->GetDataTableName() != "")
+				    componentMapping->GetDataTableDriver()->GetDataTableName() != "")
 				{
 					// Ouverture physique de la sous-base si necessaire
 					sAttributeName =
-						componentMapping->GetDataPathAttributeNameAt(nDataPathAttributeNumber);
+					    componentMapping->GetDataPathAttributeNameAt(nDataPathAttributeNumber);
 					physicalAttribute =
-						mapping->GetDataTableDriver()->GetClass()->LookupAttribute(sAttributeName);
+					    mapping->GetDataTableDriver()->GetClass()->LookupAttribute(sAttributeName);
 					attribute = kwcLogicalClass->LookupAttribute(sAttributeName);
 					if (physicalAttribute != NULL)
 					{
 						assert(KWType::IsRelation(physicalAttribute->GetType()));
 						assert(physicalAttribute->GetClass()->IsCompiled());
 						assert(componentMapping->GetDataTableDriver()->GetClass() ==
-							physicalAttribute->GetClass());
+						       physicalAttribute->GetClass());
 						assert(attribute->GetClass() != NULL);
 						assert(attribute->GetClass()->GetName() ==
-							physicalAttribute->GetClass()->GetName());
+						       physicalAttribute->GetClass()->GetName());
 
 						// Ouverture de la sous-table
 						componentMapping->GetDataTableDriver()->OpenForRead(
-							attribute->GetClass());
+						    attribute->GetClass());
 						bOk = bOk and componentMapping->GetDataTableDriver()->IsOpenedForRead();
 
 						// Propagation si OK
 						if (bOk)
 							bOk = DMTMPhysicalOpenForRead(componentMapping,
-								attribute->GetClass());
+										      attribute->GetClass());
 						// Arret sinon
 						else
 							break;
@@ -2293,18 +2291,18 @@ boolean KWMTDatabase::DMTMPhysicalOpenForWrite(KWMTDatabaseMapping* mapping)
 
 			// Ouverture de la table du mapping composant
 			if (componentMapping->GetDataTableDriver() != NULL and
-				componentMapping->GetDataTableDriver()->GetDataTableName() != "")
+			    componentMapping->GetDataTableDriver()->GetDataTableName() != "")
 			{
 				// Ouverture physique de la sous-base si necessaire
 				sAttributeName = componentMapping->GetDataPathAttributeNameAt(nDataPathAttributeNumber);
 				physicalAttribute =
-					mapping->GetDataTableDriver()->GetClass()->LookupAttribute(sAttributeName);
+				    mapping->GetDataTableDriver()->GetClass()->LookupAttribute(sAttributeName);
 				if (physicalAttribute != NULL)
 				{
 					assert(KWType::IsRelation(physicalAttribute->GetType()));
 					assert(physicalAttribute->GetClass()->IsCompiled());
 					assert(componentMapping->GetDataTableDriver()->GetClass() ==
-						physicalAttribute->GetClass());
+					       physicalAttribute->GetClass());
 
 					// Ouverture de la sous-table
 					componentMapping->GetDataTableDriver()->OpenForWrite();
@@ -2424,7 +2422,7 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 		if (mapping->GetDataTableDriver()->GetClass()->IsUnique())
 		{
 			assert(mapping->GetDataTableDriver()->GetLastReadMainKey()->GetSize() ==
-				mapping->GetDataTableDriver()->GetClass()->GetKeyAttributeNumber());
+			       mapping->GetDataTableDriver()->GetClass()->GetKeyAttributeNumber());
 			mapping->SetLastReadKey(mapping->GetDataTableDriver()->GetLastReadMainKey());
 		}
 		return NULL;
@@ -2450,12 +2448,12 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 				// Warning si la cle egale dans le cas d'une classe principale, et supression de
 				// l'enregistrement
 				if (kwoObject->GetClass()->IsUnique() and
-					objectKey.StrictCompare(mapping->GetLastReadKey()) == 0)
+				    objectKey.StrictCompare(mapping->GetLastReadKey()) == 0)
 				{
 					// Warning de lecture
 					mapping->GetDataTableDriver()->AddWarning(
-						sTmp + "Ignored record" + ", duplicate key " + mapping->GetClassName() +
-						objectKey.GetObjectLabel());
+					    sTmp + "Ignored record" + ", duplicate key " + mapping->GetClassName() +
+					    objectKey.GetObjectLabel());
 
 					// On ignore l'enregistrement
 					delete kwoObject;
@@ -2466,10 +2464,10 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 				{
 					// Erreur de lecture
 					mapping->GetDataTableDriver()->AddError(
-						sTmp + "Unsorted record " + mapping->GetClassName() +
-						objectKey.GetObjectLabel() +
-						", with key inferior to that of the preceding record " +
-						mapping->GetClassName() + mapping->GetLastReadKey()->GetObjectLabel());
+					    sTmp + "Unsorted record " + mapping->GetClassName() +
+					    objectKey.GetObjectLabel() +
+					    ", with key inferior to that of the preceding record " +
+					    mapping->GetClassName() + mapping->GetLastReadKey()->GetObjectLabel());
 					bIsError = true;
 
 					// On ignore l'enregistrement
@@ -2489,7 +2487,7 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 			// L'incrementation pour les mappings de la composition est effectuee par la suite
 			if (mapping == mainMultiTableMapping)
 				mapping->GetDataTableDriver()->SetUsedRecordNumber(
-					mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
+				    mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
 		}
 
 		// Parcours des mappings de la composition  pour completer la lecture de l'objet
@@ -2500,13 +2498,13 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 			// Lecture dans la sous base
 			mappedDataTableDriver = componentMapping->GetDataTableDriver();
 			if (mappedDataTableDriver != NULL and mappedDataTableDriver->GetDataTableName() != "" and
-				mappedDataTableDriver->IsOpenedForRead())
+			    mappedDataTableDriver->IsOpenedForRead())
 			{
 				// Lecture des sous-objets
 				oaSubObjects = NULL;
 				kwoSubObject = NULL;
 				while (componentMapping->GetLastReadObject() != NULL or
-					not mappedDataTableDriver->IsEnd())
+				       not mappedDataTableDriver->IsEnd())
 				{
 					bNewSubObject = false;
 
@@ -2540,12 +2538,12 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 						// Verification de la coherence entre la classe du sous-objet, et sa
 						// classe attendue depuis son objet englobant
 						assert(componentMapping != mainMultiTableMapping and
-							not kwoSubObject->GetClass()->GetRoot());
+						       not kwoSubObject->GetClass()->GetRoot());
 						assert(kwoSubObject->GetClass() ==
-							kwoObject->GetClass()
-							->GetAttributeAtLoadIndex(
-								componentMapping->GetMappedAttributeLoadIndex())
-							->GetClass());
+						       kwoObject->GetClass()
+							   ->GetAttributeAtLoadIndex(
+							       componentMapping->GetMappedAttributeLoadIndex())
+							   ->GetClass());
 
 						// Recherche de la cle de l'objet secondaire
 						subObjectKey.InitializeFromObject(kwoSubObject);
@@ -2570,19 +2568,19 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 							// Pour un attribut de type Object, on associe le sous-objet a
 							// son incluant et c'est fini
 							else if (componentMapping->GetMappedAttributeType() ==
-								KWType::Object)
+								 KWType::Object)
 							{
 								kwoObject->SetObjectValueAt(
-									componentMapping->GetMappedAttributeLoadIndex(),
-									kwoSubObject);
+								    componentMapping->GetMappedAttributeLoadIndex(),
+								    kwoSubObject);
 
 								// Incrementation du compteur d'objet utilise au niveau
 								// physique
 								componentMapping->GetDataTableDriver()
-									->SetUsedRecordNumber(
-										componentMapping->GetDataTableDriver()
-										->GetUsedRecordNumber() +
-										1);
+								    ->SetUsedRecordNumber(
+									componentMapping->GetDataTableDriver()
+									    ->GetUsedRecordNumber() +
+									1);
 
 								// Memorisation de la derniere cle lue
 								componentMapping->SetLastReadKey(&subObjectKey);
@@ -2595,16 +2593,16 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 							else
 							{
 								assert(componentMapping->GetMappedAttributeType() ==
-									KWType::ObjectArray);
+								       KWType::ObjectArray);
 
 								// Creation si necessaire du tableau
 								if (oaSubObjects == NULL)
 								{
 									oaSubObjects = new ObjectArray;
 									kwoObject->SetObjectArrayValueAt(
-										componentMapping
+									    componentMapping
 										->GetMappedAttributeLoadIndex(),
-										oaSubObjects);
+									    oaSubObjects);
 								}
 
 								// Rangement du sous-objet dans le tableau
@@ -2613,10 +2611,10 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 								// Incrementation du compteur d'objet utilise au niveau
 								// physique
 								componentMapping->GetDataTableDriver()
-									->SetUsedRecordNumber(
-										componentMapping->GetDataTableDriver()
-										->GetUsedRecordNumber() +
-										1);
+								    ->SetUsedRecordNumber(
+									componentMapping->GetDataTableDriver()
+									    ->GetUsedRecordNumber() +
+									1);
 							}
 
 							// Memorisation de la derniere cle lue
@@ -2633,36 +2631,36 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 							// ete lu
 							bWarningEmmited = false;
 							if (componentMapping->GetLastReadKey()->GetSize() > 0 and
-								bNewSubObject)
+							    bNewSubObject)
 							{
 								// Erreur si probleme d'ordonnancement
 								if (subObjectKey.StrictCompare(
 									componentMapping->GetLastReadKey()) < 0)
 								{
 									mappedDataTableDriver->AddError(
-										sTmp + "Unsorted record " +
-										componentMapping->GetClassName() +
-										subObjectKey.GetObjectLabel() +
-										", with key inferior to that of the "
-										"preceding record " +
-										componentMapping->GetClassName() +
-										componentMapping->GetLastReadKey()
+									    sTmp + "Unsorted record " +
+									    componentMapping->GetClassName() +
+									    subObjectKey.GetObjectLabel() +
+									    ", with key inferior to that of the "
+									    "preceding record " +
+									    componentMapping->GetClassName() +
+									    componentMapping->GetLastReadKey()
 										->GetObjectLabel());
 									bIsError = true;
 								}
 								// Warning si probleme de duplication dans le cas d'un
 								// sous-objet
 								else if (componentMapping->GetMappedAttributeType() ==
-									KWType::Object and
-									subObjectKey.StrictCompare(
-										componentMapping->GetLastReadKey()) == 0)
+									     KWType::Object and
+									 subObjectKey.StrictCompare(
+									     componentMapping->GetLastReadKey()) == 0)
 								{
 									bWarningEmmited = true;
 									mappedDataTableDriver->AddWarning(
-										sTmp + "Ignored record" +
-										", duplicate key " +
-										componentMapping->GetClassName() +
-										subObjectKey.GetObjectLabel());
+									    sTmp + "Ignored record" +
+									    ", duplicate key " +
+									    componentMapping->GetClassName() +
+									    subObjectKey.GetObjectLabel());
 								}
 							}
 
@@ -2672,17 +2670,17 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 							// enregistrement secondaires non rattachable a l'objet
 							// principal
 							if (not bIsError and not bWarningEmmited and
-								nSkippedRecordNumber == 0)
+							    nSkippedRecordNumber == 0)
 							{
 								bWarningEmmited = true;
 								mappedDataTableDriver->AddWarning(
-									sTmp + "Ignored record" + ", orphan record " +
-									componentMapping->GetClassName() +
-									subObjectKey.GetObjectLabel() +
-									" with key inferior to that of the including "
-									"record " +
-									mapping->GetClassName() +
-									objectKey.GetObjectLabel());
+								    sTmp + "Ignored record" + ", orphan record " +
+								    componentMapping->GetClassName() +
+								    subObjectKey.GetObjectLabel() +
+								    " with key inferior to that of the including "
+								    "record " +
+								    mapping->GetClassName() +
+								    objectKey.GetObjectLabel());
 							}
 
 							// Destruction du sous-objet non utilise
@@ -2729,7 +2727,7 @@ void KWMTDatabase::DMTMPhysicalWrite(KWMTDatabaseMapping* mapping, const KWObjec
 	// Incrementation du compteur d'objet utilise au niveau physique
 	if (not bIsError)
 		mapping->GetDataTableDriver()->SetUsedRecordNumber(
-			mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
+		    mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
 
 	// Positionnement du flag d'erreur
 	bIsError = bIsError or mapping->GetDataTableDriver()->IsError();
@@ -2743,13 +2741,13 @@ void KWMTDatabase::DMTMPhysicalWrite(KWMTDatabaseMapping* mapping, const KWObjec
 		// Ecriture si necessaire
 		mappedDataTableDriver = componentMapping->GetDataTableDriver();
 		if (mappedDataTableDriver != NULL and mappedDataTableDriver->GetDataTableName() != "" and
-			mappedDataTableDriver->IsOpenedForWrite())
+		    mappedDataTableDriver->IsOpenedForWrite())
 		{
 			// Ecriture de l'attribut mappe
 			if (componentMapping->GetMappedAttributeType() == KWType::Object)
 			{
 				kwoSubObject =
-					kwoObject->GetObjectValueAt(componentMapping->GetMappedAttributeLoadIndex());
+				    kwoObject->GetObjectValueAt(componentMapping->GetMappedAttributeLoadIndex());
 				// Propagation au reste de la composition par appel recursif a DMTMPhysicalWrite
 				if (kwoSubObject != NULL)
 					DMTMPhysicalWrite(componentMapping, kwoSubObject);
@@ -2757,7 +2755,7 @@ void KWMTDatabase::DMTMPhysicalWrite(KWMTDatabaseMapping* mapping, const KWObjec
 			else if (componentMapping->GetMappedAttributeType() == KWType::ObjectArray)
 			{
 				oaSubObjectArray =
-					kwoObject->GetObjectArrayValueAt(componentMapping->GetMappedAttributeLoadIndex());
+				    kwoObject->GetObjectArrayValueAt(componentMapping->GetMappedAttributeLoadIndex());
 				if (oaSubObjectArray != NULL)
 				{
 					// Ecriture des sous-objet du tableau
@@ -2789,6 +2787,6 @@ void KWMTDatabase::WriteMapingArray(ostream& ost, const ALString& sTitle, const 
 	{
 		mapping = cast(KWMTDatabaseMapping*, oaMappings->GetAt(n));
 		ost << "\t" << n + 1 << "\t" << mapping->GetDataPath() << "\t" << mapping->GetClassName() << "\t"
-			<< mapping->GetDataTableName() << "\n";
+		    << mapping->GetDataTableName() << "\n";
 	}
 }

--- a/src/Learning/KWDataPreparation/KWDataGridStats.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridStats.cpp
@@ -3258,7 +3258,7 @@ int KWDGSAttributeGrouping::GetGroupLastValueIndexAt(int nGroupIndex) const
 {
 	require(0 <= nGroupIndex and nGroupIndex < GetGroupNumber());
 
-	// On renvoie soit l'index de la valeur precedent la premiere valeur du groupe suivant
+	// On renvoie soit l'index de la valeur precedant la premiere valeur du groupe suivant
 	if (nGroupIndex < ivGroupFirstValueIndexes.GetSize() - 1)
 		return ivGroupFirstValueIndexes.GetAt(nGroupIndex + 1) - 1;
 	// Soit l'index de la derniere valeur

--- a/src/Learning/MODL_Coclustering/CCCoclusteringReport.cpp
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringReport.cpp
@@ -550,7 +550,7 @@ boolean CCCoclusteringReport::ReadDimensionSummaries(CCHierarchicalDataGrid* coc
 		}
 
 		// CH IV Begin
-		// Lecture de la prochaine cle explicitement, pour traiter la cle optionnelle "isVarPart" precedent la
+		// Lecture de la prochaine cle explicitement, pour traiter la cle optionnelle "isVarPart" precedant la
 		// cle "type", depuis la prise en compte du coclustering instances x variables
 		bOk = bOk and JSONTokenizer::ReadStringValue(sKey);
 

--- a/src/Norm/base/JSONLex.inc
+++ b/src/Norm/base/JSONLex.inc
@@ -774,7 +774,7 @@ char *yytext;
 #pragma warning(disable : 4996) // C4996: warning for deprecated POSIX names isatty and fileno
 #endif                          // __MSC__
 #line 776 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONLex.inc"
-/* pour avoir acces aux numeros de lignes, et moins cher que le -l de la ligne de commande */
+/* Pour avoir acces aux numeros de lignes, et moins cher que le -l de la ligne de commande */
 #line 778 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONLex.inc"
 
 #define INITIAL 0
@@ -1137,11 +1137,13 @@ case 12:
 /* rule 12 can match eol */
 YY_RULE_SETUP
 #line 76 "JSONLex.lex"
-{/*IGNORE*/}
+{
+                  // On ignore les caracteres d'espacement
+                }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 78 "JSONLex.lex"
+#line 80 "JSONLex.lex"
 {
                     ALString *sValue;
 
@@ -1152,10 +1154,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 86 "JSONLex.lex"
+#line 88 "JSONLex.lex"
 ECHO;
 	YY_BREAK
-#line 1158 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONLex.inc"
+#line 1160 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONLex.inc"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2172,5 +2174,5 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 86 "JSONLex.lex"
+#line 88 "JSONLex.lex"
 

--- a/src/Norm/base/JSONLex.lex
+++ b/src/Norm/base/JSONLex.lex
@@ -13,7 +13,7 @@
 #endif                          // __MSC__
 %}
 
-/* pour avoir acces aux numeros de lignes, et moins cher que le -l de la ligne de commande */
+/* Pour avoir acces aux numeros de lignes, et moins cher que le -l de la ligne de commande */
 %option yylineno 
 
 DIGIT           [0-9]
@@ -73,7 +73,9 @@ null            {return NULLVALUE;}
                     return NUMBERVALUE;
                 }
 
-{WHITESPACE}    {/*IGNORE*/}
+{WHITESPACE}    {
+                  // On ignore les caracteres d'espacement
+                }
 
 .               {
                     ALString *sValue;

--- a/src/Norm/base/JSONYac.cpp
+++ b/src/Norm/base/JSONYac.cpp
@@ -512,8 +512,8 @@ static const yytype_int8 yytranslate[] = {
 
 #if JSONDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_int16 yyrline[] = {0,   80,  80,  99,  107, 108, 109, 121, 134, 147, 155, 165,
-				       181, 183, 187, 200, 227, 237, 253, 270, 272, 276, 289};
+static const yytype_int16 yyrline[] = {0,   80,  80,  98,  106, 107, 108, 121, 133, 145, 153, 165,
+				       182, 184, 188, 200, 225, 237, 254, 271, 273, 277, 289};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -1130,12 +1130,11 @@ yyreduce:
 	case 2: /* jsonFile: object  */
 #line 81 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
-		JSONObject* jsonObject;
+		JSONObject* jsonObject = (yyvsp[0].jsonObject);
 		JSONMember* member;
 		int i;
 
 		// On memorise l'objet construit, qui sera detruit par le parser
-		jsonObject = (yyvsp[0].jsonObject);
 		(yyval.jsonObject) = jsonObject;
 
 		// Transfert du contenu vers l'objet principal
@@ -1147,37 +1146,38 @@ yyreduce:
 		}
 		jsonObject->RemoveAll();
 	}
-#line 1223 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1222 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 3: /* jsonFile: error  */
-#line 100 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 99 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonObject) = NULL;
 		YYABORT;
 	}
-#line 1232 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1231 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 4: /* value: object  */
-#line 107 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 106 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonValue) = (yyvsp[0].jsonObject);
 	}
-#line 1238 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1237 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 5: /* value: array  */
-#line 108 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 107 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonValue) = (yyvsp[0].jsonArray);
 	}
-#line 1244 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1243 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 6: /* value: STRINGVALUE  */
-#line 110 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 109 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
+		ALString* sValue = (yyvsp[0].sValue);
 		JSONString* jsonString;
 
 		// Creation d'une valeur chaine de caractere
@@ -1185,8 +1185,8 @@ yyreduce:
 		(yyval.jsonValue) = jsonString;
 
 		// Alimentation
-		jsonString->SetString(*(yyvsp[0].sValue));
-		delete (yyvsp[0].sValue);
+		jsonString->SetString(*sValue);
+		delete sValue;
 	}
 #line 1260 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
@@ -1194,39 +1194,37 @@ yyreduce:
 	case 7: /* value: NUMBERVALUE  */
 #line 122 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
+		double dValue = (yyvsp[0].dValue);
 		JSONNumber* jsonNumber;
-		double dValue;
 
 		// Creation d'une valeur chaine de caractere
 		jsonNumber = new JSONNumber;
 		(yyval.jsonValue) = jsonNumber;
 
 		// Alimentation
-		dValue = (yyvsp[0].dValue);
 		jsonNumber->SetNumber(dValue);
 	}
-#line 1277 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1276 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 8: /* value: BOOLEANVALUE  */
-#line 135 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 134 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
+		boolean bValue = (yyvsp[0].bValue);
 		JSONBoolean* jsonBoolean;
-		boolean bValue;
 
 		// Creation d'une valeur chaine de caractere
 		jsonBoolean = new JSONBoolean;
 		(yyval.jsonValue) = jsonBoolean;
 
 		// Alimentation
-		bValue = (yyvsp[0].bValue);
 		jsonBoolean->SetBoolean(bValue);
 	}
-#line 1294 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1292 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 9: /* value: NULLVALUE  */
-#line 148 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 146 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONNull* jsonNull;
 
@@ -1234,18 +1232,19 @@ yyreduce:
 		jsonNull = new JSONNull;
 		(yyval.jsonValue) = jsonNull;
 	}
-#line 1306 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1304 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 10: /* value: STRINGERROR  */
-#line 156 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 154 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
+		ALString* sError = (yyvsp[0].sValue);
+
 		// Message d'erreur
-		jsonerror("Invalid json string \"" + jsonPrintableValue(*(yyvsp[0].sValue)) +
-			  "\" with non-utf8 encoding");
+		jsonerror("Invalid json string \"" + jsonPrintableValue(*sError) + "\" with non-utf8 encoding");
 
 		// Nettoyage et sortie
-		delete (yyvsp[0].sValue);
+		delete sError;
 		(yyval.jsonValue) = NULL;
 		YYABORT;
 	}
@@ -1255,49 +1254,49 @@ yyreduce:
 	case 11: /* value: ERROR  */
 #line 166 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
+		ALString* sError = (yyvsp[0].sValue);
 		ALString sValueError;
 
 		// Message d'erreur, avec indication de la valeur sauf si elle se reduit au caractete '"'
-		if (*(yyvsp[0].sValue) != "\"")
-			sValueError = " \"" + jsonPrintableValue(*(yyvsp[0].sValue)) + "\"";
+		if (*sError != "\"")
+			sValueError = " \"" + jsonPrintableValue(*sError) + "\"";
 		jsonerror("Invalid json value" + sValueError);
 
 		// Nettoyage et sortie
-		delete (yyvsp[0].sValue);
+		delete sError;
 		(yyval.jsonValue) = NULL;
 		YYABORT;
 	}
-#line 1338 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1339 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 12: /* object: '{' '}'  */
-#line 182 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 183 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonObject) = new JSONObject;
 	}
-#line 1344 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1345 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 13: /* object: '{' members '}'  */
-#line 184 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 185 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonObject) = (yyvsp[-1].jsonObject);
 	}
-#line 1350 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1351 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 14: /* members: member  */
-#line 188 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 189 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
+		JSONMember* member = (yyvsp[0].jsonMember);
 		JSONObject* jsonObject;
-		JSONMember* member;
 
 		// Creation d'un objet json
 		jsonObject = new JSONObject;
 		(yyval.jsonObject) = jsonObject;
 
 		// Alimentation avec un premier membre d'objet
-		member = cast(JSONMember*, (yyvsp[0].jsonMember));
 		jsonObject->AddMember(member);
 	}
 #line 1367 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
@@ -1306,16 +1305,14 @@ yyreduce:
 	case 15: /* members: members ',' member  */
 #line 201 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
-		JSONObject* jsonObject;
-		JSONMember* member;
+		JSONObject* jsonObject = (yyvsp[-2].jsonObject);
+		JSONMember* member = (yyvsp[0].jsonMember);
 		ALString sJsonKey;
 
 		// On recupere l'objet json en cours
-		jsonObject = cast(JSONObject*, (yyvsp[-2].jsonObject));
 		(yyval.jsonObject) = jsonObject;
 
 		// Ajout d'un nouveau membre d'objet, s'il n'en existe pas deja un du meme nom
-		member = cast(JSONMember*, (yyvsp[0].jsonMember));
 		if (jsonObject->LookupMember(member->GetKey()) == NULL)
 			jsonObject->AddMember(member);
 		// Erreur sinon
@@ -1331,17 +1328,19 @@ yyreduce:
 			YYABORT;
 		}
 	}
-#line 1398 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1396 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 16: /* members: STRINGERROR  */
-#line 228 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 226 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
+		ALString* sError = (yyvsp[0].sValue);
+
 		// Message d'erreur
-		jsonerror("Invalid json key \"" + jsonPrintableValue(*(yyvsp[0].sValue)) + "\" with non-utf8 encoding");
+		jsonerror("Invalid json key \"" + jsonPrintableValue(*sError) + "\" with non-utf8 encoding");
 
 		// Nettoyage et sortie
-		delete (yyvsp[0].sValue);
+		delete sError;
 		(yyval.jsonObject) = NULL;
 		YYABORT;
 	}
@@ -1351,68 +1350,68 @@ yyreduce:
 	case 17: /* members: ERROR  */
 #line 238 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
+		ALString* sError = (yyvsp[0].sValue);
 		ALString sValueError;
 
 		// Message d'erreur, avec indication de la valeur sauf si elle se reduit au caractete '"'
-		if (*(yyvsp[0].sValue) != "\"")
-			sValueError = " \"" + jsonPrintableValue(*(yyvsp[0].sValue)) + "\"";
+		if (*sError != "\"")
+			sValueError = " \"" + jsonPrintableValue(*sError) + "\"";
 		jsonerror("Invalid json key" + sValueError);
 
 		// Nettoyage et sortie
-		delete (yyvsp[0].sValue);
+		delete sError;
 		(yyval.jsonObject) = NULL;
 		YYABORT;
 	}
-#line 1430 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1431 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 18: /* member: STRINGVALUE ':' value  */
-#line 254 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 255 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
+		ALString* sKey = (yyvsp[-2].sValue);
+		JSONValue* jsonValue = (yyvsp[0].jsonValue);
 		JSONMember* member;
-		JSONValue* jsonValue;
 
 		// Creation d'un membre d'objet
 		member = new JSONMember;
 		(yyval.jsonMember) = member;
 
 		// Alimentation
-		jsonValue = cast(JSONValue*, (yyvsp[0].jsonValue));
-		member->SetKey(*(yyvsp[-2].sValue));
+		member->SetKey(*sKey);
 		member->SetValue(jsonValue);
-		delete (yyvsp[-2].sValue);
+		delete sKey;
 	}
-#line 1449 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1450 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 19: /* array: '[' ']'  */
-#line 271 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 272 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonArray) = new JSONArray;
 	}
-#line 1455 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1456 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 20: /* array: '[' values ']'  */
-#line 273 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 274 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonArray) = (yyvsp[-1].jsonArray);
 	}
-#line 1461 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1462 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 21: /* values: value  */
-#line 277 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 278 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
+		JSONValue* jsonValue = (yyvsp[0].jsonValue);
 		JSONArray* jsonArray;
-		JSONValue* jsonValue;
 
 		// Creation d'un tableau de valeur
 		jsonArray = new JSONArray;
 		(yyval.jsonArray) = jsonArray;
 
 		// Alimentation avec un premier membre d'objet
-		jsonValue = cast(JSONValue*, (yyvsp[0].jsonValue));
 		jsonArray->AddValue(jsonValue);
 	}
 #line 1478 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
@@ -1421,21 +1420,19 @@ yyreduce:
 	case 22: /* values: values ',' value  */
 #line 290 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
-		JSONArray* jsonArray;
-		JSONValue* jsonValue;
+		JSONArray* jsonArray = (yyvsp[-2].jsonArray);
+		JSONValue* jsonValue = (yyvsp[0].jsonValue);
 
 		// On recupere le tableau en cours
-		jsonArray = cast(JSONArray*, (yyvsp[-2].jsonArray));
 		(yyval.jsonArray) = jsonArray;
 
 		// Ajout d'un nouveau membre d'objet
-		jsonValue = cast(JSONValue*, (yyvsp[0].jsonValue));
 		jsonArray->AddValue(jsonValue);
 	}
-#line 1495 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1493 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
-#line 1499 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1497 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 
 	default:
 		break;
@@ -1614,7 +1611,7 @@ yyreturnlab:
 	return yyresult;
 }
 
-#line 304 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 302 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 
 #include "JSONLex.inc"
 

--- a/src/Norm/base/JSONYac.cpp
+++ b/src/Norm/base/JSONYac.cpp
@@ -81,30 +81,30 @@
 /* First part of user prologue.  */
 #line 1 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 
-/* Parser de json, inspire de la grammaire  de reference https://www.json.org/json-en.html */
+// Parser de json, inspire de la grammaire  de reference https://www.json.org/json-en.html
 
 #include "Object.h"
 #include "ALString.h"
 #include "TextService.h"
 #include "JSONObject.h"
 
-/* Declaration du lexer utilise */
+// Declaration du lexer utilise
 int jsonlex();
 
-/* Methode de gestion des erreurs */
+// Methode de gestion des erreurs
 void jsonerror(char const* fmt);
 const ALString jsonPrintableValue(const ALString& sValue);
 
-/* Objet json principal a utiliser pendant la lecture d'un fichier. */
-/* Ce domaine est positionner par la methode ReadFile de JSONObject */
+// Objet json principal a utiliser pendant la lecture d'un fichier.
+// Ce domaine est positionner par la methode ReadFile de JSONObject
 static JSONObject* mainReadJSONObject = NULL;
 
-/* Work around a bug in the relation between bison and GCC 3.x: */
+// Work around a bug in the relation between bison and GCC 3.x:
 #if defined(__GNUC__) && 3 <= __GNUC__
 #define __attribute__(arglist)
 #endif
 
-/* Nombre total d'erreurs de parsing */
+// Nombre total d'erreurs de parsing
 static int nJsonFileParsingErrorNumber = 0;
 
 // Desactivation de warnings pour le Visual C++
@@ -114,14 +114,15 @@ static int nJsonFileParsingErrorNumber = 0;
 
 #define YY_STATIC
 
-/* Debugging YAC */
+// Debugging YAC
 
-/*
-#define YYDEBUG 1
-extern char   *yyptok(int i);
-*/
+// Debugging YAC
+// Ajouter ici les instruction suivantes
+//   #define YYDEBUG 1
+//   extern char   *yyptok(int i);
+// Ajouter l'instruction yydebug = 1 dans le code d'une action du fichier .lex ou .yac
 
-#line 122 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 123 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 
 #ifndef YY_CAST
 #ifdef __cplusplus
@@ -511,8 +512,8 @@ static const yytype_int8 yytranslate[] = {
 
 #if JSONDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_int16 yyrline[] = {0,   79,  79,  98,  106, 107, 108, 120, 133, 146, 154, 164,
-				       180, 182, 186, 199, 226, 236, 252, 269, 271, 275, 288};
+static const yytype_int16 yyrline[] = {0,   80,  80,  99,  107, 108, 109, 121, 134, 147, 155, 165,
+				       181, 183, 187, 200, 227, 237, 253, 270, 272, 276, 289};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -781,103 +782,103 @@ static void yydestruct(const char* yymsg, yysymbol_kind_t yykind, YYSTYPE* yyval
 	switch (yykind)
 	{
 	case YYSYMBOL_STRINGVALUE: /* STRINGVALUE  */
-#line 72 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 73 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 881 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 882 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case YYSYMBOL_STRINGERROR: /* STRINGERROR  */
-#line 72 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 73 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 887 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 888 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case YYSYMBOL_ERROR: /* ERROR  */
-#line 72 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 73 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		if (((*yyvaluep).sValue) != NULL)
 			delete ((*yyvaluep).sValue);
 		((*yyvaluep).sValue) = NULL;
 	}
-#line 893 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 894 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case YYSYMBOL_jsonFile: /* jsonFile  */
-#line 72 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 73 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		if (((*yyvaluep).jsonObject) != NULL)
 			delete ((*yyvaluep).jsonObject);
 		((*yyvaluep).jsonObject) = NULL;
 	}
-#line 899 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 900 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case YYSYMBOL_value: /* value  */
-#line 72 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 73 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		if (((*yyvaluep).jsonValue) != NULL)
 			delete ((*yyvaluep).jsonValue);
 		((*yyvaluep).jsonValue) = NULL;
 	}
-#line 905 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 906 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case YYSYMBOL_object: /* object  */
-#line 72 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 73 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		if (((*yyvaluep).jsonObject) != NULL)
 			delete ((*yyvaluep).jsonObject);
 		((*yyvaluep).jsonObject) = NULL;
 	}
-#line 911 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 912 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case YYSYMBOL_members: /* members  */
-#line 72 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 73 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		if (((*yyvaluep).jsonObject) != NULL)
 			delete ((*yyvaluep).jsonObject);
 		((*yyvaluep).jsonObject) = NULL;
 	}
-#line 917 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 918 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case YYSYMBOL_member: /* member  */
-#line 72 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 73 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		if (((*yyvaluep).jsonMember) != NULL)
 			delete ((*yyvaluep).jsonMember);
 		((*yyvaluep).jsonMember) = NULL;
 	}
-#line 923 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 924 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case YYSYMBOL_array: /* array  */
-#line 72 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 73 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		if (((*yyvaluep).jsonArray) != NULL)
 			delete ((*yyvaluep).jsonArray);
 		((*yyvaluep).jsonArray) = NULL;
 	}
-#line 929 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 930 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case YYSYMBOL_values: /* values  */
-#line 72 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 73 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		if (((*yyvaluep).jsonArray) != NULL)
 			delete ((*yyvaluep).jsonArray);
 		((*yyvaluep).jsonArray) = NULL;
 	}
-#line 935 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 936 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	default:
@@ -1127,7 +1128,7 @@ yyreduce:
 	switch (yyn)
 	{
 	case 2: /* jsonFile: object  */
-#line 80 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 81 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONObject* jsonObject;
 		JSONMember* member;
@@ -1146,36 +1147,36 @@ yyreduce:
 		}
 		jsonObject->RemoveAll();
 	}
-#line 1222 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1223 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 3: /* jsonFile: error  */
-#line 99 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 100 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonObject) = NULL;
 		YYABORT;
 	}
-#line 1231 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1232 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 4: /* value: object  */
-#line 106 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 107 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonValue) = (yyvsp[0].jsonObject);
 	}
-#line 1237 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1238 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 5: /* value: array  */
-#line 107 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 108 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonValue) = (yyvsp[0].jsonArray);
 	}
-#line 1243 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1244 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 6: /* value: STRINGVALUE  */
-#line 109 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 110 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONString* jsonString;
 
@@ -1187,11 +1188,11 @@ yyreduce:
 		jsonString->SetString(*(yyvsp[0].sValue));
 		delete (yyvsp[0].sValue);
 	}
-#line 1259 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1260 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 7: /* value: NUMBERVALUE  */
-#line 121 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 122 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONNumber* jsonNumber;
 		double dValue;
@@ -1204,11 +1205,11 @@ yyreduce:
 		dValue = (yyvsp[0].dValue);
 		jsonNumber->SetNumber(dValue);
 	}
-#line 1276 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1277 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 8: /* value: BOOLEANVALUE  */
-#line 134 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 135 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONBoolean* jsonBoolean;
 		boolean bValue;
@@ -1221,11 +1222,11 @@ yyreduce:
 		bValue = (yyvsp[0].bValue);
 		jsonBoolean->SetBoolean(bValue);
 	}
-#line 1293 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1294 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 9: /* value: NULLVALUE  */
-#line 147 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 148 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONNull* jsonNull;
 
@@ -1233,11 +1234,11 @@ yyreduce:
 		jsonNull = new JSONNull;
 		(yyval.jsonValue) = jsonNull;
 	}
-#line 1305 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1306 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 10: /* value: STRINGERROR  */
-#line 155 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 156 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		// Message d'erreur
 		jsonerror("Invalid json string \"" + jsonPrintableValue(*(yyvsp[0].sValue)) +
@@ -1248,11 +1249,11 @@ yyreduce:
 		(yyval.jsonValue) = NULL;
 		YYABORT;
 	}
-#line 1319 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1320 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 11: /* value: ERROR  */
-#line 165 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 166 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		ALString sValueError;
 
@@ -1266,27 +1267,27 @@ yyreduce:
 		(yyval.jsonValue) = NULL;
 		YYABORT;
 	}
-#line 1337 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1338 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 12: /* object: '{' '}'  */
-#line 181 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 182 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonObject) = new JSONObject;
 	}
-#line 1343 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1344 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 13: /* object: '{' members '}'  */
-#line 183 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 184 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonObject) = (yyvsp[-1].jsonObject);
 	}
-#line 1349 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1350 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 14: /* members: member  */
-#line 187 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 188 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONObject* jsonObject;
 		JSONMember* member;
@@ -1299,11 +1300,11 @@ yyreduce:
 		member = cast(JSONMember*, (yyvsp[0].jsonMember));
 		jsonObject->AddMember(member);
 	}
-#line 1366 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1367 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 15: /* members: members ',' member  */
-#line 200 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 201 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONObject* jsonObject;
 		JSONMember* member;
@@ -1330,11 +1331,11 @@ yyreduce:
 			YYABORT;
 		}
 	}
-#line 1397 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1398 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 16: /* members: STRINGERROR  */
-#line 227 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 228 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		// Message d'erreur
 		jsonerror("Invalid json key \"" + jsonPrintableValue(*(yyvsp[0].sValue)) + "\" with non-utf8 encoding");
@@ -1344,11 +1345,11 @@ yyreduce:
 		(yyval.jsonObject) = NULL;
 		YYABORT;
 	}
-#line 1411 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1412 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 17: /* members: ERROR  */
-#line 237 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 238 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		ALString sValueError;
 
@@ -1362,11 +1363,11 @@ yyreduce:
 		(yyval.jsonObject) = NULL;
 		YYABORT;
 	}
-#line 1429 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1430 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 18: /* member: STRINGVALUE ':' value  */
-#line 253 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 254 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONMember* member;
 		JSONValue* jsonValue;
@@ -1381,27 +1382,27 @@ yyreduce:
 		member->SetValue(jsonValue);
 		delete (yyvsp[-2].sValue);
 	}
-#line 1448 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1449 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 19: /* array: '[' ']'  */
-#line 270 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 271 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonArray) = new JSONArray;
 	}
-#line 1454 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1455 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 20: /* array: '[' values ']'  */
-#line 272 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 273 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		(yyval.jsonArray) = (yyvsp[-1].jsonArray);
 	}
-#line 1460 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1461 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 21: /* values: value  */
-#line 276 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 277 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONArray* jsonArray;
 		JSONValue* jsonValue;
@@ -1414,11 +1415,11 @@ yyreduce:
 		jsonValue = cast(JSONValue*, (yyvsp[0].jsonValue));
 		jsonArray->AddValue(jsonValue);
 	}
-#line 1477 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1478 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
 	case 22: /* values: values ',' value  */
-#line 289 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 290 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 	{
 		JSONArray* jsonArray;
 		JSONValue* jsonValue;
@@ -1431,10 +1432,10 @@ yyreduce:
 		jsonValue = cast(JSONValue*, (yyvsp[0].jsonValue));
 		jsonArray->AddValue(jsonValue);
 	}
-#line 1494 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1495 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 	break;
 
-#line 1498 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
+#line 1499 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.cpp"
 
 	default:
 		break;
@@ -1613,11 +1614,11 @@ yyreturnlab:
 	return yyresult;
 }
 
-#line 303 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 304 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 
 #include "JSONLex.inc"
 
-/* default yyerror for YACC and LEX */
+// default yyerror for YACC and LEX
 void jsonerror(char const* fmt)
 {
 	char sErrorLine[20];
@@ -1641,29 +1642,29 @@ const ALString jsonPrintableValue(const ALString& sValue)
 
 int jsonparse();
 
-/* Implementation de la methode de lecture de fichier de KWClassDomain */
+// Implementation de la methode de lecture de fichier de KWClassDomain
 boolean JSONObject::ReadFile(const ALString& sFileName)
 {
 	boolean bOk = true;
 	FILE* fFile;
 	ALString sLocalFileName;
 
-	/* Affichage de stats memoire si log memoire actif */
+	// Affichage de stats memoire si log memoire actif
 	MemoryStatsManager::AddLog(GetClassLabel() + " " + sFileName + " ReadFile Begin");
 
-	/* Initialisation de l'objet json principal a utiliser pour la lecture */
+	// Initialisation de l'objet json principal a utiliser pour la lecture
 	assert(mainReadJSONObject == NULL);
 	mainReadJSONObject = this;
 	mainReadJSONObject->DeleteAll();
 
-	/* Erreur si pas de nom de fichier */
+	// Erreur si pas de nom de fichier
 	fFile = NULL;
 	if (sFileName == "")
 	{
 		AddError("Missing file name");
 		bOk = false;
 	}
-	/* Sinon, ouverture du fichier */
+	// Sinon, ouverture du fichier
 	else
 	{
 		// Copie depuis un fichier distant si necessaire
@@ -1672,51 +1673,51 @@ boolean JSONObject::ReadFile(const ALString& sFileName)
 			bOk = FileService::OpenInputBinaryFile(sLocalFileName, fFile);
 	}
 
-	/* On continue si fichier ouvert correctement */
+	// On continue si fichier ouvert correctement
 	if (bOk)
 	{
 		assert(fFile != NULL);
 
-		/* Activation du nombre max d'erreurs a afficher */
+		// Activation du nombre max d'erreurs a afficher
 		nJsonFileParsingErrorNumber = 0;
 		Global::ActivateErrorFlowControl();
 
-		/* Positionnement du fichier a parser par la variable yyin de LEX */
+		// Positionnement du fichier a parser par la variable yyin de LEX
 		jsonlineno = 1;
 		jsonrestart(fFile);
 
-		/* Parsing */
+		// Parsing
 		jsonparse();
 
-		/* Cleaning lexer */
+		// Cleaning lexer
 		jsonlex_destroy();
 
-		/* Fermeture du fichier */
+		// Fermeture du fichier
 		FileService::CloseInputBinaryFile(sLocalFileName, fFile);
 
-		/* Si fichier distant, on supprime la copie locale */
+		// Si fichier distant, on supprime la copie locale
 		PLRemoteFileService::CleanInputWorkingFile(sFileName, sLocalFileName);
 
-		/* Desactivation du nombre max d'erreurs a afficher */
+		// Desactivation du nombre max d'erreurs a afficher
 		Global::DesactivateErrorFlowControl();
 
-		/* Nettoyage si erreurs */
+		// Nettoyage si erreurs
 		if (nJsonFileParsingErrorNumber > 0)
 		{
-			/* Destruction du contenu de l'objet construit */
+			// Destruction du contenu de l'objet construit
 			mainReadJSONObject->DeleteAll();
 
-			/* En cas d'erreur, ajout d'une ligne blanche pour separer des autres logs */
+			// En cas d'erreur, ajout d'une ligne blanche pour separer des autres logs
 			AddError("Errors detected during parsing " + sFileName + ": read operation cancelled");
 			bOk = false;
 		}
 		nJsonFileParsingErrorNumber = 0;
 	}
 
-	/* Nettoyage */
+	// Nettoyage
 	mainReadJSONObject = NULL;
 
-	/* Affichage de stats memoire si log memoire actif */
+	// Affichage de stats memoire si log memoire actif
 	MemoryStatsManager::AddLog(GetClassLabel() + " " + sFileName + " ReadFile End");
 
 	return bOk;

--- a/src/Norm/base/JSONYac.hpp
+++ b/src/Norm/base/JSONYac.hpp
@@ -80,7 +80,7 @@ typedef enum jsontokentype jsontoken_kind_t;
 #if !defined JSONSTYPE && !defined JSONSTYPE_IS_DECLARED
 union JSONSTYPE
 {
-#line 46 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
+#line 47 "C:/Applications/boullema/DevGit/khiops/src/Norm/base/JSONYac.yac"
 
 	ALString* sValue;
 	double dValue;

--- a/src/Norm/base/JSONYac.yac
+++ b/src/Norm/base/JSONYac.yac
@@ -1,28 +1,28 @@
 %{
-/* Parser de json, inspire de la grammaire  de reference https://www.json.org/json-en.html */
+// Parser de json, inspire de la grammaire  de reference https://www.json.org/json-en.html
 
 #include "Object.h"
 #include "ALString.h"
 #include "TextService.h"
 #include "JSONObject.h"
 
-/* Declaration du lexer utilise */
+// Declaration du lexer utilise
 int jsonlex();
 
-/* Methode de gestion des erreurs */
+// Methode de gestion des erreurs
 void jsonerror(char const *fmt);
 const ALString jsonPrintableValue(const ALString& sValue);
 
-/* Objet json principal a utiliser pendant la lecture d'un fichier. */
-/* Ce domaine est positionner par la methode ReadFile de JSONObject */
+// Objet json principal a utiliser pendant la lecture d'un fichier.
+// Ce domaine est positionner par la methode ReadFile de JSONObject
 static JSONObject* mainReadJSONObject=NULL;
 
-/* Work around a bug in the relation between bison and GCC 3.x: */
+// Work around a bug in the relation between bison and GCC 3.x:
 #if defined (__GNUC__) && 3 <= __GNUC__
 #define __attribute__(arglist)
 #endif
 
-/* Nombre total d'erreurs de parsing */
+// Nombre total d'erreurs de parsing
 static int nJsonFileParsingErrorNumber = 0;
 
 // Desactivation de warnings pour le Visual C++
@@ -32,12 +32,13 @@ static int nJsonFileParsingErrorNumber = 0;
 
 #define YY_STATIC
 
-/* Debugging YAC */
+// Debugging YAC
 
-/*
-#define YYDEBUG 1 
-extern char   *yyptok(int i); 
-*/
+// Debugging YAC
+// Ajouter ici les instruction suivantes
+//   #define YYDEBUG 1 
+//   extern char   *yyptok(int i); 
+// Ajouter l'instruction yydebug = 1 dans le code d'une action du fichier .lex ou .yac
 
 %}
 
@@ -68,7 +69,7 @@ extern char   *yyptok(int i);
 %type <jsonArray> values
 
 
-/* Parametrage du destructeur a appeler en cas d'erreur */
+// Parametrage du destructeur a appeler en cas d'erreur
 %destructor {if ($$ != NULL) delete $$; $$=NULL;} <sValue> <jsonValue> <jsonObject> <jsonArray> <jsonMember>
 
 
@@ -305,7 +306,7 @@ values: value
 
 #include "JSONLex.inc"
 
-/* default yyerror for YACC and LEX */
+// default yyerror for YACC and LEX
 void jsonerror(char const *fmt)
 {
   char sErrorLine[20];
@@ -331,29 +332,29 @@ const ALString jsonPrintableValue(const ALString& sValue)
 
 int jsonparse();
 
-/* Implementation de la methode de lecture de fichier de KWClassDomain */
+// Implementation de la methode de lecture de fichier de KWClassDomain
 boolean JSONObject::ReadFile(const ALString& sFileName)
 {
   boolean bOk = true;
   FILE* fFile;
   ALString sLocalFileName;
 
-  /* Affichage de stats memoire si log memoire actif */
+  // Affichage de stats memoire si log memoire actif
   MemoryStatsManager::AddLog(GetClassLabel() + " " + sFileName + " ReadFile Begin");
 
-  /* Initialisation de l'objet json principal a utiliser pour la lecture */
+  // Initialisation de l'objet json principal a utiliser pour la lecture
   assert(mainReadJSONObject == NULL);
   mainReadJSONObject = this;
   mainReadJSONObject->DeleteAll();
 
-  /* Erreur si pas de nom de fichier */
+  // Erreur si pas de nom de fichier
   fFile = NULL;
   if (sFileName == "")
   {
      AddError("Missing file name");
 	 bOk = false;
   }
-  /* Sinon, ouverture du fichier */
+  // Sinon, ouverture du fichier
   else
   { 
 		// Copie depuis un fichier distant si necessaire
@@ -362,51 +363,51 @@ boolean JSONObject::ReadFile(const ALString& sFileName)
 			bOk = FileService::OpenInputBinaryFile(sLocalFileName, fFile);
   }
 
-  /* On continue si fichier ouvert correctement */
+  // On continue si fichier ouvert correctement
   if (bOk)
   {
     assert(fFile != NULL);
 
-	/* Activation du nombre max d'erreurs a afficher */
+	// Activation du nombre max d'erreurs a afficher
 	nJsonFileParsingErrorNumber = 0;
 	Global::ActivateErrorFlowControl();
 
-    /* Positionnement du fichier a parser par la variable yyin de LEX */
+    // Positionnement du fichier a parser par la variable yyin de LEX
     jsonlineno = 1;
     jsonrestart(fFile);
     
-	/* Parsing */
+	// Parsing
     jsonparse();
 
-	/* Cleaning lexer */
+	// Cleaning lexer
 	jsonlex_destroy();
 
-    /* Fermeture du fichier */
+    // Fermeture du fichier
 	FileService::CloseInputBinaryFile(sLocalFileName, fFile);
 	
-	/* Si fichier distant, on supprime la copie locale */
+	// Si fichier distant, on supprime la copie locale
 	PLRemoteFileService::CleanInputWorkingFile(sFileName, sLocalFileName);
 
-	/* Desactivation du nombre max d'erreurs a afficher */
+	// Desactivation du nombre max d'erreurs a afficher
 	Global::DesactivateErrorFlowControl();
 
-    /* Nettoyage si erreurs */
+    // Nettoyage si erreurs
 	if (nJsonFileParsingErrorNumber > 0)
     {
-	  /* Destruction du contenu de l'objet construit */
+	  // Destruction du contenu de l'objet construit
 	  mainReadJSONObject->DeleteAll();
 
-	  /* En cas d'erreur, ajout d'une ligne blanche pour separer des autres logs */
+	  // En cas d'erreur, ajout d'une ligne blanche pour separer des autres logs
       AddError("Errors detected during parsing " + sFileName + ": read operation cancelled");
 	  bOk = false;
 	}
 	nJsonFileParsingErrorNumber = 0;
   }
 
-  /* Nettoyage */
+  // Nettoyage
   mainReadJSONObject = NULL;
 
-  /* Affichage de stats memoire si log memoire actif */
+  // Affichage de stats memoire si log memoire actif
   MemoryStatsManager::AddLog(GetClassLabel() + " " + sFileName + " ReadFile End");
 
   return bOk;

--- a/src/Norm/base/JSONYac.yac
+++ b/src/Norm/base/JSONYac.yac
@@ -79,12 +79,11 @@ static int nJsonFileParsingErrorNumber = 0;
 
 jsonFile: object
     {
-		JSONObject* jsonObject;
+		JSONObject* jsonObject = $1;
 		JSONMember* member;
 		int i;
 		
 		// On memorise l'objet construit, qui sera detruit par le parser
-		jsonObject = $1;
 		$$ = jsonObject;
 
 		// Transfert du contenu vers l'objet principal
@@ -108,6 +107,7 @@ value: object     { $$ = $1; }
 	| array   { $$ = $1; } 
 	| STRINGVALUE  
 	{ 
+	    ALString* sValue = $1;
 		JSONString* jsonString;
 		
 		// Creation d'une valeur chaine de caractere
@@ -115,33 +115,31 @@ value: object     { $$ = $1; }
 		$$ = jsonString;
 
 		// Alimentation
-		jsonString->SetString(*$1);
-		delete $1;
+		jsonString->SetString(*sValue);
+		delete sValue;
 	}
 	| NUMBERVALUE
 	{ 
+		double dValue = $1;
 		JSONNumber* jsonNumber;
-		double dValue;
 		
 		// Creation d'une valeur chaine de caractere
 		jsonNumber = new JSONNumber;
 		$$ = jsonNumber;
 
 		// Alimentation
-		dValue = $1;
 		jsonNumber->SetNumber(dValue);
 	}
 	| BOOLEANVALUE
 	{ 
+		boolean bValue = $1;
 		JSONBoolean* jsonBoolean;
-		boolean bValue;
 		
 		// Creation d'une valeur chaine de caractere
 		jsonBoolean = new JSONBoolean;
 		$$ = jsonBoolean;
 
 		// Alimentation
-		bValue = $1;
 		jsonBoolean->SetBoolean(bValue);
 	}
 	| NULLVALUE
@@ -153,26 +151,29 @@ value: object     { $$ = $1; }
 		$$ = jsonNull;
 	}
 	| STRINGERROR  
-	{ 
+	{
+	    ALString* sError = $1;
+
 		// Message d'erreur
-		jsonerror("Invalid json string \"" + jsonPrintableValue(*$1) + "\" with non-utf8 encoding");
+		jsonerror("Invalid json string \"" + jsonPrintableValue(*sError) + "\" with non-utf8 encoding");
 
 		// Nettoyage et sortie
-		delete $1;
+		delete sError;
 		$$ = NULL;
 		YYABORT;
 	}
 	| ERROR  
 	{ 
+	    ALString* sError = $1;
 		ALString sValueError;
 
 		// Message d'erreur, avec indication de la valeur sauf si elle se reduit au caractete '"'
-		if (*$1 != "\"")
-			sValueError = " \"" + jsonPrintableValue(*$1) + "\"";
+		if (*sError != "\"")
+			sValueError = " \"" + jsonPrintableValue(*sError) + "\"";
 		jsonerror("Invalid json value" + sValueError);
 
 		// Nettoyage et sortie
-		delete $1;
+		delete sError;
 		$$ = NULL;
 		YYABORT;
 	}
@@ -186,29 +187,26 @@ object: '{' '}'
 
 members: member                    
 	{ 
+		JSONMember* member = $1;
 		JSONObject* jsonObject;
-		JSONMember* member;
 		
 		// Creation d'un objet json
 		jsonObject = new JSONObject;
 		$$ = jsonObject;
 		
 		// Alimentation avec un premier membre d'objet
-		member = cast(JSONMember*, $1); 
 		jsonObject->AddMember(member);
 	}
 	| members ',' member
 	{ 
-		JSONObject* jsonObject;
-		JSONMember* member;
+		JSONObject* jsonObject = $1;
+		JSONMember* member = $3;
 		ALString sJsonKey;
 		
 		// On recupere l'objet json en cours
-		jsonObject = cast(JSONObject*, $1);
 		$$ = jsonObject;
 		
 		// Ajout d'un nouveau membre d'objet, s'il n'en existe pas deja un du meme nom
-		member = cast(JSONMember*, $3);
 		if (jsonObject->LookupMember(member->GetKey()) == NULL)
 			jsonObject->AddMember(member);
 		// Erreur sinon
@@ -226,25 +224,28 @@ members: member
 	}
 	| STRINGERROR  
 	{ 
+	    ALString* sError = $1;
+
 		// Message d'erreur
-		jsonerror("Invalid json key \"" + jsonPrintableValue(*$1) + "\" with non-utf8 encoding");
+		jsonerror("Invalid json key \"" + jsonPrintableValue(*sError) + "\" with non-utf8 encoding");
 
 		// Nettoyage et sortie
-		delete $1;
+		delete sError;
 		$$ = NULL;
 		YYABORT;
 	}
 	| ERROR  
 	{ 
+	    ALString* sError = $1;
 		ALString sValueError;
 
 		// Message d'erreur, avec indication de la valeur sauf si elle se reduit au caractete '"'
-		if (*$1 != "\"")
-			sValueError = " \"" + jsonPrintableValue(*$1) + "\"";
+		if (*sError != "\"")
+			sValueError = " \"" + jsonPrintableValue(*sError) + "\"";
 		jsonerror("Invalid json key" + sValueError);
 
 		// Nettoyage et sortie
-		delete $1;
+		delete sError;
 		$$ = NULL;
 		YYABORT;
 	}
@@ -252,18 +253,18 @@ members: member
 
 member: STRINGVALUE ':' value 	 
 	{ 
+	    ALString* sKey = $1;
+		JSONValue* jsonValue = $3;
 		JSONMember* member;
-		JSONValue* jsonValue;
 
 		// Creation d'un membre d'objet
 		member = new JSONMember;
 		$$ = member;
 
 		// Alimentation
-		jsonValue = cast(JSONValue*, $3);
-		member->SetKey(*$1);
+		member->SetKey(*sKey);
 		member->SetValue(jsonValue);
-		delete $1;
+		delete sKey;
 	}
 	;
 
@@ -275,28 +276,25 @@ array: '[' ']'
 
 values: value
 	{ 
+		JSONValue* jsonValue = $1;
 		JSONArray* jsonArray;
-		JSONValue* jsonValue;
 		
 		// Creation d'un tableau de valeur
 		jsonArray = new JSONArray;
 		$$ = jsonArray;
 		
 		// Alimentation avec un premier membre d'objet
-		jsonValue = cast(JSONValue*, $1); 
 		jsonArray->AddValue(jsonValue);
 	}
 	| values ',' value   
 	{ 
-		JSONArray* jsonArray;
-		JSONValue* jsonValue;
+		JSONArray* jsonArray = $1;
+		JSONValue* jsonValue = $3;
 		
 		// On recupere le tableau en cours
-		jsonArray = cast(JSONArray*, $1);
 		$$ = jsonArray;
 		
 		// Ajout d'un nouveau membre d'objet
-		jsonValue = cast(JSONValue*, $3); 
 		jsonArray->AddValue(jsonValue);
 	}
 	;


### PR DESCRIPTION
Seuls les 6 derniers commits sont a prendre en compte.
Le commit principal contient une spécification détaillée de la fonctionnalité, après ré-actualisation due à certains choix d'implémentation: [Extend comment syntax in Khiops dictionaries](https://github.com/KhiopsML/khiops/pull/503/commits/2567a23188754ce3f8fc083af1dabb923150fb84)