### PR TITLE
498 exploit sparse variable blocks for table creation rules

### DIFF
--- a/src/Learning/KIInterpretation/KILeverVariablesSpecView.cpp
+++ b/src/Learning/KIInterpretation/KILeverVariablesSpecView.cpp
@@ -33,7 +33,6 @@ void KILeverVariablesSpecView::EventUpdate(Object* object)
 	KWClass* kwcClass;
 	KWAttribute* attribute;
 	KWAttributeSpec* attributeSpec;
-	ALString sCompleteType;
 	ALString sMetaData;
 
 	require(object != NULL);
@@ -74,7 +73,6 @@ void KILeverVariablesSpecView::SetObject(Object* object)
 	KWClass* kwcClass;
 	KWAttribute* attribute;
 	KWAttributeSpec* attributeSpec;
-	ALString sCompleteType;
 	ALString sMetaData;
 	boolean bHasLeverVariables = false;
 
@@ -100,13 +98,6 @@ void KILeverVariablesSpecView::SetObject(Object* object)
 				attributeSpec = new KWAttributeSpec;
 				oaAttributeSpecs.Add(attributeSpec);
 
-				// Calcul du type complet de l'attribut
-				sCompleteType = KWType::ToString(attribute->GetType());
-				if (KWType::IsRelation(attribute->GetType()) and attribute->GetClass() != NULL)
-					sCompleteType = sCompleteType + "(" + attribute->GetClass()->GetName() + ")";
-				else if (attribute->GetType() == KWType::Structure)
-					sCompleteType = sCompleteType + "(" + attribute->GetStructureName() + ")";
-
 				// Acces aux meta-data
 				sMetaData = attribute->GetMetaData()->WriteString();
 
@@ -116,7 +107,7 @@ void KILeverVariablesSpecView::SetObject(Object* object)
 							       "true"
 							   ? true
 							   : false);
-				attributeSpec->SetType(sCompleteType);
+				attributeSpec->SetType(attribute->GetTypeLabel());
 				attributeSpec->SetName(attribute->GetName());
 				attributeSpec->SetDerived(attribute->GetAnyDerivationRule() != NULL);
 				attributeSpec->SetMetaData(sMetaData);

--- a/src/Learning/KWData/KWAttribute.cpp
+++ b/src/Learning/KWData/KWAttribute.cpp
@@ -29,6 +29,36 @@ KWAttribute::~KWAttribute()
 		delete advancedTypeSpecification.genericSpecification;
 }
 
+const ALString KWAttribute::GetTypeLabel() const
+{
+	ALString sTypeLabel;
+
+	// Libelle de base du type
+	sTypeLabel = KWType::ToString(GetType());
+
+	// Complement dans le cas d'un type relation
+	if (KWType::IsRelation(GetType()))
+	{
+		sTypeLabel += '(';
+		if (GetClass() != NULL)
+			sTypeLabel += GetClass()->GetName();
+		else
+			sTypeLabel += '?';
+		sTypeLabel += ')';
+	}
+	// Complement dans le cas d'un type structure
+	else if (GetType() == KWType::Structure)
+	{
+		sTypeLabel += '(';
+		if (GetStructureName() != "")
+			sTypeLabel += GetStructureName();
+		else
+			sTypeLabel += '?';
+		sTypeLabel += ')';
+	}
+	return sTypeLabel;
+}
+
 const ALString KWAttribute::GetFormatMetaDataKey(int nComplexType)
 {
 	ALString sFormatKey;

--- a/src/Learning/KWData/KWAttribute.h
+++ b/src/Learning/KWData/KWAttribute.h
@@ -50,6 +50,9 @@ public:
 	const ALString& GetStructureName() const;
 	void SetStructureName(const ALString& sValue);
 
+	// Libelle complet associe au type, notamment dans le cas d'un type relation ou structure
+	const ALString GetTypeLabel() const;
+
 	// Utilisation des attributs de type objets par referencement (sinon: sous-partie)
 	// Faux si pas de regle de derivation ou type non Object, sinon selon la regle
 	boolean GetReference() const;

--- a/src/Learning/KWData/KWAttributeBlock.cpp
+++ b/src/Learning/KWData/KWAttributeBlock.cpp
@@ -766,12 +766,14 @@ longint KWAttributeBlock::GetUsedMemory() const
 	if (kwdrRule != NULL)
 		lUsedMemory += kwdrRule->GetUsedMemory();
 
-	// Prise en compte des donne additionnelle de gestion du bloc
+	// Prise en compte des donnees additionnelles de gestion du bloc
 	if (loadedAttributesIndexedKeyBlock != NULL)
 		lUsedMemory += loadedAttributesIndexedKeyBlock->GetUsedMemory();
 	if (ivLoadedAttributeMutationIndexes != NULL)
 		lUsedMemory += ivLoadedAttributeMutationIndexes->GetUsedMemory();
 	lUsedMemory += nkdAttributesByVarKeys.GetUsedMemory() - sizeof(NumericKeyDictionary);
+	lUsedMemory += oaLoadedAttributes.GetUsedMemory() - sizeof(ObjectArray);
+	lUsedMemory += ivLoadedAttributeIndexesBySparseIndex.GetUsedMemory() - sizeof(IntVector);
 	return lUsedMemory;
 }
 

