### PR TITLE
Fix asserts errors in SNB task

### DIFF
--- a/src/Learning/KWDataUtils/KWDataTableSliceSet.cpp
+++ b/src/Learning/KWDataUtils/KWDataTableSliceSet.cpp
@@ -934,7 +934,7 @@ boolean KWDataTableSliceSet::CheckReadClass(const KWClass* kwcInputClass) const
 					    currentDerivationRule, &odSliceAttributes, &nkdAllUsedSliceAttributes,
 					    &nkdAllUsedDerivedAttributes, sErrorAttribute);
 					if (not bOk)
-						AddError("Variable " + attribute->GetName() + " in read dictionnary " +
+						AddError("Variable " + attribute->GetName() + " in read dictionary " +
 							 kwcInputClass->GetName() +
 							 " relies on a derivation rule involving variable " +
 							 sErrorAttribute + " that is not in a slice");
@@ -2659,6 +2659,17 @@ boolean KWDataTableSliceSet::BuildAllUsedSliceAttributes(const KWDerivationRule*
 				originAttribute = originAttributeBlock->GetFirstAttribute();
 				while (originAttribute != NULL)
 				{
+					// On ignore l'attribut cible si present dans le bloc
+					if (originAttribute->GetName() == sClassTargetAttributeName)
+					{
+						if (originAttribute != originAttributeBlock->GetLastAttribute())
+							originAttribute->GetParentClass()->GetNextAttribute(
+							    originAttribute);
+						else
+							originAttribute = NULL;
+						continue;
+					}
+
 					// Recherche de l'attribut dans le sliceset
 					slice = cast(KWDataTableSlice*,
 						     odSliceAttributes->Lookup(originAttribute->GetName()));

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.cpp
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.cpp
@@ -2075,10 +2075,10 @@ boolean SNBPredictorSelectiveNaiveBayesTrainingTask::SlaveProcess()
 
 boolean SNBPredictorSelectiveNaiveBayesTrainingTask::SlaveFinalize(boolean bProcessEndedCorrectly)
 {
-	require(IsSlaveDataTableBinarySliceSetInitialized());
-	require(slaveBinarySliceSet == NULL or slaveBinarySliceSet->Check());
-	require(slaveRecoderClass != NULL or IsParallel());
-	require(not bProcessEndedCorrectly or slaveWeightedSelectionScorer != NULL);
+	require(not bProcessEndedCorrectly or IsSlaveDataTableBinarySliceSetInitialized());
+	require(not bProcessEndedCorrectly or (slaveBinarySliceSet == NULL or slaveBinarySliceSet->Check()));
+	require(not bProcessEndedCorrectly or (slaveRecoderClass != NULL or IsParallel()));
+	require(not bProcessEndedCorrectly or (slaveWeightedSelectionScorer != NULL));
 
 	// Nettoyage des objets de travail l'esclave
 	if (slaveBinarySliceSet != NULL)
@@ -2109,6 +2109,8 @@ boolean SNBPredictorSelectiveNaiveBayesTrainingTask::SlaveFinalize(boolean bProc
 
 	ensure(slaveBinarySliceSet == NULL);
 	ensure(slaveRecoderClass == NULL);
+	ensure(slaveWeightedSelectionScorer == NULL);
+	ensure(slaveDummyDatabase == NULL);
 
 	return true;
 }


### PR DESCRIPTION

Closes #460

---

commit 242ae678dfd11c2a8b560ab818efec282545b06d (HEAD -> fix-snb-assert, origin/fix-snb-assert)
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Wed Feb 26 16:56:47 2025 +0100

    Ignore target variable in sparse block when reading in KWDataTableSliceSet

commit b7182b8b51188b3479f71cb2ac8b17cb656a3afc
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Tue Feb 25 10:10:47 2025 +0100

    Execute coherence requires in SNB task's SlaveFinalize only it ended correctly
