### PR TITLE
Takes into account the case where the dictionary name contains a path

### DIFF
--- a/src/Learning/KWDataUtils/KWDatabaseTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTask.cpp
@@ -386,16 +386,27 @@ boolean KWDatabaseTask::MasterInitialize()
 	boolean bOk = true;
 	KWClass* kwcClass;
 	ALString sClassTmpFile;
+	ALString sAlphaNumClassName;
 	int i;
+	char c;
 
 	require(databaseChunkBuilder.IsComputed());
 
 	// Ecriture du fichier dictionnaire dans un repertoire temporaire pour passage au slave
 	if (IsParallel())
 	{
+		// Le nom du dictionnaire temporaire ne doit contenir que des alphanumeriques. Sinon, on remplace les char par '_'
+		for (i = 0; i < shared_sourceDatabase.GetDatabase()->GetClassName().GetLength(); i++)
+		{
+			c = shared_sourceDatabase.GetDatabase()->GetClassName().GetAt(i);
+			if (isalnum(c))
+				sAlphaNumClassName += c;
+			else
+				sAlphaNumClassName += '_';
+		}
+
 		// Construction du nom du dictionnaire temporaire
-		sClassTmpFile = FileService::CreateUniqueTmpFile(
-		    shared_sourceDatabase.GetDatabase()->GetClassName() + ".kdic", this);
+		sClassTmpFile = FileService::CreateUniqueTmpFile(sAlphaNumClassName + ".kdic", this);
 		bOk = sClassTmpFile != "";
 
 		// Recherche de la classe du dictionnaire

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.cpp
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.cpp
@@ -1154,6 +1154,9 @@ boolean SNBPredictorSelectiveNaiveBayesTrainingTask::MasterInitializeRecoderClas
 	boolean bOk = true;
 	KWClass* recoderClass;
 	ALString sRecoderClassTmpFilePath;
+	ALString sAlphaNumClassName;
+	int i;
+	char c;
 
 	require(IsMasterProcess());
 	require(masterBinarySliceSet != NULL);
@@ -1165,8 +1168,16 @@ boolean SNBPredictorSelectiveNaiveBayesTrainingTask::MasterInitializeRecoderClas
 	shared_sRecoderClassName.SetValue(recoderClass->GetName());
 	if (IsParallel())
 	{
-		sRecoderClassTmpFilePath =
-		    FileService::CreateUniqueTmpFile(shared_sRecoderClassName.GetValue() + ".kdic", this);
+		// Le nom du dictionnaire de recodage ne doit contenir que des alphanumeriques. Sinon on remplace les char par '_'
+		for (i = 0; i < shared_sRecoderClassName.GetValue().GetLength(); i++)
+		{
+			c = shared_sRecoderClassName.GetValue().GetAt(i);
+			if (isalnum(c))
+				sAlphaNumClassName += c;
+			else
+				sAlphaNumClassName += '_';
+		}
+		sRecoderClassTmpFilePath = FileService::CreateUniqueTmpFile(sAlphaNumClassName + ".kdic", this);
 		bOk = bOk and sRecoderClassTmpFilePath != "";
 		if (not bOk)
 			AddError("Error when creating temporary dictionary file for class " +

--- a/src/Norm/base/FileService.cpp
+++ b/src/Norm/base/FileService.cpp
@@ -1491,7 +1491,7 @@ const ALString FileService::CreateUniqueTmpFile(const ALString& sBaseName, const
 			{
 				sFilePathName = "";
 				if (errorSender != NULL)
-					errorSender->AddError("Unable to create temporary file " + sBaseName +
+					errorSender->AddError("Unable to create unique temporary file " + sBaseName +
 							      " in directory " + GetApplicationTmpDir() + " " +
 							      GetLastSystemIOErrorMessage());
 			}

--- a/src/Norm/base/PLRemoteFileService.cpp
+++ b/src/Norm/base/PLRemoteFileService.cpp
@@ -177,7 +177,7 @@ boolean PLRemoteFileService::BuildOutputWorkingFile(const ALString& sPathName, A
 		if (sWorkingFileName == "")
 		{
 			bOk = false;
-			Global::AddError("File", sFileName, "Unable to create temporary file");
+			Global::AddError("File", sFileName, "Unable to create output temporary file");
 		}
 	}
 	else


### PR DESCRIPTION
Modification des noms de fichier temporaire crees dans le cas du mode Parallel afin que ces noms ne contiennent que des caracteres alphanumeriques
Creation d'un jeu de donnees test a inclure dans TestKhiops/Bugs
[BugDicoNamedWithPathSyntax.zip](https://github.com/user-attachments/files/18984183/BugDicoNamedWithPathSyntax.zip)