--- a/src/Learning/KWData/KWAttributeBlock.h
+++ b/src/Learning/KWData/KWAttributeBlock.h
@@ -139,6 +139,9 @@ public:
 	int GetLoadedAttributeNumber() const;
 	KWAttribute* GetLoadedAttributeAt(int nIndex) const;
 
+	// Index d'un attribut charge en memoire selon l'ordre des attributs dans le bloc, selon son index pparse dans le bloc
+	int GetLoadedAttributeIndexAtSparseIndex(int nSparseIndex) const;
+
 	// Ensemble des cles d'attribut (VarKey) pour les attributs du blocs charges en memoire
 	// A chaque cle correspond l'index sparse de l'attribut dans son bloc
 	const KWIndexedKeyBlock* GetLoadedAttributesIndexedKeyBlock() const;
@@ -293,6 +296,7 @@ protected:
 	KWIndexedKeyBlock* loadedAttributesIndexedKeyBlock;
 	int nAttributeNumber;
 	NumericKeyDictionary nkdAttributesByVarKeys;
+	IntVector ivLoadedAttributeIndexesBySparseIndex;
 
 	// Gestion des index de mutation du bloc vers un bloc cible constituant un sous-bloc
 	// Utilise pour la mutation des objets lors de la lecture d'une base
@@ -474,6 +478,13 @@ inline KWAttribute* KWAttributeBlock::GetLoadedAttributeAt(int nIndex) const
 	require(GetParentClass()->IsIndexed());
 	require(cast(KWAttribute*, oaLoadedAttributes.GetAt(nIndex))->GetLoadIndex().GetSparseIndex() == nIndex);
 	return cast(KWAttribute*, oaLoadedAttributes.GetAt(nIndex));
+}
+
+inline int KWAttributeBlock::GetLoadedAttributeIndexAtSparseIndex(int nSparseIndex) const
+{
+	require(GetParentClass()->IsIndexed());
+	require(0 <= nSparseIndex and nSparseIndex < GetLoadedAttributeNumber());
+	return ivLoadedAttributeIndexesBySparseIndex.GetAt(nSparseIndex);
 }
 
 inline const KWIndexedKeyBlock* KWAttributeBlock::GetLoadedAttributesIndexedKeyBlock() const

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -446,9 +446,12 @@ public:
 	// Il peut s'agir d'attributs denses natifs ou de blocs d'attributs  non calcules
 	void ExportNativeFieldNames(StringVector* svNativeFieldNames) const;
 
