### PR TITLE
Unset Visual Studio Environment Variables on conda

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -76,12 +76,6 @@ jobs:
             echo "KHIOPS_APPLE_CERTIFICATE_PASSWORD=${{ secrets.KHIOPS_APPLE_CERTIFICATE_PASSWORD }}" >> "$GITHUB_ENV"
             echo "KHIOPS_APPLE_TMP_KEYCHAIN_PASSWORD=${{ secrets.KHIOPS_APPLE_TMP_KEYCHAIN_PASSWORD }}" >> "$GITHUB_ENV"
           fi
-      - name: Set the Visual Studio Environment Variables (Windows)
-        if: runner.os == 'Windows'
-        shell: cmd
-        run: |
-          call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"
-          set >> %GITHUB_ENV%
       - name: Build conda packages
         run: |
           conda build --package-format=tar.bz2 --output-folder ./build/conda ./packaging/conda


### PR DESCRIPTION
An earlier fix e06af9d83ef was required because the Windows compiler was not found. This fix is no longer necessary and also causes a bug. This may be due to an instability in the Windows Runner. This commit is a revert from  e06af9d83ef