### PR TITLE
Excel evaluation report file produced only if asked

### DIFF
--- a/src/Learning/KWUserInterface/KWPredictorEvaluator.cpp
+++ b/src/Learning/KWUserInterface/KWPredictorEvaluator.cpp
@@ -777,8 +777,8 @@ void KWPredictorEvaluator::EvaluateTrainedPredictors(ObjectArray* oaEvaluatedTra
 		// Ecriture du rapport d'evaluation au format JSON
 		WriteJSONEvaluationReport(GetEvaluationFilePathName(), "Predictor", oaOutputPredictorEvaluations);
 
-		// Ecriture du rapport d'evaluation au fprmat xls
-		if (GetXlsEvaluationFilePathName() != "")
+		// Ecriture du rapport d'evaluation au format xls
+		if (GetExportAsXls() and GetXlsEvaluationFilePathName() != "")
 			WriteEvaluationReport(GetXlsEvaluationFilePathName(), "Predictor",
 					      oaOutputPredictorEvaluations);
 


### PR DESCRIPTION
Ajout d'une condition verifiant que le format xls est sollicite lors de la production des rapports d'evaluation des predicteurs 

Ajout d'un test a positionner dans TestKhiops/Bugs
[NewTest-EvaluateClassifiersWithoutXlsReport.zip](https://github.com/user-attachments/files/18988318/NewTest-EvaluateClassifiersWithoutXlsReport.zip)

Cela modifie les ref de 3 tests dans TestKhiops/Advanced, à savoir que les fichiers .xls ne sont plus produits
[ModifiedTestInKhiops_Advanced.zip](https://github.com/user-attachments/files/18988335/ModifiedTestInKhiops_Advanced.zip)


