### PR TITLE
Fix minor bug in some value changes for spinner widgets in java GUI

### DIFF
--- a/src/Norm/NormGUI/src/normGUI/widgets/doubleWidgets/GUIDoubleElementSpinner.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/doubleWidgets/GUIDoubleElementSpinner.java
@@ -97,37 +97,16 @@ public class GUIDoubleElementSpinner extends GUIDoubleElement
         public void focusLost(FocusEvent e)
         {
                 if (e.getOppositeComponent() != null && (!e.isTemporary() || !getParentUnit().getActionRunning())) {
-                        double dValue = 0;
-
                         // Dans le Spinner Java standard, la saisie n'est validee qu'avec le Enter
                         // Ici, on force sa validation des la perte de focus
+                        // La gestion des bornes est assuree par le SpinnerNumberModel
                         JSpinner js = (JSpinner)component;
-                        JTextField spinnerEditor = ((JSpinner.NumberEditor)js.getEditor()).getTextField();
-                        String strInitialValue = spinnerEditor.getText();
 
-                        // On supprime tous les blancs, y compris internes, potentiellement rajoutes par
-                        // le composant spinner
-                        String strValue = "";
-                        for (Character c : strInitialValue.toCharArray()) {
-                                if (!Character.isSpaceChar(c))
-                                        strValue = strValue + c;
-                        }
-
-                        // On convertit en numerique
-                        boolean valid = true;
+                        // Validation de la valeur
                         try {
-                                dValue = Double.parseDouble(strValue);
-
-                                // Projection sur les bornes si necessaires
-                                if (dValue < getMinValue())
-                                        dValue = getMinValue();
-                                else if (dValue > getMaxValue())
-                                        dValue = getMaxValue();
+                                js.commitEdit();
                         } catch (Exception ex) {
-                                valid = false;
                         }
-                        if (valid)
-                                js.setValue(dValue);
 
                         // Appel de l'implementation mere
                         super.focusLost(e);
@@ -153,14 +132,13 @@ public class GUIDoubleElementSpinner extends GUIDoubleElement
                         public Object getCellEditorValue()
                         {
                                 JSpinner js = (JSpinner)editorComponent;
-                                JTextField spinnerEditor = ((JSpinner.NumberEditor)js.getEditor()).getTextField();
-                                double dValue;
+
+                                // Validation de la valeur
                                 try {
-                                        dValue = Double.parseDouble(spinnerEditor.getText());
+                                        js.commitEdit();
                                 } catch (Exception ex) {
-                                        dValue = getMinValue();
                                 }
-                                return dValue;
+                                return js.getValue();
                         }
 
                         /**

--- a/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementSpinner.java
+++ b/src/Norm/NormGUI/src/normGUI/widgets/intWidgets/GUIIntElementSpinner.java
@@ -64,37 +64,16 @@ public class GUIIntElementSpinner extends GUIIntElement
         public void focusLost(FocusEvent e)
         {
                 if (e.getOppositeComponent() != null && (!e.isTemporary() || !getParentUnit().getActionRunning())) {
-                        int iValue = 0;
-
                         // Dans le Spinner Java standard, la saisie n'est validee qu'avec le Enter
                         // Ici, on force sa validation des la perte de focus
+                        // La gestion des bornes est assuree par le SpinnerNumberModel
                         JSpinner js = (JSpinner)component;
-                        JTextField spinnerEditor = ((JSpinner.NumberEditor)js.getEditor()).getTextField();
-                        String strInitialValue = spinnerEditor.getText();
 
-                        // On supprime tous les blancs, y compris internes, potentiellement rajoutes par
-                        // le composant spinner
-                        String strValue = "";
-                        for (Character c : strInitialValue.toCharArray()) {
-                                if (!Character.isSpaceChar(c))
-                                        strValue = strValue + c;
-                        }
-
-                        // On convertit en numerique
-                        boolean valid = true;
+                        // Validation de la valeur
                         try {
-                                iValue = Integer.parseInt(strValue);
-
-                                // Projection sur les bornes si necessaires
-                                if (iValue < getMinValue())
-                                        iValue = getMinValue();
-                                else if (iValue > getMaxValue())
-                                        iValue = getMaxValue();
+                                js.commitEdit();
                         } catch (Exception ex) {
-                                valid = false;
                         }
-                        if (valid)
-                                js.setValue(iValue);
 
                         // Appel de l'implementation mere
                         super.focusLost(e);
@@ -120,14 +99,13 @@ public class GUIIntElementSpinner extends GUIIntElement
                         public Object getCellEditorValue()
                         {
                                 JSpinner js = (JSpinner)editorComponent;
-                                JTextField spinnerEditor = ((JSpinner.NumberEditor)js.getEditor()).getTextField();
-                                int iValue;
+
+                                // Validation de la valeur
                                 try {
-                                        iValue = Integer.parseInt(spinnerEditor.getText());
+                                        js.commitEdit();
                                 } catch (Exception ex) {
-                                        iValue = getMinValue();
                                 }
-                                return iValue;
+                                return js.getValue();
                         }
 
                         /**


### PR DESCRIPTION
Fix minor bug in some value changes for spinner widgets in java GUI

Bug:
Quand on change la valeur d'un widget de type spinner (valeur numerique avec fleches haut et bas), le changement n'est pas pris en compte systematiquement. Par exemple, pour le champ `Max number of constructed variables`:
- si on change la valeur par les fleches haut ou bas: ok
- si on remplace toute la valeur d'un coup par une nouvelle valeur valide: ok
- si on se place au milieu de la valeur a la sourie, en ajoutant un ciffre: parfois KO
  - cela provient de la locale de la machine, avce 1000 affichee sous la forme `1 000` ou `1,000`

Correction:
- il suffit de s'en remettre au SpinnerNumberModel qui fait le travail correctement
- supression du code de parsing des valeurs de type texte, qui dependait de la locale
- on se contente de forcer le 'commit' de la valeur du widget
- Impacts dans les classes GUIIntElementSpinner et GUIDoubleElementSpinner
  - methodes focusLost et getCellEditorValue