### PR TITLE
Bug in interpretation dictionary with key variables

### DIFF
--- a/src/Learning/KIInterpretation/KIInterpretationDictionary.cpp
+++ b/src/Learning/KIInterpretation/KIInterpretationDictionary.cpp
@@ -138,10 +138,10 @@ boolean KIInterpretationDictionary::UpdateInterpretationAttributes()
 		// NV On met les attributs de cle en Used
 		for (nIndex = 0; nIndex < kwcInterpretationMainClass->GetKeyAttributeNumber(); nIndex++)
 		{
-			attribute = kwcInterpretationMainClass->LookupAttribute(
-			    kwcInterpretationMainClass->GetKeyAttributeNameAt(nIndex));
+			attribute = kwcInterpretationMainClass->GetKeyAttributeAt(nIndex);
 			check(attribute);
 			attribute->SetUsed(true);
+			attribute->SetLoaded(true);
 		}
 
 		// creation des attributs de contribution


### PR DESCRIPTION
Bug
- Le jeu de test LearningTest\TestKhiops\KIInterpretation\SpliceJunction plante en debug.
- Et l'inspection des résultats montre que la clé du dictionnaire multi-table n'est pas présente en sortie.

Correction dans KIInterpretationDictionary::UpdateInterpretationAttributes