### PR TITLE
Bug fix: Clean arrays at the end of the run in ParallelTask

### DIFF
--- a/src/Parallel/PLParallelTask/PLParallelTask.cpp
+++ b/src/Parallel/PLParallelTask/PLParallelTask.cpp
@@ -800,6 +800,12 @@ boolean PLParallelTask::Run()
 		RMParallelResourceDriver::grantedResources = NULL;
 	}
 
+	// Retaillage des tableaux qui stockent l'etat des esclaves au cas ou la tache
+	// serait appelee 2 fois de suite
+	oaSlaves.SetSize(0);
+	oaSlavesByRank.SetSize(0);
+	ivGrantedSlaveIds.SetSize(0);
+
 	// Arret des serveurs de fichiers
 	if (runningMode != SLAVE and not bNothingToDo)
 	{


### PR DESCRIPTION
At the end of ParallelTask:Run(), arrays that store slave states must be resized to 0. If Run() is called several times, these arrays will not be expanded.