### PR TITLE
bug fix: remove chunks when interruption is requested inside concatenation

### DIFF
--- a/src/Learning/KWDataUtils/KWDatabaseTransferTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTransferTask.cpp
@@ -413,7 +413,7 @@ boolean KWDatabaseTransferTask::MasterFinalize(boolean bProcessEndedCorrectly)
 					if (bOk)
 					{
 						TaskProgression::DisplayLabel("concatenation");
-						bOk = concatenater.Concatenate(svChunkFileNames, this, true) and bOk;
+						bOk = concatenater.Concatenate(svChunkFileNames, this) and bOk;
 					}
 				}
 
@@ -450,7 +450,7 @@ boolean KWDatabaseTransferTask::MasterFinalize(boolean bProcessEndedCorrectly)
 
 			// Concatenation des chunks
 			TaskProgression::DisplayLabel("concatenation");
-			bOk = concatenater.Concatenate(svChunkFileNames, this, true);
+			bOk = concatenater.Concatenate(svChunkFileNames, this);
 		}
 
 		// Suppression des fichiers intermediaires

--- a/src/Learning/KWDataUtils/KWDatabaseTransferTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTransferTask.cpp
@@ -405,6 +405,7 @@ boolean KWDatabaseTransferTask::MasterFinalize(boolean bProcessEndedCorrectly)
 					    KWClassDomain::GetCurrentDomain()->LookupClass(mapping->GetClassName());
 					if (targetDatabase->GetHeaderLineUsed())
 						dictionary->ExportStoredFieldNames(concatenater.GetHeaderLine());
+					concatenater.SetHeaderLineUsed(targetDatabase->GetHeaderLineUsed());
 					concatenater.SetFieldSeparator(targetDatabase->GetFieldSeparator());
 
 					// Concatenation des chunks
@@ -445,6 +446,7 @@ boolean KWDatabaseTransferTask::MasterFinalize(boolean bProcessEndedCorrectly)
 			    shared_targetDatabase.GetDatabase()->GetClassName());
 			if (shared_targetDatabase.GetSTDatabase()->GetHeaderLineUsed())
 				dictionary->ExportStoredFieldNames(concatenater.GetHeaderLine());
+			concatenater.SetHeaderLineUsed(shared_targetDatabase.GetSTDatabase()->GetHeaderLineUsed());
 			concatenater.SetFileName(sOutputFileName);
 			concatenater.SetFieldSeparator(shared_targetDatabase.GetSTDatabase()->GetFieldSeparator());
 

--- a/src/Learning/KWDataUtils/KWFileSorter.cpp
+++ b/src/Learning/KWDataUtils/KWFileSorter.cpp
@@ -257,6 +257,7 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 				concatenater.SetVerbose(PLParallelTask::GetVerbose());
 				if (bOutputHeaderLineUsed)
 					concatenater.GetHeaderLine()->CopyFrom(&svFirstLine);
+				concatenater.SetHeaderLineUsed(bOutputHeaderLineUsed);
 				concatenater.SetDisplayProgression(false);
 
 				// Concatenation
@@ -443,6 +444,7 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 					concatenater.SetFieldSeparator(cOutputFieldSeparator);
 					if (bOutputHeaderLineUsed)
 						concatenater.GetHeaderLine()->CopyFrom(&svFirstLine);
+					concatenater.SetHeaderLineUsed(bOutputHeaderLineUsed);
 					concatenater.SetFileName(sOutputFileName);
 					TaskProgression::BeginTask();
 					TaskProgression::DisplayMainLabel("files concatenation");

--- a/src/Learning/KWDataUtils/KWFileSorter.cpp
+++ b/src/Learning/KWDataUtils/KWFileSorter.cpp
@@ -260,7 +260,7 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 				concatenater.SetDisplayProgression(false);
 
 				// Concatenation
-				concatenater.Concatenate(parallelSorter.GetSortedFiles(), this, true);
+				concatenater.Concatenate(parallelSorter.GetSortedFiles(), this);
 			}
 
 			bIsInterruptedByUser = parallelSorter.IsTaskInterruptedByUser();
@@ -356,7 +356,7 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 						// Concatenation
 						concatenater.SetFileName(sNewFileName);
 						bOk = concatenater.Concatenate(overweightBucket->GetChunkFileNames(),
-									       this, true);
+									       this);
 					}
 					else
 					{
@@ -447,7 +447,7 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 					TaskProgression::BeginTask();
 					TaskProgression::DisplayMainLabel("files concatenation");
 					timerConcat.Start();
-					bOk = concatenater.Concatenate(parallelSorter.GetSortedFiles(), this, true);
+					bOk = concatenater.Concatenate(parallelSorter.GetSortedFiles(), this);
 					timerConcat.Stop();
 					TaskProgression::EndTask();
 					if (bTrace)

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
@@ -127,8 +127,7 @@ void PLFileConcatenater::RemoveChunks(const StringVector* svChunkURIs) const
 		PLParallelTask::GetDriver()->StopFileServers();
 }
 
-boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const Object* errorSender,
-					boolean bRemoveChunks) const
+boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const Object* errorSender) const
 {
 	int nChunkIndex;
 	ALString sChunkURI;
@@ -265,8 +264,7 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 					bOk = inputFile.Close() and bOk;
 
 					// Suppression du chunk
-					if (bRemoveChunks)
-						PLRemoteFileService::RemoveFile(sChunkURI);
+					PLRemoteFileService::RemoveFile(sChunkURI);
 
 					// Affichage de la progression en prenant en compte la progression intiale dProgressionLevel
 					// et la portion de progression represente par la concatenation dTaskPercent
@@ -296,7 +294,7 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 		PLRemoteFileService::RemoveFile(sOutputFileName);
 
 	// Suppression des chunks en cas d'echec
-	if (not bOk and bRemoveChunks)
+	if (not bOk)
 	{
 		// On a commence le traitement au chunk nChunkIndex, on n'est pas sur qu'il ait ete detruit
 		for (i = nChunkIndex; i < svChunkURIs->GetSize(); i++)

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
@@ -13,6 +13,7 @@ PLFileConcatenater::PLFileConcatenater()
 	cSep = '\t';
 	bDisplayProgression = false;
 	bVerbose = false;
+	bHeaderLineUsed = true;
 }
 
 PLFileConcatenater::~PLFileConcatenater() {}
@@ -40,6 +41,16 @@ void PLFileConcatenater::SetFieldSeparator(char cValue)
 char PLFileConcatenater::GetFieldSeparator() const
 {
 	return cSep;
+}
+
+void PLFileConcatenater::SetHeaderLineUsed(boolean bUsed)
+{
+	bHeaderLineUsed = bUsed;
+}
+
+boolean PLFileConcatenater::GetHeaderLineUsed() const
+{
+	return bHeaderLineUsed;
 }
 
 void PLFileConcatenater::SetDisplayProgression(boolean bDisplay)
@@ -212,7 +223,7 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 		// Calcul de la taille du fichier de sortie pour reserver la taille,
 		//  en commencant par la taille du header
 		lOutputFileSize = 0;
-		if (svHeaderLine.GetSize() > 0)
+		if (bHeaderLineUsed and svHeaderLine.GetSize() > 0)
 		{
 			for (i = 0; i < svHeaderLine.GetSize(); i++)
 			{
@@ -251,7 +262,7 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 			outputBuffer.ReserveExtraSize(lOutputFileSize);
 
 			// Ecriture du header en passant par la methode WriteField de OutputBufferFile qui gere les separateurs dans les champs.
-			if (svHeaderLine.GetSize() > 0)
+			if (bHeaderLineUsed)
 			{
 				for (i = 0; i < svHeaderLine.GetSize(); i++)
 				{

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
@@ -208,8 +208,7 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 
 	if (bOk)
 	{
-		// Ecriture du Header en passant par la methode WriteField  de OutputBufferFile qui gere les separateur
-		// dans les champs
+		// Ecriture du Header en passant par la methode WriteField de OutputBufferFile qui gere les separateurs dans les champs
 		if (svHeaderLine.GetSize() > 0)
 		{
 			for (i = 0; i < svHeaderLine.GetSize(); i++)
@@ -221,14 +220,18 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 			outputBuffer.WriteEOL();
 		}
 
-		// TODO reserver la taille du fichier de sortie (moins ce qui est deja ecrit pdans le header)
+		// TODO reserver la taille du fichier de sortie (moins ce qui est deja ecrit dans le header)
 		// Parcours de tous les chunks
 		for (nChunkIndex = 0; nChunkIndex < svChunkURIs->GetSize(); nChunkIndex++)
 		{
 			sChunkURI = svChunkURIs->GetAt(nChunkIndex);
 
 			// Interruption ?
-			if (not bOk or TaskProgression::IsInterruptionRequested())
+			if (TaskProgression::IsInterruptionRequested())
+				bOk = false;
+
+			// Sortie en cas d'erreur ou d'interruption utilisateur
+			if (not bOk)
 				break;
 
 			// Concatenation d'un nouveau chunk
@@ -236,8 +239,7 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 			{
 				inputFile.SetFileName(sChunkURI);
 
-				// Ouverture du chunk en lecture (en ignorant la gestion des BOM, car on a des fichiers
-				// internes)
+				// Ouverture du chunk en lecture (en ignorant la gestion des BOM, car on a des fichiers internes)
 				inputFile.SetUTF8BomManagement(false);
 				bOk = inputFile.Open();
 				if (bOk)
@@ -266,9 +268,8 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 					if (bRemoveChunks)
 						PLRemoteFileService::RemoveFile(sChunkURI);
 
-					// Affichage de la progression en prenant en compte la progression intiale
-					// dProgressionLevel et la portion de progression represente par la
-					// concatenation dTaskPercent
+					// Affichage de la progression en prenant en compte la progression intiale dProgressionLevel
+					// et la portion de progression represente par la concatenation dTaskPercent
 					if (bDisplayProgression)
 						TaskProgression::DisplayProgression((int)ceil(
 						    100 * (dProgressionBegin +

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.h
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.h
@@ -31,7 +31,7 @@ public:
 	// Si bRemoveChunks est a true, les chunks sont effaces au fur et a mesure (et en cas d'erreur)
 	// Si il y a assez de ressources, pour la lecture on utilise entre 1 et 8 preferred size
 	// et pour l'ecriture on utilise 1 preferred size. Sinon on utilise une taille de bloc (64Ko) pour la lecture et
-	// l'ecriture. Seul le processus maitre peut invoquer cette methode Renvoi true si tout s'est bien passe
+	// l'ecriture. Seul le processus maitre peut invoquer cette methode renvoie true si tout s'est bien passe
 	boolean Concatenate(const StringVector* svChunkURIs, const Object* errorSender, boolean bRemoveChunks) const;
 
 	// Suppression des fichiers chunks (avec la meme specification de progression que la concatenation)

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.h
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.h
@@ -41,14 +41,17 @@ public:
 	void RemoveChunks(const StringVector* svChunkURIs) const;
 
 	// Specification de l'entete du fichier
-	// Si l'entete est specifiee, elle sera ajoutee au debut du fichier
-	// Si celle-ci est vide ou non specifiee, aucune ligne ne sera ajoutee (comportement par defaut)
+	// Elle sera ajoutee au debut du fichier si le header est utilise (Cf. SetHeaderLineUsed)
 	// Memoire: le vecteur appartient a l'appele
 	StringVector* GetHeaderLine();
 
 	// Separateur utilise pour l'ecriture du header (par defaut tabulation)
 	void SetFieldSeparator(char cSep);
 	char GetFieldSeparator() const;
+
+	// Utilisation d'une ligne d'entete: par defaut true
+	void SetHeaderLineUsed(boolean bUsed);
+	boolean GetHeaderLineUsed() const;
 
 	// Activation de la progression (inactive par defaut)
 	// On peut specifier la debut et la fin de la plage de progression (entre 0 et 1)
@@ -79,4 +82,5 @@ protected:
 	double dProgressionEnd;
 	boolean bDisplayProgression;
 	boolean bVerbose;
+	boolean bHeaderLineUsed;
 };

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.h
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.h
@@ -28,11 +28,11 @@ public:
 
 	// Concatenation des chunks avec envoi des erreurs vers errorSender (facultatif)
 	// L'ordre des chunks dans fichier final sera conforme a l'ordre donne par le vecteur
-	// Si bRemoveChunks est a true, les chunks sont effaces au fur et a mesure (et en cas d'erreur)
+	// Les chunks sont effaces au fur et a mesure ou en cas d'erreur
 	// Si il y a assez de ressources, pour la lecture on utilise entre 1 et 8 preferred size
 	// et pour l'ecriture on utilise 1 preferred size. Sinon on utilise une taille de bloc (64Ko) pour la lecture et
-	// l'ecriture. Seul le processus maitre peut invoquer cette methode renvoie true si tout s'est bien passe
-	boolean Concatenate(const StringVector* svChunkURIs, const Object* errorSender, boolean bRemoveChunks) const;
+	// l'ecriture. Seul le processus maitre peut invoquer cette methode Renvoi true si tout s'est bien passe
+	boolean Concatenate(const StringVector* svChunkURIs, const Object* errorSender) const;
 
 	// Suppression des fichiers chunks (avec la meme specification de progression que la concatenation)
 	// Robuste a l'absence de chunk


### PR DESCRIPTION
A simple fix: temporary files are cleaned when there is an error. User interruption wasn't an error, it is  now.
closing #466 

2 extra things:
- Remove `bRemoveChunks` from the concatenate API , because it is always used with `bRemoveChunks=true`
- Reserve the size of the output file in concatenation.

Fix bug #468 
:warning: Don't forget to add a line in TestKhiops/NewV10/DetectFileFormatSideEffects/results.ref/D_NoFieldsHL.txt