### PR TITLE
497 optimize memory and calculation requirements for table creation rules

### DIFF
--- a/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.cpp
+++ b/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.cpp
@@ -423,7 +423,6 @@ int KDTextTokenSampleCollectionTask::GetMaxStreamCollectedTokenNumber(int nReque
 boolean KDTextTokenSampleCollectionTask::InternalCollectTokenSamples(const KWDatabase* sourceDatabase)
 {
 	boolean bOk = true;
-	// DDD boolean bDisplayPerformanceStats = false;
 	int nAttribute;
 	ALString sTmp;
 

--- a/src/Learning/KIInterpretation/KIInterpretationDictionary.cpp
+++ b/src/Learning/KIInterpretation/KIInterpretationDictionary.cpp
@@ -1123,7 +1123,7 @@ const ALString& KIInterpretationDictionary::GetWhyTypeShortLabel(const ALString 
 	else if (asWhyTypeLongLabel == "Shapley")
 		return SHAPLEY_LABEL;
 	else
-		return "Undefined";
+		return UNDEFINED_LABEL;
 }
 
 const ALString KIInterpretationDictionary::LEVER_ATTRIBUTE_META_TAG = "LeverVariable";

--- a/src/Learning/KIInterpretation/KIInterpretationDictionary.h
+++ b/src/Learning/KIInterpretation/KIInterpretationDictionary.h
@@ -58,6 +58,7 @@ public:
 	const ALString LOG_MODALITY_PROBA_LABEL = "LogModalityProba";
 	const ALString LOG_MIN_PROBA_DIFF_LABEL = "LogMinProbaDiff";
 	const ALString BAYES_DISTANCE_WITHOUT_PRIOR_LABEL = "BayesDistanceWithoutPrior";
+	const ALString UNDEFINED_LABEL = "Undefined";
 
 	static const ALString LEVER_ATTRIBUTE_META_TAG;
 	static const ALString INTERPRETATION_ATTRIBUTE_META_TAG;

--- a/src/Learning/KWData/KWAttribute.h
+++ b/src/Learning/KWData/KWAttribute.h
@@ -114,7 +114,7 @@ public:
 	KWClass* GetParentClass() const;
 
 	/////////////////////////////////////////
-	// Lien enre attribut et bloc
+	// Lien entre attribut et bloc
 
 	// Indique si l'attribut est dans un bloc
 	boolean IsInBlock() const;

--- a/src/Learning/KWData/KWClass.cpp
+++ b/src/Learning/KWData/KWClass.cpp
@@ -1530,7 +1530,17 @@ void KWClass::FinalizeBuildAllUsedAttributes(NumericKeyDictionary* nkdAllUsedAtt
 	while (bContinue)
 	{
 		nStep++;
+
+		// Export d'u dictionnaire d'attribut sous forme de tableau
 		nkdAllUsedAttributes->ExportObjectArray(&oaAllUsedAttributes);
+
+		// Tri par nom de classe et d'attribut
+		// Ce tri n'est pas obligatoire, mais il n'est pas vraiment couteux en temps, et il assure la
+		// reproductibilite de l'execution des passes d'analyse, ce qui est critique pour la mise au point
+		oaAllUsedAttributes.SetCompareFunction(KWAttributeCompareClassAndAttributeName);
+		oaAllUsedAttributes.Sort();
+
+		// Parcours des attributs pour une nouvelle passe
 		for (nAttribute = 0; nAttribute < oaAllUsedAttributes.GetSize(); nAttribute++)
 		{
 			attribute = cast(KWAttribute*, oaAllUsedAttributes.GetAt(nAttribute));

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -360,9 +360,10 @@ public:
 	// Simplification d'une classe en supprimant les attributs derives
 	// non utilises directement ou indirectement, y compris dans une
 	// autre classe du domaine.
-	// On ne touche pas aux classes non utilisee, qui gardent leur integrite structurelle
-	// (ex: avec leurs champs cle), ni aux  aux attributs natifs, pour eviter les warning
-	// llors des lectures de fichier de donnee.
+	// On supprime egalement les classes non utilisees su diomaines, qui sinon pourraient perdre
+	// leur integrite structurelle (par exemple en referencant des attributs supprimes d'autres classes)
+	// On garde par contre les attributs natifs des classes nettoyeers, pour eviter les warning
+	// lors des lectures de fichier de donnee.
 	//
 	// Si le domaine de reference n'est pas NULL, les attributs doivent
 	// etre absent de ce dernier pour etre supprimes.

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -360,28 +360,65 @@ public:
 	// Simplification d'une classe en supprimant les attributs derives
 	// non utilises directement ou indirectement, y compris dans une
 	// autre classe du domaine.
+	// On ne touche pas aux classes non utilisee, qui gardent leur integrite structurelle
+	// (ex: avec leurs champs cle), ni aux  aux attributs natifs, pour eviter les warning
+	// llors des lectures de fichier de donnee.
+	//
 	// Si le domaine de reference n'est pas NULL, les attributs doivent
-	// etre absent de ce dernier pour etre supprimes
+	// etre absent de ce dernier pour etre supprimes.
+	// Attention, si le domaine de reference est nul, cela peut impacter le mapping  dans le
+	// cas multi-table, et les bases doivent actualiser ce mapping avec le dictionnaire simplifie.
+	//
 	// Prerequis: la classe doit etre compilee (elle ne le sera plus apres)
 	void DeleteUnusedDerivedAttributes(const KWClassDomain* referenceDomain);
 
-	// Finalisation de la construction du dictionnaire de tous les attributs utilises en tenant
-	// compte des regles de construction de table, pour lesquelles la detection des attributs utilises
-	// ne peut se faire qu'en plusieurs passe:
-	// - premiere passe:
-	//   - on detecte les attributs utilises de type vue des classes en sortie des regles
-	// - deuxieme passe:
-	//   - on deduit des attribut utilises de chaque classe en sortie, les attribut utilises
-	//     de la classe source de la vue
-	// - passes suivantes, si necessaire
-	//  - si la deuxieme passe a detecte de nouveaux attribut utilise, il peut etre necessare
-	//    de faire d'autres passes
-	// Pour le service de propagation, il faut d'abord avoir manuellement effectue la premiere
-	// passe de collecte des attributs utilises. Un seul appel a la methode suivante effectue
-	// l'ensemble des passes necessaire pour finaliser la collecte des attribut utilise
-	// sur l'ensemble du domaine
-	// Les classes utilisees sont egalement alimentee en sortie, meme si le dictionnaire
-	// en entree est vide
+	// Calcul de l'ensemble de tous les attributs utilises, Used et Loaded, par analyse recursive
+	// du graphe de calcul, avec en complement des info sur les classes utilises, par type d'usage
+	// Parametres:
+	// - nkdAllUsedAttributes
+	//   - contient tous les attributs utilises recursivement
+	//   - peut etre initialement non vide pour specifier des attributs a utiliser
+	//     meme s'ils ne sont pas Used, comme par exemple un attribut de selection
+	// - nkdAllUsedClasses
+	//   - contient toutes les classes utilisees recursivement, deduites des attributs utilises
+	// - nkdAllLoadedClasses
+	//   - contient toutes les classes chargees explicitement, sans tenir compte des besoins des attributs derives
+	// - nkdAllNativeClasses
+	//   - contient toutes les classes natives, quelle soient utilisees ou non
+	//
+	// Les principe de l'algorithme sont resumes ci-dessous.
+	//
+	// La premiere etape consiste en
+	// - initialisation avec l'ensemble des attributs utilises et de leur classe
+	// - analyse des regles de derivation de ces attributs par la methode BuildAllUsedAttributes
+	//   pour en deduire tous les attributs utilises en operandes des regles, meme s'il ne sont
+	//   pas utilises (Used) directement dans les attributs des classes
+	//
+	// Il est a noter que certaines regles ont un comportement special
+	// - regle produisant un bloc en sortie, a partir d'un bloc en entree
+	//   - on deduit des attributs utilises du bloc en sortie les attribut a utiliser dans le bloc en entree
+	// - regle de creation de table de type vue
+	//   - on deduit des attributs utilises de la table en sortie les attributs a utiliser dans la table en entree
+	// - regle de creation de table avec operandes en sortie
+	//   - on deduit des attributs utilises de la table en sortie les operandes de la regle a analyser pour le calcul
+	//     des valeurs des attributs en sortie
+	//
+	// Il est egalement a noter le traitement de la partie native du schema de donnees, c'est a dire les classes utilisees
+	// par des attributs non derives de type relation, ou des tables externes.
+	// Pour les classes natives utilisees, il faut implicitement utiliser les attributs de la cle des classes, necessaire
+	// pour la lecture des donnees.
+	// Ce n'est pas necessaire pour des classes utilisees uniquement en sortie de regles de creation de table.
+	//
+	// Une deuxieme passe est necessaire pour decouvrir tous les attributs utilises, car par exemple, on ne peut connaitre
+	// la liste des attributs utilises d'une vue qu'apres avoir analyse tout le graphe de calcul.
+	// Cette deuxieme passe est reiteree tant que l'on decrouvre de nouveaux attributs utilises
+	void BuildAllUsedAttributes(NumericKeyDictionary* nkdAllUsedAttributes, NumericKeyDictionary* nkdAllUsedClasses,
+				    NumericKeyDictionary* nkdAllLoadedClasses,
+				    NumericKeyDictionary* nkdAllNativeClasses) const;
+
+	// Finalisation du calcul de l'ensemble de tous les attributs utilises, pour le cas ou on dispose deja
+	// d'un ensemble d'attributs utilises de depart
+	// Methode interne utilisee pour effectuer la deuxieme passe de la methode BuildAllUsedAttributes
 	void FinalizeBuildAllUsedAttributes(NumericKeyDictionary* nkdAllUsedAttributes,
 					    NumericKeyDictionary* nkdAllUsedClasses) const;
 

--- a/src/Learning/KWData/KWClassDomain.cpp
+++ b/src/Learning/KWData/KWClassDomain.cpp
@@ -421,35 +421,34 @@ const ALString KWClassDomain::BuildClassName(const ALString& sPrefix)
 
 boolean KWClassDomain::Check() const
 {
+	boolean bOk;
 	int i;
 	KWClass* kwcElement;
 	KWAttribute* attribute;
-	boolean bResult;
 
-	bResult = true;
+	bOk = true;
 	Global::ActivateErrorFlowControl();
 
 	// Verification de l'integrite de chaque classe
 	for (i = 0; i < GetClassNumber(); i++)
 	{
 		kwcElement = GetClassAt(i);
+
+		// Verification de l'integrite de la clase, qui emet ses propres erreurs
 		if (not kwcElement->Check())
-		{
-			kwcElement->AddError("Integrity errors");
-			bResult = false;
-		}
+			bOk = false;
 
 		// Verification de la coherence du domaine
-		if (kwcElement->GetDomain() != this)
+		if (bOk and kwcElement->GetDomain() != this)
 		{
 			kwcElement->AddError("Inconsistent dictionary domain");
-			bResult = false;
+			bOk = false;
 		}
 	}
 
 	// Verification de l'integrite referentielle: toute classe referencee doit
 	// appartenir au meme domaine de classe
-	if (bResult)
+	if (bOk)
 	{
 		for (i = 0; i < GetClassNumber(); i++)
 		{
@@ -469,7 +468,7 @@ boolean KWClassDomain::Check() const
 								     " references the dictionary " +
 								     attribute->GetClass()->GetName() +
 								     " which is belongs to another dictionary domain");
-						bResult = false;
+						bOk = false;
 					}
 				}
 
@@ -479,8 +478,7 @@ boolean KWClassDomain::Check() const
 		}
 	}
 	Global::DesactivateErrorFlowControl();
-
-	return bResult;
+	return bOk;
 }
 
 void KWClassDomain::CompleteTypeInfo()

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -2154,6 +2154,8 @@ void KWDatabase::ComputeUnusedNativeAttributesToKeep(const NumericKeyDictionary*
 			{
 				// Analyse si retourne par une regle de derivation
 				// On identifie ainsi les attributs Object natifs potentiellement references
+				// En cas d'attribut d'un bloc, il faut analyser la regle
+				// (cela ne sera fait qu'une seule fois grace a nkdAnalysedRules)
 				if (attribute->GetAnyDerivationRule() != NULL)
 					ComputeUnusedNativeAttributesToKeepForRule(nkdNeededClasses, nkdAttributes,
 										   &nkdAnalysedRules,
@@ -2197,7 +2199,7 @@ void KWDatabase::ComputeUnusedNativeAttributesToKeep(const NumericKeyDictionary*
 		for (nAttribute = 0; nAttribute < oaAttributesToKeep.GetSize(); nAttribute++)
 		{
 			attribute = cast(KWAttribute*, oaAttributesToKeep.GetAt(nAttribute));
-			cout << "\t" << attribute->GetClass()->GetName() << "\t" << attribute->GetName() << "\n";
+			cout << "\t" << attribute->GetParentClass()->GetName() << "\t" << attribute->GetName() << "\n";
 		}
 	}
 }

--- a/src/Learning/KWData/KWDatabaseFormatDetector.cpp
+++ b/src/Learning/KWData/KWDatabaseFormatDetector.cpp
@@ -1371,6 +1371,9 @@ void KWDatabaseFormatDetector::BuildMandatoryDataItemNames(const KWClass* kwcCla
 			derivationRule->BuildAllUsedAttributes(attribute, &nkdNeededAttributes);
 	}
 
+	// Finalisation de la collecte des attributs utilises via les regles de construction de table
+	KWDerivationRule::FinalizeBuildAllUsedAttributes(&nkdNeededAttributes);
+
 	// Export des attributs identifies
 	nkdNeededAttributes.ExportObjectArray(&oaNeedAttributes);
 

--- a/src/Learning/KWData/KWDatabaseFormatDetector.cpp
+++ b/src/Learning/KWData/KWDatabaseFormatDetector.cpp
@@ -1344,6 +1344,7 @@ void KWDatabaseFormatDetector::BuildMandatoryDataItemNames(const KWClass* kwcCla
 	KWAttributeBlock* attributeBlock;
 	KWDerivationRule* derivationRule;
 	NumericKeyDictionary nkdNeededAttributes;
+	NumericKeyDictionary nkdNeededClasses;
 	ObjectArray oaNeedAttributes;
 	int nAttribute;
 	NumericKeyDictionary nkdNeededAttributeBlocks;
@@ -1372,7 +1373,7 @@ void KWDatabaseFormatDetector::BuildMandatoryDataItemNames(const KWClass* kwcCla
 	}
 
 	// Finalisation de la collecte des attributs utilises via les regles de construction de table
-	KWDerivationRule::FinalizeBuildAllUsedAttributes(&nkdNeededAttributes);
+	kwcClass->FinalizeBuildAllUsedAttributes(&nkdNeededAttributes, &nkdNeededClasses);
 
 	// Export des attributs identifies
 	nkdNeededAttributes.ExportObjectArray(&oaNeedAttributes);

--- a/src/Learning/KWData/KWDerivationRule.cpp
+++ b/src/Learning/KWData/KWDerivationRule.cpp
@@ -305,58 +305,6 @@ void KWDerivationRule::BuildAllUsedAttributes(const KWAttribute* derivedAttribut
 	}
 }
 
-void KWDerivationRule::FinalizeBuildAllUsedAttributes(NumericKeyDictionary* nkdAllUsedAttributes)
-{
-	const boolean bTrace = false;
-	const boolean bTraceAttributes = false;
-	ObjectArray oaAllUsedAttributes;
-	KWAttribute* attribute;
-	KWDerivationRule* rule;
-	int nAttribute;
-	boolean bContinue;
-	int nStep;
-
-	require(nkdAllUsedAttributes != NULL);
-
-	// Trace de debut
-	if (bTrace)
-	{
-		cout << "FinalizeBuildAllUsedAttributes"
-		     << "\n";
-		cout << "\tInitial attributes\t" << nkdAllUsedAttributes->GetCount() << endl;
-	}
-
-	// Passe de propagation de la collecte des attributs utilises
-	bContinue = true;
-	nStep = 0;
-	while (bContinue)
-	{
-		nStep++;
-		nkdAllUsedAttributes->ExportObjectArray(&oaAllUsedAttributes);
-		for (nAttribute = 0; nAttribute < oaAllUsedAttributes.GetSize(); nAttribute++)
-		{
-			attribute = cast(KWAttribute*, oaAllUsedAttributes.GetAt(nAttribute));
-
-			// Recalcul des attributs utilises uniquement pour les regles de creation de table
-			rule = attribute->GetAnyDerivationRule();
-			if (rule != NULL and KWType::IsRelation(rule->GetType()) and not rule->GetReference())
-				rule->BuildAllUsedAttributes(attribute, nkdAllUsedAttributes);
-
-			// Trace des attributs
-			if (bTraceAttributes)
-			{
-				cout << "\t\t" << attribute->GetParentClass()->GetName() << "\t" << attribute->GetName()
-				     << "\n";
-			}
-		}
-		bContinue = nkdAllUsedAttributes->GetCount() > oaAllUsedAttributes.GetSize();
-
-		// Trace
-		if (bTrace)
-			cout << "\tPass " << nStep << "\t" << nkdAllUsedAttributes->GetCount() << endl;
-	}
-}
-
 boolean KWDerivationRule::IsSecondaryScopeOperand(int nOperandIndex) const
 {
 	require(0 <= nOperandIndex and nOperandIndex < GetOperandNumber());

--- a/src/Learning/KWData/KWDerivationRule.cpp
+++ b/src/Learning/KWData/KWDerivationRule.cpp
@@ -305,6 +305,58 @@ void KWDerivationRule::BuildAllUsedAttributes(const KWAttribute* derivedAttribut
 	}
 }
 
+void KWDerivationRule::FinalizeBuildAllUsedAttributes(NumericKeyDictionary* nkdAllUsedAttributes)
+{
+	const boolean bTrace = false;
+	const boolean bTraceAttributes = false;
+	ObjectArray oaAllUsedAttributes;
+	KWAttribute* attribute;
+	KWDerivationRule* rule;
+	int nAttribute;
+	boolean bContinue;
+	int nStep;
+
+	require(nkdAllUsedAttributes != NULL);
+
+	// Trace de debut
+	if (bTrace)
+	{
+		cout << "FinalizeBuildAllUsedAttributes"
+		     << "\n";
+		cout << "\tInitial attributes\t" << nkdAllUsedAttributes->GetCount() << endl;
+	}
+
+	// Passe de propagation de la collecte des attributs utilises
+	bContinue = true;
+	nStep = 0;
+	while (bContinue)
+	{
+		nStep++;
+		nkdAllUsedAttributes->ExportObjectArray(&oaAllUsedAttributes);
+		for (nAttribute = 0; nAttribute < oaAllUsedAttributes.GetSize(); nAttribute++)
+		{
+			attribute = cast(KWAttribute*, oaAllUsedAttributes.GetAt(nAttribute));
+
+			// Recalcul des attributs utilises uniquement pour les regles de creation de table
+			rule = attribute->GetAnyDerivationRule();
+			if (rule != NULL and KWType::IsRelation(rule->GetType()) and not rule->GetReference())
+				rule->BuildAllUsedAttributes(attribute, nkdAllUsedAttributes);
+
+			// Trace des attributs
+			if (bTraceAttributes)
+			{
+				cout << "\t\t" << attribute->GetParentClass()->GetName() << "\t" << attribute->GetName()
+				     << "\n";
+			}
+		}
+		bContinue = nkdAllUsedAttributes->GetCount() > oaAllUsedAttributes.GetSize();
+
+		// Trace
+		if (bTrace)
+			cout << "\tPass " << nStep << "\t" << nkdAllUsedAttributes->GetCount() << endl;
+	}
+}
+
 boolean KWDerivationRule::IsSecondaryScopeOperand(int nOperandIndex) const
 {
 	require(0 <= nOperandIndex and nOperandIndex < GetOperandNumber());

--- a/src/Learning/KWData/KWDerivationRule.h
+++ b/src/Learning/KWData/KWDerivationRule.h
@@ -225,23 +225,6 @@ public:
 	virtual void BuildAllUsedAttributes(const KWAttribute* derivedAttribute,
 					    NumericKeyDictionary* nkdAllUsedAttributes) const;
 
-	// Finalisation de la construction du dictionnaire de tous les attributs utilises en tenant
-	// compte des regles de construction de table, pour lesquelles la detection des attributs utilises
-	// ne peut se faire qu'en plusieurs passe:
-	// - premiere passe:
-	//   - on detecte les attributs utilises de type vue des classes en sortie des regles
-	// - deuxieme passe:
-	//   - on deduit des attribut utilises de chaque classe en sortie, les attribut utilises
-	//     de la classe source de la vue
-	// - passes suivantes, si necessaire
-	//  - si la deuxieme passe a detecte de nouveaux attribut utilise, il peut etre necessare
-	//    de faire d'autres passes
-	// Pour le service de propagation, il faut d'abord avoir manuellement effectue la premiere
-	// passe de collecte des attributs utilises. Un seul appel a la methode suivante effectue
-	// l'ensemble des passes necessaire pour finaliser la collecte des attribut utilise
-	// sur l'ensemble du domaine
-	static void FinalizeBuildAllUsedAttributes(NumericKeyDictionary* nkdAllUsedAttributes);
-
 	//////////////////////////////////////////////////////////////////////////
 	// Gestion du scope des operandes
 	//

--- a/src/Learning/KWData/KWDerivationRule.h
+++ b/src/Learning/KWData/KWDerivationRule.h
@@ -225,6 +225,23 @@ public:
 	virtual void BuildAllUsedAttributes(const KWAttribute* derivedAttribute,
 					    NumericKeyDictionary* nkdAllUsedAttributes) const;
 
+	// Finalisation de la construction du dictionnaire de tous les attributs utilises en tenant
+	// compte des regles de construction de table, pour lesquelles la detection des attributs utilises
+	// ne peut se faire qu'en plusieurs passe:
+	// - premiere passe:
+	//   - on detecte les attributs utilises de type vue des classes en sortie des regles
+	// - deuxieme passe:
+	//   - on deduit des attribut utilises de chaque classe en sortie, les attribut utilises
+	//     de la classe source de la vue
+	// - passes suivantes, si necessaire
+	//  - si la deuxieme passe a detecte de nouveaux attribut utilise, il peut etre necessare
+	//    de faire d'autres passes
+	// Pour le service de propagation, il faut d'abord avoir manuellement effectue la premiere
+	// passe de collecte des attributs utilises. Un seul appel a la methode suivante effectue
+	// l'ensemble des passes necessaire pour finaliser la collecte des attribut utilise
+	// sur l'ensemble du domaine
+	static void FinalizeBuildAllUsedAttributes(NumericKeyDictionary* nkdAllUsedAttributes);
+
 	//////////////////////////////////////////////////////////////////////////
 	// Gestion du scope des operandes
 	//

--- a/src/Learning/KWData/KWDerivationRule.h
+++ b/src/Learning/KWData/KWDerivationRule.h
@@ -225,6 +225,10 @@ public:
 	virtual void BuildAllUsedAttributes(const KWAttribute* derivedAttribute,
 					    NumericKeyDictionary* nkdAllUsedAttributes) const;
 
+	// Construction du dictionnaire de tous les attributs utilises pour un operande donne
+	virtual void BuildAllUsedAttributesAtOperand(const KWAttribute* derivedAttribute, int nOperandIndex,
+						     NumericKeyDictionary* nkdAllUsedAttributes) const;
+
 	//////////////////////////////////////////////////////////////////////////
 	// Gestion du scope des operandes
 	//

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -1538,7 +1538,6 @@ KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceCl
 						 boolean bIsExternalTable, const ALString& sOriginClassName,
 						 StringVector* svAttributeNames, ObjectArray* oaCreatedMappings)
 {
-	const KWDRReference referenceRule;
 	KWMTDatabaseMapping* mapping;
 	KWMTDatabaseMapping* subMapping;
 	KWAttribute* attribute;
@@ -1632,7 +1631,8 @@ KWMTDatabaseMapping* KWMTDatabase::CreateMapping(ObjectDictionary* odReferenceCl
 				}
 			}
 			// Cas d'un attribut natif reference (avec regle de derivation predefinie)
-			else if (attribute->GetAnyDerivationRule()->GetName() == referenceRule.GetName())
+			else if (attribute->GetAnyDerivationRule()->GetName() ==
+				 KWDerivationRule::GetReferenceRuleName())
 			{
 				// Memorisation du mapping a traiter
 				if (odReferenceClasses->Lookup(attribute->GetClass()->GetName()) == NULL)

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -2415,6 +2415,11 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 	// Positionnement du flag d'erreur
 	bIsError = bIsError or mapping->GetDataTableDriver()->IsError();
 
+	// Incrementation du nombre global d'enregistrements lus
+	// Si on voulait des stats relative uniquement aux instances principales selectionnees, cela devrait se faire
+	// a posteriori une fois les instances selectionnees entierement validees, au niveau de la methode Read
+	mapping->GetDataTableDriver()->SetUsedRecordNumber(mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
+
 	// Memorisation inconditionnelle de la cle du dernier enregistremnt lu, dans le cas d'une classe unique,
 	// meme si l'objet n'a pas pu etre lu
 	// Cela permet de gere les lignes dupliquees, que l'objet soit lu ou non (a cause d'une erreur de parsing)
@@ -2483,12 +2488,6 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 			// Retour si enregistrement ignore
 			if (kwoObject == NULL)
 				return NULL;
-
-			// Incrementation du compteur d'objet utilise au niveau physique pour la classe principale
-			// L'incrementation pour les mappings de la composition est effectuee par la suite
-			if (mapping == mainMultiTableMapping)
-				mapping->GetDataTableDriver()->SetUsedRecordNumber(
-				    mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
 		}
 
 		// Parcours des mappings de la composition  pour completer la lecture de l'objet
@@ -2575,14 +2574,6 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 								    componentMapping->GetMappedAttributeLoadIndex(),
 								    kwoSubObject);
 
-								// Incrementation du compteur d'objet utilise au niveau
-								// physique
-								componentMapping->GetDataTableDriver()
-								    ->SetUsedRecordNumber(
-									componentMapping->GetDataTableDriver()
-									    ->GetUsedRecordNumber() +
-									1);
-
 								// Memorisation de la derniere cle lue
 								componentMapping->SetLastReadKey(&subObjectKey);
 
@@ -2608,14 +2599,6 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 
 								// Rangement du sous-objet dans le tableau
 								oaSubObjects->Add(kwoSubObject);
-
-								// Incrementation du compteur d'objet utilise au niveau
-								// physique
-								componentMapping->GetDataTableDriver()
-								    ->SetUsedRecordNumber(
-									componentMapping->GetDataTableDriver()
-									    ->GetUsedRecordNumber() +
-									1);
 							}
 
 							// Memorisation de la derniere cle lue

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -2442,9 +2442,11 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 	// Incrementation du nombre global d'enregistrements lus
 	// Si on voulait des stats relative uniquement aux instances principales selectionnees, cela devrait se faire
 	// a posteriori une fois les instances selectionnees entierement validees, au niveau de la methode Read
-	mapping->GetDataTableDriver()->SetUsedRecordNumber(mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
+	if (kwoObject != NULL and not bIsError)
+		mapping->GetDataTableDriver()->SetUsedRecordNumber(
+		    mapping->GetDataTableDriver()->GetUsedRecordNumber() + 1);
 
-	// Memorisation inconditionnelle de la cle du dernier enregistremnt lu, dans le cas d'une classe unique,
+	// Memorisation inconditionnelle de la cle du dernier enregistrement lu, dans le cas d'une classe unique,
 	// meme si l'objet n'a pas pu etre lu
 	// Cela permet de gere les lignes dupliquees, que l'objet soit lu ou non (a cause d'une erreur de parsing)
 	if (kwoObject == NULL)

--- a/src/Learning/KWData/KWObject.h
+++ b/src/Learning/KWData/KWObject.h
@@ -216,6 +216,33 @@ protected:
 	// Destruction des attributs (recursive pour les objet inclus)
 	void DeleteAttributes();
 
+	//////////////////////////////////////////////////////////////////////////////////////////////
+	// Services de nettoyage ou destruction total ou partiel des attributs,
+	// partage par les methodes de destruction et de mutation
+
+	// Reinitialisation des valeurs de type Symbol dans la liste LoadedDenseSymbolAttribute
+	void ResetLoadedSymbolValues(int nStartIndex, int nStopIndex);
+
+	// Reinitialisation des valeurs de type Text dans la liste LoadedTextAttribute
+	void ResetLoadedTextValues(int nStartIndex, int nStopIndex);
+
+	// Destruction des valeurs de type TextList dans la liste LoadedTextListAttribute
+	void DeleteLoadedTextListValues(int nStartIndex, int nStopIndex);
+
+	// Destruction des blocs de valeurs dans la liste LoadedAttributeBlock
+	void DeleteLoadedAttributeBlockValues(int nStartIndex, int nStopIndex);
+
+	// Destruction des valeurs de type Object ou ObjectArray dans la liste LoadedRelationAttribute
+	void DeleteLoadedRelationValues(int nStartIndex, int nStopIndex);
+
+	// Destruction des valeurs de type Object ou ObjectArray inclus natifs ou crees non charges en memoire,
+	// dans la liste UnloadedOwnedRelationAttribute
+	void DeleteUnloadedOwnedRelationValues(int nStartIndex, int nStopIndex);
+
+	//////////////////////////////////////////////////////////////////////////////////////////////
+	// Services de nettoyage des attributs des instances volumineuses, dont ne peut pas calculer
+	// tous les attributs derives
+
 	// Nettoyage des elements de donnees attributs temporaires a calculer, pouvant etre nettoyes et recalcules
 	// plusieurs fois
 	void CleanTemporayDataItemsToComputeAndClean();
@@ -232,6 +259,7 @@ protected:
 	friend class KWMTDatabase;
 	void CleanNativeRelationAttributes();
 
+	//////////////////////////////////////////////////////////////////////////////////////////////
 	// Methode de mutation specifique a destination des classes KWDatabase et KWDataTableSliceSet
 	// La nouvelle classe doit avoir le meme nom que celle de la classe en cours
 	// Dans certains cas particuliers, la nouvelle classe peut-etre la meme. Dans ce cas,
@@ -254,10 +282,34 @@ protected:
 	// Le dictionnaire des attributs a garder (dans la nouvelle classe) indique
 	// les attributs natifs non utilises object inclus ou multi-inclus a garder
 	// lors de la mutation, car referencable par des regles de derivation
-	friend class KWDatabase;
-	friend class KWDataTableSliceSet;
 	void Mutate(const KWClass* kwcNewClass, const NumericKeyDictionary* nkdMutationClasses,
 		    const NumericKeyDictionary* nkdUnusedNativeAttributesToKeep);
+
+	// Classes utilisant le service de mutation
+	friend class KWDatabase;
+	friend class KWDataTableSliceSet;
+
+	//////////////////////////////////////////////////////////////////////////////////////////////
+	// Services specifiques a la mutation
+
+	// Destruction des valeurs de ObjectArray sans leur contenu dans la liste LoadedRelationAttribute
+	void DeleteLoadedReferencedObjectArrayValues(int nStartIndex, int nStopIndex);
+
+	// Nettoyage des blocs de valeurs de la nouvelle classe, conserves potentiellement avec
+	// une sous-partie de leurs attributs
+	void CleanNewLoadedAttributeBlockValues(const KWClass* kwcNewClass);
+
+	// Mutation des valeurs de type Object ou ObjectArray dans la liste LoadedRelationAttribute
+	void MutateLoadedRelationValues(const NumericKeyDictionary* nkdMutationClasses,
+					const NumericKeyDictionary* nkdUnusedNativeAttributesToKeep);
+
+	// Destruction des valeurs de type Object ou ObjectArray inclus natifs ou crees non charges en memoire,
+	// dans la liste UnloadedOwnedRelationAttribute
+	void MutateUnloadedOwnedRelationValues(const NumericKeyDictionary* nkdMutationClasses,
+					       const NumericKeyDictionary* nkdUnusedNativeAttributesToKeep);
+
+	//////////////////////////////////////////////////////////////////////////////////////////////
+	// Attributs de gestion de la classe
 
 	// KWClass
 	const KWClass* kwcClass;

--- a/src/Learning/KWData/KWRelationCreationRule.h
+++ b/src/Learning/KWData/KWRelationCreationRule.h
@@ -178,6 +178,33 @@ public:
 	///////////////////////////////////////////////////////
 	///// Implementation
 protected:
+	/////////////////////////////////////////////////////////////////////////////////////////
+	// Collecte des operandes en entree utilises en fonction des operandes en sortie utilises
+	// Cela permet d'optimiser le graphe de calcul, en ne traitant que les operandes en entree
+	// necessaires pour chaque operande en sortie
+
+	// Collecte globale des operandes utilises en entree
+	// - ivUsedOutputOperands: vecteur des index des operandes en sortie, avec '1' par operande utilise
+	// - ivUsedOutputOperands: vecteur des index des operandes en entree a mettre a jour
+	// Par defaut, cette methode appelle CollectMandatoryInputOperands,
+	//  suivi d'une boucle de CollectSpecificInputOperandsAt
+	virtual void CollectUsedInputOperands(const IntVector* ivUsedOutputOperands,
+					      IntVector* ivUsedInputOperands) const;
+
+	// Collecte des operandes en entree obligatoire
+	// Par defaut, on traite le cas d'une correspondance de chaque operande en sortie avec un operande
+	// en entree de meme positiion par rapport a la fin de liste
+	// Les operandes en entree du debut sont tous consideres comme obligatoires et marques comme utilises
+	virtual void CollectMandatoryInputOperands(IntVector* ivUsedInputOperands) const;
+
+	// Collecte des operandes en entree specifique par operande en en sortie
+	// Par defaut, on traite le cas d'une correspondance de chaque operande en sortie avec un operande
+	// en entree de meme positiion par rapport a la fin de liste
+	virtual void CollectSpecificInputOperandsAt(int nOutputOperand, IntVector* ivUsedInputOperands) const;
+
+	/////////////////////////////////////////////////////////////////////////////////////////
+	// Methodes internes avancees
+
 	// Redefinition de la completion des infos pour les operandes en sortie
 	void InternalCompleteTypeInfo(const KWClass* kwcOwnerClass,
 				      NumericKeyDictionary* nkdCompletedAttributes) override;
@@ -200,7 +227,7 @@ protected:
 
 	// Alimentation de type calcul des attributs cibles dans le cas d'un nombre variable d'operandes en entree
 	// Dans ce cas, on doit avoir egalement un nombre variable d'operandes en sortie, qui doivent
-	// correspondre aux operande en entree
+	// correspondre aux operandes en entree
 	void FillComputeModeTargetAttributesForVariableOperandNumber(const KWObject* kwoSourceObject,
 								     KWObject* kwoTargetObject) const;
 

--- a/src/Learning/KWData/KWRelationCreationRule.h
+++ b/src/Learning/KWData/KWRelationCreationRule.h
@@ -80,7 +80,7 @@ public:
 	KWDRRelationCreationRule();
 	~KWDRRelationCreationRule();
 
-	// On indique que la regle cree de nouveau objets
+	// On indique que la regle cree de nouveaux objets
 	boolean GetReference() const override;
 
 	//////////////////////////////////////////////////////////////////////////////////////

--- a/src/Learning/KWDataPreparation/KWDataGrid.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGrid.cpp
@@ -3106,9 +3106,9 @@ boolean KWDGAttribute::Check() const
 						// Erreur si VarPart non trouvee
 						if (searchedPart == NULL)
 						{
-							searchedPart->AddError(sTmp + "Inner variable VarPart " +
-									       usedVarPart->GetObjectLabel() +
-									       " not found amond parts of variables");
+							AddError(sTmp + "Inner variable VarPart " +
+								 usedVarPart->GetObjectLabel() +
+								 " not found amond parts of variables");
 							bOk = false;
 							break;
 						}

--- a/src/Learning/KWDataUtils/KWDatabaseTransferTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTransferTask.cpp
@@ -32,15 +32,41 @@ boolean KWDatabaseTransferTask::Transfer(const KWDatabase* sourceDatabase, const
 	boolean bOk = true;
 	KWMTDatabaseTextFile refMTDatabaseTextFile;
 	KWSTDatabaseTextFile refSTDatabaseTextFile;
+	KWClass* databaseClass;
+	ObjectArray oaAttributesToUnload;
+	KWAttribute* attribute;
+	int i;
 	ALString sTmp;
 
 	require(sourceDatabase != NULL);
 	require(sourceDatabase->Check());
 	require(targetDatabase != NULL);
 	require(targetDatabase->CheckPartially(true));
+	require(sourceDatabase->GetClassName() == targetDatabase->GetClassName());
 	require(sourceDatabase->GetTechnologyName() == targetDatabase->GetTechnologyName());
 	require(sourceDatabase->GetTechnologyName() == refMTDatabaseTextFile.GetTechnologyName() or
 		sourceDatabase->GetTechnologyName() == refSTDatabaseTextFile.GetTechnologyName());
+
+	// Collecte des attributs de type relation non necessaires pour la base en sortie
+	databaseClass = KWClassDomain::GetCurrentDomain()->LookupClass(sourceDatabase->GetClassName());
+	assert(databaseClass != NULL);
+	CollectRelationAttributesToUnload(targetDatabase, databaseClass, &oaAttributesToUnload);
+
+	// Passage en unloaded des attributs non necessaires, pour optimiser les acces aux sous-tables
+	if (oaAttributesToUnload.GetSize() > 0)
+	{
+		// On met les attributs en unloaded
+		for (i = 0; i < oaAttributesToUnload.GetSize(); i++)
+		{
+			attribute = cast(KWAttribute*, oaAttributesToUnload.GetAt(i));
+			assert(attribute->GetUsed());
+			assert(attribute->GetLoaded());
+			attribute->SetLoaded(false);
+		}
+
+		// Recompilation
+		databaseClass->GetDomain()->Compile();
+	}
 
 	// Initialisation de la base en sortie
 	shared_targetDatabase.GetPLDatabase()->InitializeFrom(targetDatabase);
@@ -51,7 +77,86 @@ boolean KWDatabaseTransferTask::Transfer(const KWDatabase* sourceDatabase, const
 	bOk = RunDatabaseTask(sourceDatabase);
 	if (bOk)
 		lWrittenObjectNumber = lWrittenObjects;
+
+	// On remet en load les attributs non necessaires
+	if (oaAttributesToUnload.GetSize() > 0)
+	{
+		// On met les attributs en loaded
+		for (i = 0; i < oaAttributesToUnload.GetSize(); i++)
+		{
+			attribute = cast(KWAttribute*, oaAttributesToUnload.GetAt(i));
+			attribute->SetLoaded(true);
+		}
+
+		// Recompilation
+		databaseClass->GetDomain()->Compile();
+	}
+
 	return bOk;
+}
+
+void KWDatabaseTransferTask ::CollectRelationAttributesToUnload(const KWDatabase* targetDatabase,
+								const KWClass* databaseClass,
+								ObjectArray* oaAttributesToUnload) const
+{
+	int nMapping;
+	KWMTDatabase* targetMTDatabase;
+	KWMTDatabaseMapping* mapping;
+	NumericKeyDictionary nkdAllDataPathAttributes;
+	ObjectArray oaAllDataPathAttributes;
+	NumericKeyDictionary nkdNecessaryDataPathAttributes;
+	const KWClass* currentClass;
+	KWAttribute* attribute;
+	int i;
+
+	require(targetDatabase != NULL);
+	require(databaseClass != NULL);
+	require(targetDatabase->GetClassName() == databaseClass->GetName());
+	require(oaAttributesToUnload != NULL);
+	require(oaAttributesToUnload->GetSize() == 0);
+
+	// Parcours des mapping de la base en sortie
+	if (targetDatabase->GetTableNumber() > 0)
+	{
+		targetMTDatabase = cast(KWMTDatabase*, targetDatabase);
+		for (nMapping = 0; nMapping < targetMTDatabase->GetMultiTableMappings()->GetSize(); nMapping++)
+		{
+			mapping =
+			    cast(KWMTDatabaseMapping*, targetMTDatabase->GetMultiTableMappings()->GetAt(nMapping));
+
+			// Collecte des attributs du data path, necessaires ou non, pour les tables du flocon principal
+			if (not mapping->GetExternalTable())
+			{
+				currentClass = databaseClass;
+				for (i = 0; i < mapping->GetDataPathAttributeNumber(); i++)
+				{
+					// Recherche de l'attribut dans la classe courante du chemin
+					attribute =
+					    currentClass->LookupAttribute(mapping->GetDataPathAttributeNameAt(i));
+					assert(attribute != NULL);
+					assert(KWType::IsRelation(attribute->GetType()));
+
+					// Memorisation de l'attribut
+					nkdAllDataPathAttributes.SetAt(attribute, attribute);
+					if (mapping->GetDataTableName() != "")
+						nkdNecessaryDataPathAttributes.SetAt(attribute, attribute);
+
+					// Passage a la classe courante suivante
+					currentClass = attribute->GetClass();
+				}
+			}
+		}
+
+		// Collecte des attributs non necessaire que l'on peut passer en unload
+		nkdAllDataPathAttributes.ExportObjectArray(&oaAllDataPathAttributes);
+		for (i = 0; i < oaAllDataPathAttributes.GetSize(); i++)
+		{
+			attribute = cast(KWAttribute*, oaAllDataPathAttributes.GetAt(i));
+			if (attribute->GetUsed() and attribute->GetLoaded() and
+			    nkdNecessaryDataPathAttributes.Lookup(attribute) == NULL)
+				oaAttributesToUnload->Add(attribute);
+		}
+	}
 }
 
 void KWDatabaseTransferTask::DisplaySpecificTaskMessage()

--- a/src/Learning/KWDataUtils/KWDatabaseTransferTask.h
+++ b/src/Learning/KWDataUtils/KWDatabaseTransferTask.h
@@ -27,6 +27,11 @@ public:
 	///////////////////////////////////////////////////////////////////////////////
 	///// Implementation
 protected:
+	// Collecte des attributs de type relation non necessaires, que l'on peut passer en not loaded si les tables correspondantes
+	// ne sont pas specifiee dans la base en sortie
+	void CollectRelationAttributesToUnload(const KWDatabase* targetDatabase, const KWClass* databaseClass,
+					       ObjectArray* oaAttributesToUnload) const;
+
 	// Reimplemenattion de l'affichage des messages
 	void DisplaySpecificTaskMessage() override;
 

--- a/src/Learning/KWModeling/KWPredictor.cpp
+++ b/src/Learning/KWModeling/KWPredictor.cpp
@@ -316,6 +316,7 @@ void KWPredictor::CollectSelectedPreparationStats(ObjectArray* oaUsedDataPrepara
 	KWClass* kwcPreparedClass;
 	KWAttribute* attribute;
 	NumericKeyDictionary nkdAllUsedAttributes;
+	NumericKeyDictionary nkdAllUsedClassess;
 	ObjectArray oaAllUsedAttributes;
 
 	require(nkdSelectedDataPreparationStats.GetCount() == 0);
@@ -374,7 +375,7 @@ void KWPredictor::CollectSelectedPreparationStats(ObjectArray* oaUsedDataPrepara
 	}
 
 	// Finalisation de la collecte des attributs utilises via les regles de construction de table
-	KWDerivationRule::FinalizeBuildAllUsedAttributes(&nkdAllUsedAttributes);
+	kwcPreparedClass->FinalizeBuildAllUsedAttributes(&nkdAllUsedAttributes, &nkdAllUsedClassess);
 
 	// Prise en compte des preparation de tous les attributs utilises recursivement
 	nkdAllUsedAttributes.ExportObjectArray(&oaAllUsedAttributes);

--- a/src/Learning/KWModeling/KWPredictor.cpp
+++ b/src/Learning/KWModeling/KWPredictor.cpp
@@ -363,7 +363,7 @@ void KWPredictor::CollectSelectedPreparationStats(ObjectArray* oaUsedDataPrepara
 				}
 			}
 
-			// Analyse des attributs utilise recursivement dans une forumule de calcul, comme par exemple
+			// Analyse des attributs utilise recursivement dans une formule de calcul, comme par exemple
 			// pour les arbres
 			attribute = kwcPreparedClass->LookupAttribute(sAttributeName);
 			check(attribute);
@@ -372,6 +372,9 @@ void KWPredictor::CollectSelectedPreparationStats(ObjectArray* oaUsedDataPrepara
 										       &nkdAllUsedAttributes);
 		}
 	}
+
+	// Finalisation de la collecte des attributs utilises via les regles de construction de table
+	KWDerivationRule::FinalizeBuildAllUsedAttributes(&nkdAllUsedAttributes);
 
 	// Prise en compte des preparation de tous les attributs utilises recursivement
 	nkdAllUsedAttributes.ExportObjectArray(&oaAllUsedAttributes);

--- a/src/Learning/KWModeling/KWPredictor.cpp
+++ b/src/Learning/KWModeling/KWPredictor.cpp
@@ -316,7 +316,7 @@ void KWPredictor::CollectSelectedPreparationStats(ObjectArray* oaUsedDataPrepara
 	KWClass* kwcPreparedClass;
 	KWAttribute* attribute;
 	NumericKeyDictionary nkdAllUsedAttributes;
-	NumericKeyDictionary nkdAllUsedClassess;
+	NumericKeyDictionary nkdAllUsedClasses;
 	ObjectArray oaAllUsedAttributes;
 
 	require(nkdSelectedDataPreparationStats.GetCount() == 0);
@@ -368,6 +368,7 @@ void KWPredictor::CollectSelectedPreparationStats(ObjectArray* oaUsedDataPrepara
 			// pour les arbres
 			attribute = kwcPreparedClass->LookupAttribute(sAttributeName);
 			check(attribute);
+			nkdAllUsedAttributes.SetAt(attribute, attribute);
 			if (attribute->GetDerivationRule() != NULL)
 				attribute->GetDerivationRule()->BuildAllUsedAttributes(attribute,
 										       &nkdAllUsedAttributes);
@@ -375,7 +376,11 @@ void KWPredictor::CollectSelectedPreparationStats(ObjectArray* oaUsedDataPrepara
 	}
 
 	// Finalisation de la collecte des attributs utilises via les regles de construction de table
-	kwcPreparedClass->FinalizeBuildAllUsedAttributes(&nkdAllUsedAttributes, &nkdAllUsedClassess);
+	// Cette finalization permet une analyse plus exhaustive de la propagation des regles
+	// de derivation utilisee, en ne partant que des attributs exploites en preparation
+	// L'enjeu est ici essentiellement de fournir des statistiques d'uilisation des attributs pour les utlisateurs
+	// Il n'y a pas d'enjeu de compilation ni de bugs potentiels
+	kwcPreparedClass->FinalizeBuildAllUsedAttributes(&nkdAllUsedAttributes, &nkdAllUsedClasses);
 
 	// Prise en compte des preparation de tous les attributs utilises recursivement
 	nkdAllUsedAttributes.ExportObjectArray(&oaAllUsedAttributes);

--- a/src/Learning/KWUtils/KWKhiopsVersion.h
+++ b/src/Learning/KWUtils/KWKhiopsVersion.h
@@ -10,7 +10,7 @@
 // dans le TaskManager de Windows (par exemple)
 
 // Version de Khiops
-#define KHIOPS_VERSION KHIOPS_STR(10.6.0-b.0)
+#define KHIOPS_VERSION KHIOPS_STR(10.6.1-b.0)
 // Les versions release distribuees sont bases sur trois numeros, par exemple KHIOPS_STR(10.2.0)
 // Les versions alpha, beta ou release candidate ont un suffixe supplementaire, par exemple :
 // - KHIOPS_STR(10.5.0-a.1)

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
@@ -164,8 +164,10 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 	require(not bDisplayProgression or dProgressionEnd > dProgressionBegin);
 	require(not bDisplayProgression or dProgressionEnd <= 1);
 
-	fileHandle = NULL;
+	// Initialisations
 	bOk = true;
+	nChunkIndex = 0;
+	fileHandle = NULL;
 	dTaskPercent = dProgressionEnd - dProgressionBegin;
 
 	// Lancement des serveurs de fichiers si on n'est pas dans une tache


### PR DESCRIPTION
Essentiellement:
- refactoring de code complexe, pour en simplifier la maintenance
- optimisation du graphe de calcul pour les règles de création de table
  - en mode vue: il n'est pas nécessaire d'évaluer les attributs d'origine d'une vue si les attributs cibles ne sont pas utilisés
  - en mode calcul: il n'est pas nécessaire d'évaluer les opérandes d'origine concernés si les attributs cibles ne sont pas utilisés
- quelques mini-correction de bug au passage

On passe ensuite a la version 10.6.1-b.0, associées à une nouvelle version des LearningTest
 