### PR TITLE
Correction of DetectFileFormat in case of one-column root table

### DIFF
--- a/src/Learning/KWData/KWDatabaseFormatDetector.cpp
+++ b/src/Learning/KWData/KWDatabaseFormatDetector.cpp
@@ -469,9 +469,18 @@ boolean KWDatabaseFormatDetector::DetectFileFormatUsingClassWithHeaderLine(const
 	if (bShowDetails)
 		cout << "First line: " << cfvFirstLine << "\n";
 
-	// Initialisation des separateurs candidats avec les caracteres de la premiere ligne
-	cfvCandidateSeparators.CopyFrom(&cfvFirstLine);
+	// Initialisation des separateurs candidats
+	// Cas particulier d'un seul champ natif
+	if (kwcClass->GetNativeDataItemNumber() == 1)
+		cfvCandidateSeparators.InitializeFrequencies(1);
+	// Cas general avec au moins deux champs
+	// Initialisation avec les caracteres de la premiere ligne
+	else
+		cfvCandidateSeparators.CopyFrom(&cfvFirstLine);
 	bIsHeaderLine = not cfvCandidateSeparators.IsZero();
+
+	if (bShowDetails)
+		cout << "Initialisation des separateurs candidats: " << cfvCandidateSeparators << "\n";
 
 	// On soustrait les caracteres des champs obligatoire
 	if (bIsHeaderLine)
@@ -479,6 +488,11 @@ boolean KWDatabaseFormatDetector::DetectFileFormatUsingClassWithHeaderLine(const
 		bIsHeaderLine = cfvCandidateSeparators.IsGreaterOrEqual(&cfvAttributeNames);
 		if (bIsHeaderLine)
 			cfvCandidateSeparators.Substract(&cfvAttributeNames);
+
+		if (bShowDetails)
+			cout << "Separateurs candidats apres caracteres des champs obligatoires: "
+			     << cfvCandidateSeparators << "\n";
+
 		bIsHeaderLine = not cfvCandidateSeparators.IsZero();
 	}
 

--- a/src/Learning/KWData/KWDatabaseFormatDetector.cpp
+++ b/src/Learning/KWData/KWDatabaseFormatDetector.cpp
@@ -43,6 +43,10 @@ boolean KWDatabaseFormatDetector::DetectFileFormat()
 	RewindableInputBufferedFile inputFile;
 	CharVector cvLine;
 	longint lBeginPos;
+	KWMTDatabase* mtDatabase;
+	KWMTDatabaseMapping* mapping;
+	int nMapping;
+	ALString sInputFileName;
 	ALString sTmp;
 
 	require(analysedDatabase != NULL);
@@ -95,6 +99,7 @@ boolean KWDatabaseFormatDetector::DetectFileFormat()
 
 	// Verification si utilisation d'un dictionnaire
 	kwcDatabaseClass = NULL;
+	sInputFileName = analysedDatabase->GetDatabaseName();
 	if (GetUsingClass() and analysedDatabase->GetClassName() != "")
 	{
 		// Recherche du dictionnaire associee a la base
@@ -118,13 +123,39 @@ boolean KWDatabaseFormatDetector::DetectFileFormat()
 				bOk = false;
 			}
 		}
+
+		// Cas d'un seul attribut natif : il est alors impossible de detecter un champ separateur
+		// Dans le cas multi-table, recherche d'un eventuel autre dictionnaire avec plus d'un attribut natif
+		if (bOk)
+		{
+			if (kwcDatabaseClass->GetNativeDataItemNumber() == 1 and
+			    analysedDatabase->IsMultiTableTechnology())
+			{
+				mtDatabase = cast(KWMTDatabase*, analysedDatabase);
+
+				// Recherche d'une table secondaire contenant au moins deux attributs natifs
+				for (nMapping = 0; nMapping < mtDatabase->GetTableNumber(); nMapping++)
+				{
+					mapping = cast(KWMTDatabaseMapping*,
+						       mtDatabase->GetMultiTableMappings()->GetAt(nMapping));
+					kwcDatabaseClass =
+					    KWClassDomain::GetCurrentDomain()->LookupClass(mapping->GetClassName());
+					if (kwcDatabaseClass != NULL and mapping->GetDataTableName() != "" and
+					    kwcDatabaseClass->GetNativeDataItemNumber() > 1)
+					{
+						sInputFileName = mapping->GetDataTableName();
+						break;
+					}
+				}
+			}
+		}
 	}
 
 	// Ouverture du fichier
 	if (bOk)
 	{
 		// Ouverture
-		inputFile.SetFileName(analysedDatabase->GetDatabaseName());
+		inputFile.SetFileName(sInputFileName);
 		bOk = inputFile.Open();
 		if (not bOk)
 			AddError("No possible format detection");
@@ -478,7 +509,6 @@ boolean KWDatabaseFormatDetector::DetectFileFormatUsingClassWithHeaderLine(const
 	else
 		cfvCandidateSeparators.CopyFrom(&cfvFirstLine);
 	bIsHeaderLine = not cfvCandidateSeparators.IsZero();
-
 	if (bShowDetails)
 		cout << "Initialisation des separateurs candidats: " << cfvCandidateSeparators << "\n";
 
@@ -488,7 +518,6 @@ boolean KWDatabaseFormatDetector::DetectFileFormatUsingClassWithHeaderLine(const
 		bIsHeaderLine = cfvCandidateSeparators.IsGreaterOrEqual(&cfvAttributeNames);
 		if (bIsHeaderLine)
 			cfvCandidateSeparators.Substract(&cfvAttributeNames);
-
 		if (bShowDetails)
 			cout << "Separateurs candidats apres caracteres des champs obligatoires: "
 			     << cfvCandidateSeparators << "\n";

--- a/src/Learning/KWData/KWDatabaseFormatDetector.h
+++ b/src/Learning/KWData/KWDatabaseFormatDetector.h
@@ -9,6 +9,7 @@ class KWHeaderLineAnalyser;
 class RewindableInputBufferedFile;
 
 #include "KWDatabase.h"
+#include "KWMTDatabase.h"
 #include "KWSTDatabaseTextFile.h"
 #include "KWDataTableDriverTextFile.h"
 #include "KWCharFrequencyVector.h"


### PR DESCRIPTION
Correction dans la methode DetectFileFormatUsingClassWithHeaderLine afin que le cas d'un seul champ natif soit pris en compte La correction reprend ce qui etait deja fait dans la methode DetectFileFormatUsingClassWithoutHeaderLine