### PR TITLE
Slight improvement of GUI with better initial size on small screens

### DIFF
--- a/src/Norm/NormGUI/src/normGUI/engine/GUIDialog.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIDialog.java
@@ -140,10 +140,9 @@ public class GUIDialog extends GUIObject
                 dialog.pack();
                 int minDialogWidth = getMinFramedWidth(guiDialogCard.getLabel());
                 Dimension currentPreferredSize = dialog.getPreferredSize();
-                if (currentPreferredSize.getWidth() <= minDialogWidth) {
-                        dialog.setPreferredSize(new Dimension(minDialogWidth, (int)currentPreferredSize.getHeight()));
-                        dialog.pack();
-                }
+                Dimension adjustedDimension = computeAdjustedDimension(currentPreferredSize, minDialogWidth);
+                dialog.setPreferredSize(adjustedDimension);
+                dialog.pack();
 
                 // Positionnement de la boite de dialogue par rapport a la fenetre parente
                 dialog.setLocationRelativeTo(parentFrame);

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIList.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIList.java
@@ -6,6 +6,7 @@ package normGUI.engine;
 
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
+import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Vector;
@@ -142,12 +143,22 @@ public class GUIList extends GUIUnit
                         }
                 });
 
-                int width = guiTable.getPreferredSize().width;
+                // On recupere les dimensions de l'ecran
+                Rectangle screenBounds = getCurrentScreenBounds();
+
                 // On fixe la hauteur a 5 lignes par defaut
                 int defaultRowNumber = 5;
                 int rowNumber = defaultRowNumber;
 
+                // Nombre max de lignes, en tenant compte de la taille de l'ecran, avec une marge heuristique
+                // pour tenir compte de la barre de tache, de la barre de titre, de menu, d'un libelle, de boutons...
+                int screenMaxUsableHeight = screenBounds.height * 2 / 3;
+                int maxRowNumber = screenMaxUsableHeight / getComponentPreferredHeight();
+                if (maxRowNumber < defaultRowNumber)
+                        maxRowNumber = defaultRowNumber;
+
                 // Recherche du (LineNumber, LastColumnExtraWidth) dans les parametres
+                int tableWidth = guiTable.getPreferredSize().width;
                 if (!getParameters().equals("") && getParametersAsArray().length == 2) {
                         String value;
 
@@ -159,8 +170,10 @@ public class GUIList extends GUIUnit
                                 } catch (Exception ex) {
                                         rowNumber = defaultRowNumber;
                                 }
-                                if (rowNumber < 1 || rowNumber > 50)
+                                if (rowNumber < 1)
                                         rowNumber = defaultRowNumber;
+                                if (rowNumber > maxRowNumber)
+                                        rowNumber = maxRowNumber;
                         }
 
                         // Recherche de la taille supplementaires a ajouter
@@ -174,14 +187,21 @@ public class GUIList extends GUIUnit
                                 }
                                 if (lastColumnExtraWidth < 0 || lastColumnExtraWidth > 50)
                                         lastColumnExtraWidth = 0;
-                                width = width + getComponentPreferredWidth(lastColumnExtraWidth);
+                                tableWidth = tableWidth + getComponentPreferredWidth(lastColumnExtraWidth);
                         }
                 }
-                int height = rowNumber * getComponentPreferredHeight();
+
                 // On limite l'affichage a 15 colonnes (de 10 caracteres)
-                if (width > 15 * getComponentPreferredWidth(10))
-                        width = 15 * getComponentPreferredWidth(10);
-                guiTable.setPreferredScrollableViewportSize(new Dimension(width, height));
+                int tableHeight = rowNumber * getComponentPreferredHeight();
+                if (tableWidth > 15 * getComponentPreferredWidth(10))
+                        tableWidth = 15 * getComponentPreferredWidth(10);
+                if (tableWidth > screenBounds.width)
+                        tableWidth = screenBounds.width;
+                if (tableHeight > screenMaxUsableHeight)
+                        tableHeight = screenMaxUsableHeight;
+                guiTable.setPreferredScrollableViewportSize(new Dimension(tableWidth, tableHeight));
+
+                // Ajout du composant
                 constraints.weightx = 1.0;
                 constraints.weighty = 1.0;
                 constraints.gridwidth = GridBagConstraints.REMAINDER;

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIMessage.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIMessage.java
@@ -10,7 +10,6 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Insets;
 import java.awt.Rectangle;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import javax.swing.JButton;
