### PR TITLE
Update action versions

### DIFF
--- a/.github/actions/test-khiops-on-iris/action.yml
+++ b/.github/actions/test-khiops-on-iris/action.yml
@@ -96,7 +96,7 @@ runs:
         fi
     - name: Upload test results
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-results-${{ inputs.os-decription}}
         retention-days: 7

--- a/.github/actions/test-kni/action.yml
+++ b/.github/actions/test-kni/action.yml
@@ -14,11 +14,11 @@ runs:
           false
         fi
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: khiops
     - name: Checkout KhiopsNativeInterface-tutorial
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: KhiopsML/KhiopsNativeInterface-tutorial
         path: tutorial

--- a/.github/workflows/build-linux-pack-containers.yml
+++ b/.github/workflows/build-linux-pack-containers.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write  # Allows writing in the container registry
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/pack-macos.yml
+++ b/.github/workflows/pack-macos.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build Khiops executables
         uses: ./.github/actions/build-khiops
         with:

--- a/.github/workflows/pack-macos.yml
+++ b/.github/workflows/pack-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build package with CPack
         run: cd build/${{env.PRESET_NAME}} && cpack -G ZIP
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: macos
           path: build/${{env.PRESET_NAME}}/packages/*.zip

--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
       - name: Run pre-commit checks

--- a/.github/workflows/run-standard-tests.yml
+++ b/.github/workflows/run-standard-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Cache binaries (windows)
         id: cache-binaries-windows
         if: runner.os == 'Windows'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # We add binaries path one by one to avoid *.pdb and other msvc stuffs that generate a cache of 200Mo for windows
           path: |
@@ -74,7 +74,7 @@ jobs:
       - name: Cache binaries (macOS, Linux)
         id: cache-binaries-unix
         if: runner.os != 'Windows'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/build/${{ env.PRESET_NAME }}/bin/*          
@@ -102,7 +102,7 @@ jobs:
       - name: Restore cached binaries (windows)
         if: runner.os == 'Windows'
         id: restore-binaries-windows
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ${{ github.workspace }}/build/${{ env.PRESET_NAME }}/bin/MODL.exe
@@ -116,7 +116,7 @@ jobs:
       - name: Restore cached binaries (macOS, Linux)
         if: runner.os != 'Windows'
         id: restore-binaries
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ${{ github.workspace }}/build/${{ env.PRESET_NAME }}/bin/*           

--- a/.github/workflows/run-standard-tests.yml
+++ b/.github/workflows/run-standard-tests.yml
@@ -49,7 +49,7 @@ jobs:
       PRESET_NAME: ${{ matrix.build-setup.cmake-preset }}-${{ matrix.config }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build all binaries
         uses: ./.github/actions/build-khiops
         with:
@@ -98,7 +98,7 @@ jobs:
       PRESET_NAME: ${{ matrix.build-setup.cmake-preset }}-${{ matrix.config }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Restore cached binaries (windows)
         if: runner.os == 'Windows'
         id: restore-binaries-windows
@@ -211,7 +211,7 @@ jobs:
           fi
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ env.PRESET_NAME }}-${{ matrix.running-mode }}
           retention-days: 7
@@ -226,7 +226,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           sparse-checkout: .git
       - name: Cleanup cache

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
           ctest --preset ${{ matrix.build-setup.cmake-preset }}
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-test-results-${{ matrix.build-setup.cmake-preset }}
           retention-days: 7

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -38,7 +38,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build Khiops test executables
         uses: ./.github/actions/build-khiops
         with:

--- a/.github/workflows/update-kni-tutorial.yml
+++ b/.github/workflows/update-kni-tutorial.yml
@@ -13,13 +13,13 @@ jobs:
       contents: write  # To push a branch
     steps:
       - name: Checkout Khiops sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: khiops
       - name: Put Khiops version on the environment
         run: echo "KHIOPS_VERSION=$(./khiops/scripts/khiops-version)" >> "$GITHUB_ENV"
       - name: Checkout KNI-tutorial
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: KhiopsML/KNI-tutorial
           ssh-key: ${{ secrets.KNI_TUTORIAL_SSH_KEY }}


### PR DESCRIPTION
Update all actions to up-to-date version:
- upload 
- checkout
- cache

NB: upload artifact V3 [is deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)