### PR TITLE
518 remove compiler warnings on linux with gcc

### DIFF
--- a/src/Learning/KDDomainKnowledge/KDConstructedRule.cpp
+++ b/src/Learning/KDDomainKnowledge/KDConstructedRule.cpp
@@ -213,7 +213,16 @@ void KDConstructedRule::RemoveOperandAt(int nIndex)
 
 	// Reinitialisation de l'operande
 	oaConstructedOperands.SetAt(nIndex, NULL);
+#if defined(__GNUC__) && !defined(__clang__)
+// Dans plusieurs parties du code, on desactive le warning stringop-overflow
+// pour le compilateur gcc car il emet ce warning a tord (au moins pour la version 11)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 	cOperandOrigins[nIndex] = None;
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 void KDConstructedRule::DeleteAllOperands()

--- a/src/Learning/KWModeling/KWLearningBenchmarkUnivariate.cpp
+++ b/src/Learning/KWModeling/KWLearningBenchmarkUnivariate.cpp
@@ -53,9 +53,11 @@ void KWLearningBenchmarkUnivariate::Evaluate()
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnonnull"
+#endif
 		crashBench->Evaluate();
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
 	}
 
 	// Evaluation standard

--- a/src/Learning/KWModeling/KWLearningBenchmarkUnivariate.cpp
+++ b/src/Learning/KWModeling/KWLearningBenchmarkUnivariate.cpp
@@ -49,8 +49,13 @@ void KWLearningBenchmarkUnivariate::Evaluate()
 		cout << "CRASH" << endl;
 		KWLearningBenchmarkUnivariate* crashBench = NULL;
 
-		// Appel d'une methode sur un pointeur NULL
+// Appel d'une methode sur un pointeur NULL
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
 		crashBench->Evaluate();
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
 	}
 
 	// Evaluation standard

--- a/src/Norm/base/ALString.cpp
+++ b/src/Norm/base/ALString.cpp
@@ -97,8 +97,17 @@ void ALString::AssignCopy(int nSrcLen, const char* pszSrcData)
 		Empty();
 		AllocBuffer(nSrcLen);
 	}
+#if defined(__GNUC__) && !defined(__clang__)
+// Dans plusieurs parties du code, on desactive le warning stringop-overflow
+// pour le compilateur gcc car il emet ce warning a tord (au moins pour la version 11)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 	if (nSrcLen != 0)
 		memcpy(pchData, pszSrcData, nSrcLen);
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 	nDataLength = nSrcLen;
 
 	// Attention au cas particulier d'une chaine vide
@@ -164,7 +173,14 @@ char* ALString::GetBuffer(int nMinBufLength)
 		AllocBuffer(nMinBufLength);
 		memcpy(pchData, pszOldData, nOldLen);
 		nDataLength = nOldLen;
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push // Disable spurious stringop-overflow warning (bug on GCC 11)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 		pchData[nDataLength] = '\0';
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 		SafeDelete(pszOldData);
 	}
 
@@ -224,11 +240,18 @@ void ALString::ConcatInPlace(int nSrcLen, const char* pszSrcData)
 	if (nDataLength + nSrcLen > nAllocLength)
 		GetBuffer(2 * (nDataLength + nSrcLen));
 
-	// Cocatenation rapide
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push // Disable spurious stringop-overflow warning (bug on GCC 11)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+	// Concatenation rapide
 	memcpy(&pchData[nDataLength], pszSrcData, nSrcLen);
 	nDataLength += nSrcLen;
 	assert(nDataLength <= nAllocLength);
 	pchData[nDataLength] = '\0';
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 const ALString& ALString::operator+=(const char* psz)
@@ -420,10 +443,17 @@ int ALString::CompareNoCase(const char* psz) const
 	ALString sFirst;
 	ALString sSecond;
 
-	// Comparaison apres mise en majuscule
+// Comparaison apres mise en majuscule
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push // Disable spurious stringop-overflow warning (bug on GCC 11)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 	sFirst = pchData;
 	sFirst.MakeUpper();
 	sSecond = psz;
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 	sSecond.MakeUpper();
 
 	// Non ANSI: return stricmp(pchData, psz);
@@ -447,7 +477,10 @@ void ALString::MakeReverse()
 
 //////////////////////////////////////////////////////////////////////////////
 // Test
-
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push // Disable spurious stringop-overflow warning (bug on GCC 11)
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 void ALString::Test()
 {
 	ALString sTest;
@@ -609,3 +642,6 @@ void ALString::Test()
 	delete sTestAlloc;
 	delete sTestComp;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif

--- a/src/Parallel/PLParallelTask/PLSerializer.cpp
+++ b/src/Parallel/PLParallelTask/PLSerializer.cpp
@@ -915,6 +915,12 @@ void PLSerializer::PutBufferChars(const char* sSource, int nSize)
 	nPutBufferCharsCallNumber++;
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
+// Dans plusieurs parties du code, on desactive le warning stringop-overflow
+// pour le compilateur gcc car il emet ce warning a tord (au moins pour la version 11)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 void PLSerializer::GetBufferChars(char* sTarget, int nSize)
 {
 	int nCharNumberInBlocSrc;
@@ -1052,7 +1058,9 @@ void PLSerializer::GetBufferChars(char* sTarget, int nSize)
 		}
 	}
 }
-
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 void PLSerializer::AddMemVectorToBuffer(MemHugeVector& memHugeVector, int nSize, int nAllocSize)
 {
 	int nBlocIndex;


### PR DESCRIPTION
*  Disable spurious warning stringop-overflow

There is a false positive stringop-overflow warning on gcc 11
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106297
We add pragmas to disable this warning on minimum code lines

*  Remove gcc 11 Release warning: ‘this’ pointer is null [-Wnonnull]
*  The warning "reference to temporary [-Wreturn-local-addr]" is not handle in this PR because it is handle in another branch