-	// Export des noms des champs stockes (et loades), dans l'ordre du dictionnaire (utile pour constituer une ligne
-	// de header) Il peut s'agir d'attributs denses ou de blocs d'attributs
-	void ExportStoredFieldNames(StringVector* svStoredFieldNames) const;
+	// Export des noms des champs stockes (et loades), dans l'ordre du dictionnaire
+	// Utile pour constituer une ligne de header
+	// En mode de sortie standard, il peut agit des attributs denses ou des blocs d'attributs
+	// En mode de sortie dense, il s'agit de tous les attributs denses ou sparse, en ignorant
+	// l'appartenance ou non aux blocs d'attributs
+	void ExportStoredFieldNames(StringVector* svStoredFieldNames, boolean bDenseOutputFormat) const;
 
 	// Export des noms des attributs cles dans l'ordre des cles
 	void ExportKeyAttributeNames(StringVector* svAttributedNames) const;

--- a/src/Learning/KWData/KWDRStandard.cpp
+++ b/src/Learning/KWData/KWDRStandard.cpp
@@ -379,6 +379,7 @@ void KWDRValueBlockRule::DynamicCompile(const KWIndexedKeyBlock* indexedKeyBlock
 			cout << GetClassName() << " " << GetName() << endl;
 			cout << "\tSource block: " << *sourceIndexedKeyBlock;
 			cout << "\tTarget block: " << *indexedKeyBlock;
+			cout << "\tSame block: " << BooleanToString(bSameValueIndexes) << "\n";
 			cout << "\tNew value indexes: " << ivNewValueIndexes << endl;
 		}
 

--- a/src/Learning/KWData/KWDataTableDriver.cpp
+++ b/src/Learning/KWData/KWDataTableDriver.cpp
@@ -7,6 +7,7 @@
 KWDataTableDriver::KWDataTableDriver()
 {
 	kwcClass = NULL;
+	bDenseOutputFormat = false;
 	bVerboseMode = true;
 	bSilentMode = false;
 	lRecordIndex = 0;
@@ -38,6 +39,7 @@ void KWDataTableDriver::CopyFrom(const KWDataTableDriver* kwdtdSource)
 
 	// Reinitialisation prealable de toutes les variables
 	kwcClass = NULL;
+	bDenseOutputFormat = false;
 	bVerboseMode = true;
 	bSilentMode = false;
 	lRecordIndex = 0;
@@ -46,6 +48,7 @@ void KWDataTableDriver::CopyFrom(const KWDataTableDriver* kwdtdSource)
 
 	// Recopie des parametres de specification de la base
 	SetDataTableName(kwdtdSource->GetDataTableName());
+	SetDenseOutputFormat(kwdtdSource->GetDenseOutputFormat());
 	SetVerboseMode(kwdtdSource->GetVerboseMode());
 	SetSilentMode(kwdtdSource->GetSilentMode());
 }

--- a/src/Learning/KWData/KWDataTableDriver.h
+++ b/src/Learning/KWData/KWDataTableDriver.h
@@ -63,6 +63,11 @@ public:
 	////////////////////////////////////////////////////////////////////////////////
 	// Fonctionnalites de base
 
+	// Format de d'ecriture de type dense (defaut: false)
+	// En format dense, meme les blocs sparses sont ecrits de facon dense
+	void SetDenseOutputFormat(boolean bValue);
+	boolean GetDenseOutputFormat() const;
+
 	// Verification du format
 	// A redefinir dans les sous-classes specifiant un format physique
 	virtual boolean CheckFormat() const;
@@ -226,6 +231,7 @@ protected:
 	// Attributs
 	ALString sDataTableName;
 	const KWClass* kwcClass;
+	boolean bDenseOutputFormat;
 
 	// Cle correspondant a la derniere ligne lue, dans le cas d'une classe principale d'un schema multi-table
 	KWObjectKey lastReadMainKey;
