### PR TITLE
Use local build Conda channel with the highest priority

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -107,18 +107,16 @@ jobs:
         with:
           miniforge-version: latest  # needed for macOS 13
           python-version: ${{ matrix.python-version }}
+          channels: ./build/conda
           conda-remove-defaults: true
       - name: Download Conda Package Artifact
         uses: actions/download-artifact@v4
         with:
           name: khiops-conda-${{ matrix.env.os-family }}
           path: ./build/conda
-      - name: Install the Conda package
-        run: |
-          conda install --channel ./build/conda khiops-core
       - name: Install the Khiops executables in the Conda environment
         run: |
-          conda install --channel conda-forge --channel ./build/conda khiops-core
+          conda install khiops-core
       - name: Add  CONDA_PREFIX to shared PATH (Windows)
         if: runner.os == 'Windows'
         run: |


### PR DESCRIPTION
Make sure that the locally-built khiops-core package is installed, rather than a possible khiops-core package situated on conda-forge.