### PR TITLE
Change conda package format to tar.bz2

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -78,7 +78,7 @@ jobs:
           fi
       - name: Build conda packages
         run: |
-          conda build --output-folder ./build/conda ./packaging/conda
+          conda build --package-format=tar.bz2 --output-folder ./build/conda ./packaging/conda
       - name: Upload conda packages artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Since the new package format is .conda we switch back to tar.bz2 to make minor changes in the CI