@@ -263,6 +269,17 @@ inline void KWDataTableDriver::SetClass(const KWClass* kwcValue)
 inline const KWClass* KWDataTableDriver::GetClass() const
 {
 	return kwcClass;
+}
+
+inline void KWDataTableDriver::SetDenseOutputFormat(boolean bValue)
+{
+	require(not IsOpenedForWrite());
+	bDenseOutputFormat = bValue;
+}
+
+inline boolean KWDataTableDriver::GetDenseOutputFormat() const
+{
+	return bDenseOutputFormat;
 }
 
 inline boolean KWDataTableDriver::IsError() const

--- a/src/Learning/KWData/KWDataTableDriverTextFile.h
+++ b/src/Learning/KWData/KWDataTableDriverTextFile.h
@@ -125,6 +125,10 @@ public:
 	/////////////////////////////////////////////////
 	///// Implementation
 protected:
+	// Ecriture d'un bloc sparse au format dense
+	void WriteContinuousBlockUsingDenseFormat(KWAttributeBlock* attributeBlock, KWContinuousValueBlock* valueBlock);
+	void WriteSymbolBlockUsingDenseFormat(KWAttributeBlock* attributeBlock, KWSymbolValueBlock* valueBlock);
+
 	// Implementation specifique du saut de ligne dans le cas d'une classe principale
 	// En effet, dans ce cas, on analyse partiellement la ligne pour en extraire la derniere cle
 	void SkipMainRecord();

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -13,6 +13,7 @@ KWDatabase::KWDatabase()
 	bModeExcludeSample = false;
 	nSelectionAttributeType = KWType::Unknown;
 	cSelectionContinuous = 0;
+	bDenseOutputFormat = false;
 	bVerboseMode = true;
 	bSilentMode = false;
 	bIsError = false;
@@ -62,6 +63,7 @@ void KWDatabase::CopyFrom(const KWDatabase* kwdSource)
 	liSelectionAttributeLoadIndex.Reset();
 	nSelectionAttributeType = KWType::Unknown;
 	cSelectionContinuous = 0;
+	bDenseOutputFormat = false;
 	bVerboseMode = true;
 	bSilentMode = false;
 	bIsError = false;
@@ -82,6 +84,7 @@ void KWDatabase::CopyFrom(const KWDatabase* kwdSource)
 	SetSelectionAttribute(kwdSource->GetSelectionAttribute());
 	SetSelectionValue(kwdSource->GetSelectionValue());
 	GetMarkedInstances()->CopyFrom(&kwdSource->ivMarkedInstances);
+	SetDenseOutputFormat(kwdSource->GetDenseOutputFormat());
 	SetVerboseMode(kwdSource->GetVerboseMode());
 	SetSilentMode(kwdSource->GetSilentMode());
 }

--- a/src/Learning/KWData/KWDatabase.h
+++ b/src/Learning/KWData/KWDatabase.h
@@ -131,6 +131,11 @@ public:
 	// grand nombre d'enregistrements
 	KWClass* ComputeClass();
 
+	// Format de d'ecriture de type dense (defaut: false)
+	// En format dense, meme les blocs sparses sont ecrits de facon dense
+	void SetDenseOutputFormat(boolean bValue);
+	boolean GetDenseOutputFormat() const;
+
 	// Ouverture de la base de donnees pour lecture ou ecriture
 	// L'etat passe en IsOpened si l'ouverture a reussie
 	boolean OpenForRead();
@@ -591,6 +596,7 @@ protected:
 	// Attributs principaux
 	ALString sClassName;
 	ALString sDatabaseName;
+	boolean bDenseOutputFormat;
 	boolean bOpenedForRead;
 	boolean bOpenedForWrite;
 	boolean bVerboseMode;
@@ -625,6 +631,17 @@ protected:
 
 //////////////////////////////////////////////////////////////////////
 // Methodes en inline