@@ -51,8 +50,7 @@ public class GUIMessage extends JFrame
                 currentTextLength = 0;
 
                 // On recupere les dimensions de l'ecran
-                int screenWidth = Toolkit.getDefaultToolkit().getScreenSize().width;
-                int screenHeight = Toolkit.getDefaultToolkit().getScreenSize().height;
+                Rectangle screenBounds = GUIObject.getCurrentScreenBounds();
 
                 // Creation de la zone de texte
                 pane = new NonWrappingTextPane();
@@ -63,7 +61,7 @@ public class GUIMessage extends JFrame
 
                 // Creation et ajout des composants au panel
                 JScrollPane scrollPane = new JScrollPane(pane);
-                scrollPane.setPreferredSize(new Dimension(screenWidth / 3, screenHeight / 3));
+                scrollPane.setPreferredSize(new Dimension(screenBounds.width / 3, screenBounds.height / 3));
                 getContentPane().add(scrollPane, BorderLayout.CENTER);
                 JPanel panelButton = new JPanel();
                 JButton buttonClear = new JButton("Clear");

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIObject.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIObject.java
@@ -181,8 +181,34 @@ public abstract class GUIObject
         }
 
         /*
-         * Recherche des caracteristiques de l'ecran courant, contena t la fenetre
-         * active
+         * Ajustement d'une dimension initiale par rapport a une largeur de frame minimale et a la taille de l'ecran
+         */
+        static public Dimension computeAdjustedDimension(Dimension initialDimension, int minFrameWidth)
+        {
+                // On recupere les dimensions de l'ecran
+                Rectangle screenBounds = getCurrentScreenBounds();
+
+                // Ajustement des dimensions a la largeur minimale
+                int newWidth = (int)initialDimension.getWidth();
+                int newHeight = (int)initialDimension.getHeight();
+                if (newWidth < minFrameWidth)
+                        newWidth = minFrameWidth;
+
+                // Ajout heuristique d'une petite marge en largeur
+                newWidth = (newWidth * 105) / 100;
+
+                // Ajustement a la taille de l'ecran, avec une marge heuristique
+                // pour tenir compte de la barre de tache, de la barre de titre, de menu, d'un libelle, de boutons...
+                int maxUsableHeight = (screenBounds.height * 95) / 100;
+                if (newWidth > screenBounds.width)
+                        newWidth = screenBounds.width;
+                if (newHeight > maxUsableHeight)
+                        newHeight = maxUsableHeight;
+                return new Dimension(newWidth, newHeight);
+        }
+
+        /*
+         * Recherche des caracteristiques de l'ecran courant, contenant la fenetre active
          */
         static public Rectangle getCurrentScreenBounds()
         {

--- a/src/Norm/NormGUI/src/normGUI/engine/GUIUnit.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIUnit.java
@@ -1281,14 +1281,14 @@ import javax.swing.SwingUtilities;
                 // Initialisation des valeurs
                 graphicRefreshAll();
 
-                // Ajustement de la taille de la fenetre pour tenir compte de la longueur du titre
+                // Ajustement de la taille de la fenetre pour tenir compte de la longueur du titre et de la taille de
+                // l'ecran
                 frame.pack();
                 int minFrameWidth = getMinFramedWidth(getLabel());
                 Dimension currentPreferredSize = frame.getPreferredSize();
-                if (currentPreferredSize.getWidth() <= minFrameWidth) {
-                        frame.setPreferredSize(new Dimension(minFrameWidth, (int)currentPreferredSize.getHeight()));
-                        frame.pack();
-                }
+                Dimension adjustedDimension = computeAdjustedDimension(currentPreferredSize, minFrameWidth);
+                frame.setPreferredSize(adjustedDimension);
+                frame.pack();
 
                 // Creation et enregistrement d'une gestion personnaliser de la fermeture
                 // de la fenetre pour gerer la synchronisation avec le programme


### PR DESCRIPTION
Quelques ajustements rapides et pragmatiques pour améliorer ce petit problème ergonomique. Essentiellement :
- ne pas afficher trop de lignes dans les listes, en s'adaptant à la taille de l'écran
- lors de l'affichage d'une fenêtre, limiter la taille initiale en fonction de la taille de l'écran