### PR TITLE
Use local build Conda channel with the highest priority

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -105,6 +105,11 @@ jobs:
     runs-on: ${{ matrix.env.os }}
     container: ${{ fromJSON(matrix.env.json-image) }}
     steps:
+      - name: Download Conda Package Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: khiops-conda-${{ matrix.env.os-family }}
+          path: ./build/conda
       - name: Install Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -112,11 +117,6 @@ jobs:
           python-version: '3.12'
           channels: ./build/conda
           conda-remove-defaults: true
-      - name: Download Conda Package Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: khiops-conda-${{ matrix.env.os-family }}
-          path: ./build/conda
       - name: Install the Khiops executables in the Conda environment
         run: |
           conda install khiops-core

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -110,18 +110,16 @@ jobs:
         with:
           miniforge-version: latest  # needed for macOS 13
           python-version: '3.12'
+          channels: ./build/conda
           conda-remove-defaults: true
       - name: Download Conda Package Artifact
         uses: actions/download-artifact@v4
         with:
           name: khiops-conda-${{ matrix.env.os-family }}
           path: ./build/conda
-      - name: Install the Conda package
-        run: |
-          conda install --channel ./build/conda khiops-core
       - name: Install the Khiops executables in the Conda environment
         run: |
-          conda install --channel conda-forge --channel ./build/conda khiops-core
+          conda install khiops-core
       - name: Add  CONDA_PREFIX to shared PATH (Windows)
         if: runner.os == 'Windows'
         run: |


### PR DESCRIPTION
Thus, one makes sure that the locally-built khiops-core package is installed, rather than a possible khiops-core package situated on conda-forge.