### PR TITLE
Fix bug in V11, while opening modeling dictionary

### DIFF
--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -620,13 +620,14 @@ boolean KWMTDatabase::CheckPartially(boolean bWriteOnly) const
 
 			// Recherche de la classe principale du chemin de mapping
 			originClass = KWClassDomain::GetCurrentDomain()->LookupClass(mapping->GetOriginClassName());
-			assert(originClass->GetName() == GetClassName() or originClass->GetRoot());
+			assert(originClass == NULL or originClass->GetName() == GetClassName() or
+			       originClass->GetRoot());
 
 			// Existence de cette classe
 			if (originClass == NULL)
 			{
 				bOk = false;
-				if (originClass->GetName() == GetClassName())
+				if (mapping->GetOriginClassName() == GetClassName())
 					sOriginLabel = "Main";
 				else
 					sOriginLabel = "Root";


### PR DESCRIPTION
Bug se produisant apres un apprentissage multi-table, lors de l'ouverture du dictionnaire de modelisation construit

Correction
- KWMTDatabase::CheckPartially
- acces a tort a un objet NULL pour constituer un message d'erreur