### PR TITLE
Improve MPI Detection in Conda Environments to Avoid Immediate Fatal Errors

### DIFF
--- a/scripts/get_mpi_implementation.cmake
+++ b/scripts/get_mpi_implementation.cmake
@@ -23,12 +23,16 @@ function(get_mpi_implementation)
     set(VAR_MPI_INFO "${MPI_LIBRARIES}")
   endif(IS_CONDA)
 
-  # ERROR if VAR_MPI_INFO is not defined, it means either: - in standard environment find_mpi provides no MPI path (MPI
-  # is not installed) - or in conda build, the 'mpi' variable is missing and find_mpi may find the system wide mpi, this
-  # is not not what we want. - or in conda, outside of the build process, the mpi package is not installed and find_mpi
-  # may find the system wide mpi.
+  # If no MPI library information is detected (i.e. VAR_MPI_INFO is undefined or empty),
+  # then we check if MPI_IMPL was provided externally. If so, we use the provided MPI_IMPL,
+  # otherwise, we terminate with a fatal error. This allows us to use a system-defined MPI
+  # implementation when building in a conda environment that does not list MPI via "conda list | grep mpi".
   if(NOT DEFINED VAR_MPI_INFO OR "${VAR_MPI_INFO}" STREQUAL "")
-    message(FATAL_ERROR "Missing information to discover the MPI implementation")
+    if(DEFINED MPI_IMPL)
+      message(STATUS "Using provided MPI_IMPL: ${MPI_IMPL}")
+    else()
+      message(FATAL_ERROR "Missing information to discover the MPI implementation")
+    endif()
   endif()
 
   # Find "openmpi", "mpich" or "intel" in the variable VAR_MPI_INFO


### PR DESCRIPTION
This merge request addresses [issue #594](https://github.com/KhiopsML/khiops/issues/594). In a conda environment, if no MPI library information is detected via conda list | grep mpi, the original implementation would immediately trigger a fatal error. With this fix, if the user has provided an MPI_IMPL value, that value is used instead of failing immediately. This change allows the build process to fall back to the system-installed MPI configuration when no conda-specific MPI package is found.

### Changelog

    Modified get_mpi_implementation.cmake to use the provided MPI_IMPL if no MPI library info is detected.
    Updated comments to clearly explain the new behavior.

### Testing

Tested locally in a conda environment with OpenMPI installed. The build now completes successfully even when the conda environment does not list any MPI package.

```sh
(base) ┌──(athena㉿DESKTOP-D0DH9M9)-[~/Document/gitkhyops/khiops]
└─$ git branch -a
  572-use-renovate-in-ci
* 594-fix-mpi-detection-conda
  854-segmentation-fault
  dev
  dev-v10
  mpi-detection-issue
  mpi-verify-bug
  remotes/origin/10.2.x-hotfix
  remotes/origin/18-refactor-the-documentation

(base) ┌──(athena㉿DESKTOP-D0DH9M9)-[~/Document/gitkhyops/khiops]
└─$ conda list | grep mpi

(base) ┌──(athena㉿DESKTOP-D0DH9M9)-[~/Document/gitkhyops/khiops]
└─$ cd ..

(base) ┌──(athena㉿DESKTOP-D0DH9M9)-[~/Document/gitkhyops]
└─$ cd khiops-build/

(base) ┌──(athena㉿DESKTOP-D0DH9M9)-[~/Document/gitkhyops/khiops-build]
└─$ ls
bin  CMakeCache.txt  CMakeFiles  cmake_install.cmake  CPackConfig.cmake  CPackSourceConfig.cmake  lib  Makefile  src  tmp

(base) ┌──(athena㉿DESKTOP-D0DH9M9)-[~/Document/gitkhyops/khiops-build]
└─$ cmake -DCMAKE_BUILD_TYPE=Debug       -DMPI_IMPL=OpenMPI       -DMPI_EXECUTABLE=/usr/bin/mpiexec       -DMPI_CXX_INCLUDE_PATH=/usr/lib/x86_64-linux-gnu/openmpi/include       -DMPI_CXX_LIBRARIES=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so       ../khiops
-- Building Khiops Version: 10.6.0-b.0 (CMake version : 10.6.0)

Khiops build options:

  CMAKE_BUILD_TYPE="Debug"
  MPI="ON"
  TESTING="OFF"
  C11="ON"
  BUILD_LEX_YACC="OFF"
  BUILD_JARS="OFF"
  GENERATE_VIEWS="OFF"


-- Auto-detected conda environment
CMake Warning at CMakeLists.txt:86 (message):
  You are building in a conda environment without using `conda build`.
  find_mpi may not work as expected.


-- Executables will be stored in /home/athena/Document/gitkhyops/khiops-build/bin/
-- Libraries will be stored in /home/athena/Document/gitkhyops/khiops-build/lib/
-- MPI command line: /usr/bin/mpiexec -n 4  EXECUTABLE  ARGS
-- Using provided MPI_IMPL: OpenMPI
-- Auto-detected MPI implementation: OpenMPI (from conda standard environment)
-- CMake generator is: Unix Makefiles
-- CMake compiler is: GNU
-- CMake C++ standard is: 11
-- Setting up STATIC_LIBRARY base
-- Setting up SHARED_LIBRARY khiopsdriver_file_null
-- Setting up EXECUTABLE genere
-- Setting up EXECUTABLE basetest
-- Setting up EXECUTABLE generetest
-- Setting up EXECUTABLE _khiopsgetprocnumber
-- Setting up EXECUTABLE norm_sample1
-- Setting up EXECUTABLE norm_sample2
-- Setting up EXECUTABLE norm_sample3
-- Setting up STATIC_LIBRARY RMResourceManager
-- Setting up STATIC_LIBRARY PLParallelTask
-- Setting up STATIC_LIBRARY PLMPI
-- Setting up STATIC_LIBRARY PLSamples
-- Setting up EXECUTABLE PLTest
-- Setting up STATIC_LIBRARY DTForest
-- Setting up EXECUTABLE genum
-- Setting up EXECUTABLE khisto
-- Setting up STATIC_LIBRARY KDDomainKnowledge
-- Setting up SHARED_LIBRARY KhiopsNativeInterface
-- Setting up STATIC_LIBRARY KIInterpretation
-- Setting up STATIC_LIBRARY KMDRRuleLibrary
-- Setting up EXECUTABLE KNITransfer
-- Setting up STATIC_LIBRARY KWData
-- Setting up STATIC_LIBRARY KWDataPreparation
-- Setting up STATIC_LIBRARY KWDataUtils
-- Setting up STATIC_LIBRARY KWDRRuleLibrary
-- Setting up STATIC_LIBRARY KWLearningProblem
-- Setting up STATIC_LIBRARY KWModeling
-- Setting up STATIC_LIBRARY KWUserInterface
-- Setting up STATIC_LIBRARY KWUtils
-- Setting up STATIC_LIBRARY MHHistograms
-- Setting up EXECUTABLE MODL
-- Setting up SHARED_LIBRARY MODL_DLL
-- Setting up EXECUTABLE MODL_Coclustering
-- Setting up SHARED_LIBRARY MODL_Coclustering_DLL
-- Setting up STATIC_LIBRARY SNBPredictor
-- Setting up EXECUTABLE learning_sample3
-- Setting up EXECUTABLE KWTest
-- Configuring done (5.1s)
-- Generating done (0.1s)
-- Build files have been written to: /home/athena/Document/gitkhyops/khiops-build

(base) ┌──(athena㉿DESKTOP-D0DH9M9)-[~/Document/gitkhyops/khiops-build]
└─$ 
```