+
+inline void KWDatabase::SetDenseOutputFormat(boolean bValue)
+{
+	require(not IsOpenedForWrite());
+	bDenseOutputFormat = bValue;
+}
+
+inline boolean KWDatabase::GetDenseOutputFormat() const
+{
+	return bDenseOutputFormat;
+}
 
 inline boolean KWDatabase::IsOpenedForRead() const
 {

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -1172,6 +1172,9 @@ boolean KWMTDatabase::PhysicalOpenForWrite()
 
 	require(CheckPartially(true));
 
+	// Parametrage du format de sortie dense dans le driver
+	dataTableDriverCreator->SetDenseOutputFormat(GetDenseOutputFormat());
+
 	// Nettoyage prealable
 	DMTMPhysicalTerminateMapping(mainMultiTableMapping);
 	nSkippedRecordNumber = 0;

--- a/src/Learning/KWData/KWRelationCreationRule.h
+++ b/src/Learning/KWData/KWRelationCreationRule.h
@@ -11,6 +11,7 @@ class KWDRRelationCreationRule;
 class KWDRTableCreationRule;
 
 #include "KWDerivationRule.h"
+#include "KWDRStandard.h"
 
 ////////////////////////////////////////////////////////////////////////////
 // Classe KWDRRelationCreationRule
@@ -212,6 +213,10 @@ protected:
 	// Test si le type d'un operande en sortie est valide
 	boolean IsValidOutputOperandType(int nType) const;
 
+	// Ajout d'une erreur de verification en mode vue pur une variable du dictionnaire en sortie
+	void AddViewModeError(const KWClass* kwcSourceClass, const KWClass* kwcTargetClass,
+			      const KWAttribute* targetAttribute, const ALString& sLabel) const;
+
 	// Indique si l'alimentation de type vue est activee
 	// Dans ce cas, le premier operande est de type Relation pour le dictionnaire en entree de la vue,
 	// et on verifie la compatibilite entre les attributs natif du dictionnaire en sortie et
@@ -243,11 +248,21 @@ protected:
 	KWLoadIndexVector livComputeModeTargetAttributeLoadIndexes;
 	IntVector ivComputeModeTargetAttributeTypes;
 
-	// Index de chargement des attributs pour une alimentation de type vue
+	// Index de chargement des attributs denses pour une alimentation de type vue
 	// On precise pour chaque attribut concerne son index dans le dictionnaire source et cible
 	KWLoadIndexVector livViewModeSourceAttributeLoadIndexes;
 	KWLoadIndexVector livViewModeTargetAttributeLoadIndexes;
 	IntVector ivViewModeTargetAttributeTypes;
+
+	// Index de chargement des blocs d'attributs pour une alimentation de type vue
+	// On precise pour chaque bloc d'attribut concerne son index dans le dictionnaire source et cible
+	KWLoadIndexVector livViewModeSourceBlockLoadIndexes;
+	KWLoadIndexVector livViewModeTargetBlockLoadIndexes;
+	IntVector ivViewModeTargetBlockTypes;
+
+	// Dans le cas des bloc, on utilise une regle de derivation de type CopyBlock par bloc a recopier depuis
+	// la source vers la cible, pour reutiliser les services d'extraction de la sous-partie du bloc sparse
+	ObjectArray oaViewModeCopyBlockRules;
 
 	// Classe de la cible de la vue
 	KWClass* kwcCompiledTargetClass;

--- a/src/Learning/KWData/KWSTDatabase.cpp
+++ b/src/Learning/KWData/KWSTDatabase.cpp
@@ -158,6 +158,7 @@ boolean KWSTDatabase::PhysicalOpenForWrite()
 	// Parametrage
 	dataTableDriverCreator->SetDataTableName(GetDatabaseName());
 	dataTableDriverCreator->SetClass(kwcClass);
+	dataTableDriverCreator->SetDenseOutputFormat(GetDenseOutputFormat());
 
 	// Ouverture physique
 	bOk = dataTableDriverCreator->OpenForWrite();

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
@@ -1318,6 +1318,7 @@ void PLShared_MTDatabaseTextFile::SerializeObject(PLSerializer* serializer, cons
 	serializer->PutString(database->GetSelectionAttribute());
 	serializer->PutString(database->GetSelectionValue());
 	serializer->PutIntVector(database->GetMarkedInstances());
+	serializer->PutBoolean(database->GetDenseOutputFormat());
 	serializer->PutBoolean(database->GetVerboseMode());
 	serializer->PutBoolean(database->GetSilentMode());
 	serializer->PutBoolean(database->GetHeaderLineUsed());
@@ -1402,6 +1403,7 @@ void PLShared_MTDatabaseTextFile::DeserializeObject(PLSerializer* serializer, Ob
 	database->SetSelectionAttribute(serializer->GetString());
 	database->SetSelectionValue(serializer->GetString());
 	serializer->GetIntVector(database->GetMarkedInstances());
+	database->SetDenseOutputFormat(serializer->GetBoolean());
 	database->SetVerboseMode(serializer->GetBoolean());
 	database->SetSilentMode(serializer->GetBoolean());
 	database->SetHeaderLineUsed(serializer->GetBoolean());

--- a/src/Learning/KWDataUtils/PLSTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLSTDatabaseTextFile.cpp
@@ -438,6 +438,7 @@ void PLShared_STDatabaseTextFile::SerializeObject(PLSerializer* serializer, cons
 	serializer->PutString(database->GetSelectionAttribute());
 	serializer->PutString(database->GetSelectionValue());
 	serializer->PutIntVector(database->GetMarkedInstances());
+	serializer->PutBoolean(database->GetDenseOutputFormat());
 	serializer->PutBoolean(database->GetVerboseMode());
 	serializer->PutBoolean(database->GetSilentMode());
 	serializer->PutBoolean(database->GetHeaderLineUsed());
@@ -484,6 +485,7 @@ void PLShared_STDatabaseTextFile::DeserializeObject(PLSerializer* serializer, Ob
 	database->SetSelectionAttribute(serializer->GetString());
 	database->SetSelectionValue(serializer->GetString());
 	serializer->GetIntVector(database->GetMarkedInstances());
+	database->SetDenseOutputFormat(serializer->GetBoolean());
 	database->SetVerboseMode(serializer->GetBoolean());
 	database->SetSilentMode(serializer->GetBoolean());
 	database->SetHeaderLineUsed(serializer->GetBoolean());

--- a/src/Learning/KWUserInterface/KWAttributeSpecArrayView.h
+++ b/src/Learning/KWUserInterface/KWAttributeSpecArrayView.h
@@ -57,28 +57,8 @@ public:
 protected:
 	// ## Custom implementation
 
-	// Construction des informations permettant de savoir pour chaque attribut d'une classe s'il est utilise la cle
-	void BuildKeyAttributes(KWClass* kwcClass, NumericKeyDictionary* nkdKeyAttributes) const;
-
-	// Construction des informations permettant de savoir pour chaque attribut d'une classe s'il est utilise
-	// dans une regle de derivation par un data item (attribut ou un bloc d'attribut)
-	// Dans le dictionnaire en sortie, la cle est le data item utilise, et la valeur un data item referencant
-	// le data item utilise au moyen d'une regle
-	void BuildClassUsedAttributeReferences(KWClass* kwcClass,
-					       NumericKeyDictionary* nkdUsedAttributeReferences) const;
-
-	// Idem pour une regle de derivation
-	// Comme on n'analyse pas les regles attributs parametres de regles, il n'y a pas de risque de recursion infinie
-	void BuildRuleUsedAttributeReferences(KWDerivationRule* rule, KWDataItem* referenceDataItem,
-					      NumericKeyDictionary* nkdUsedAttributeReferences) const;
-
 	// Classe editee
 	KWClass* kwcEditedClass;
-
-	// Dictionnaires des infortion d'utilisation des attributs de la classe editees (dans cle ou dans regles de
-	// derivation) pour permettre la correction des informations de types a la volee
-	NumericKeyDictionary nkdEditedClassKeyAttributes;
-	NumericKeyDictionary nkdEditedClassUsedAttributeReferences;
 
 	// Liste des types d'attributs stockes, pour les messages d'erreur
 	ALString sStoredTypes;

--- a/src/Learning/KWUserInterface/KWClassSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWClassSpecView.cpp
@@ -190,7 +190,6 @@ void KWClassSpecView::SetObject(Object* object)
 	KWClass* kwcClass;
 	KWAttribute* attribute;
 	KWAttributeSpec* attributeSpec;
-	ALString sCompleteType;
 	ALString sMetaData;
 
 	require(object != NULL);
@@ -210,19 +209,12 @@ void KWClassSpecView::SetObject(Object* object)
 			attributeSpec = new KWAttributeSpec;
 			oaAttributeSpecs.Add(attributeSpec);
 
-			// Calcul du type complet de l'attribut
-			sCompleteType = KWType::ToString(attribute->GetType());
-			if (KWType::IsRelation(attribute->GetType()) and attribute->GetClass() != NULL)
-				sCompleteType = sCompleteType + "(" + attribute->GetClass()->GetName() + ")";
-			else if (attribute->GetType() == KWType::Structure)
-				sCompleteType = sCompleteType + "(" + attribute->GetStructureName() + ")";
-
 			// Acces aux meta-data
 			sMetaData = attribute->GetMetaData()->WriteString();
 
 			// Initialisation a partir de l'attribut
 			attributeSpec->SetUsed(attribute->GetUsed());
-			attributeSpec->SetType(sCompleteType);
+			attributeSpec->SetType(attribute->GetTypeLabel());
 			attributeSpec->SetName(attribute->GetName());
 			attributeSpec->SetDerived(attribute->GetAnyDerivationRule() != NULL);
 			attributeSpec->SetMetaData(sMetaData);

--- a/src/Learning/KWUserInterface/KWDatabaseTransferView.h
+++ b/src/Learning/KWUserInterface/KWDatabaseTransferView.h
@@ -64,19 +64,6 @@ protected:
 	// Le transfer se fait au format sparse ou dense selon les specifications de l'interface
 	KWClass* InternalBuildTransferredClass(KWClassDomain* transferredClassDomain, const KWClass* transferClass);
 
-	// Test si une classe (ou sa composition) contient des blocs d'attributs a transferer
-	boolean IsClassWithTransferredAttributeBlocks(const KWClass* transferClass) const;
-
-	// Creation d'un domaine ou la classe a transferer (et les classes de sa composition) sont transformees
-	// au format dense, a partir d'une classe source.
-	// Tous les attributs sparse utilises sont renommes, mis en unused, et recopies dans des attributs dense
-	// de meme nom que les attributs initiaux
-	// Cela permet de gerer la transformation d'un format sparse vers un format dense au moyen d'un dictionnaire
-	// dedie, plutot qu'au moyen d'un flag a positionner dans les database et a propager dans les tables, drivers,
-	// en parallele, ce qui ne serait pas maintenable. On a ici une solution qui reste localisee dans une seule
-	// methode
-	KWClassDomain* InternalBuildDenseClassDomain(const KWClass* transferClass);
-
 	// Preparation de la classe de transfer (et de sa composition), en ne mettant en Load que les attributs
 	// transferables de facon a optimiser le nombre d'attributs calcules a traiter
 	void PrepareTransferClass(KWClass* transferClass);


### PR DESCRIPTION
L’utilisation de blocs sparse natifs dans les tables en sortie est autorisé pour les alimentations de type vue, avec des contraintes de correspondance de nom, type, VarKey et nom de bloc.
Mais c’est interdit pour les alimentations de type calcul.