### PR TITLE
Remove version from LearningTest result files

### DIFF
--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -607,6 +607,9 @@ def evaluate_tool_on_test_dir(
                 exception,
             )
 
+        # Nettoyage de toute reference a la version des fichiers de resultats
+        check.clean_version_from_results(results_dir)
+
     # Restore initial path
     if os.name == "nt":
         os.environ["path"] = initial_path
@@ -615,7 +618,6 @@ def evaluate_tool_on_test_dir(
 
     # Comparaison des resultats
     os.chdir(suite_dir)
-    test_dir = os.path.join(suite_dir, test_dir_name)
     check.check_results(test_dir)
 
 


### PR DESCRIPTION
Optimisation de la place prise par les fichiers de resultats, pour minimiser la taille du repo de stockage de LearningTest
- supprimer de l'information de versin des fichiers de résultats (.kdic, .khv, .khcj, .xls,...)
- on garde ce numero de version en deuxieme ligne du fichier time.log
- on minimise ainsi les differences entre fichiers de resultats de reference d'une version a l'autre, et donc la place occupee sur un repo git, notamment pour un stockage de type LFS

Impacts:

_kht_check_results.py
- clean_version_from_results(results_dir): nouvelle fonction de netoyyage de la version des fichiers d'un repertoire de resultats

_kht_one_shot_instructions.py
- nouvelle instruction clean-version: clean version info in all results dirs
- suppression de l'instruction obsolete instruction_simplify_scenario_v11
- deplacement de l'instruction_work en fin de fichier

kht_test.py
- evaluate_tool_on_test_dir: appel de clean_version_from_results en fin de methode pour nettoyer les resultats produits