### PR TITLE
Fix conda tests in ci

### DIFF
--- a/.github/actions/test-khiops-on-iris/action.yml
+++ b/.github/actions/test-khiops-on-iris/action.yml
@@ -20,8 +20,10 @@ runs:
           # Detect Debian based OS
           if [ -d "/etc/apt" ]
           then
+            apt-get update
             apt-get install -y python3 > /dev/null
           else
+            yum check-update || true
             yum install -y python3.11
           fi
         fi

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -105,6 +105,11 @@ jobs:
     runs-on: ${{ matrix.env.os }}
     container: ${{ fromJSON(matrix.env.json-image) }}
     steps:
+      - name: Download Conda Package Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: khiops-conda-${{ matrix.env.os-family }}
+          path: ./build/conda
       - name: Install Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -112,11 +117,6 @@ jobs:
           python-version: '3.12'
           channels: ./build/conda
           conda-remove-defaults: true
-      - name: Download Conda Package Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: khiops-conda-${{ matrix.env.os-family }}
-          path: ./build/conda
       - name: Install the Khiops executables in the Conda environment
         run: |
           conda install khiops-core

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -92,21 +92,24 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - {os: ubuntu-20.04, os-family: linux-64}
-          - {os: ubuntu-22.04, os-family: linux-64}
-          - {os: ubuntu-24.04, os-family: linux-64}
-          - {os: windows-2019, os-family: win-64}
-          - {os: windows-2022, os-family: win-64}
-          - {os: macos-13, os-family: osx-64}
-          - {os: macos-14, os-family: osx-arm64}
-          - {os: macos-15, os-family: osx-arm64}
+          - {os: ubuntu-22.04, json-image: '{"image": "ubuntu:20.04"}', os-family: linux-64}
+          - {os: ubuntu-22.04, json-image: '{"image": null}', os-family: linux-64}
+          - {os: ubuntu-24.04, json-image: '{"image": null}', os-family: linux-64}
+          - {os: ubuntu-22.04, json-image: '{"image": "rockylinux:8"}', os-family: linux-64}
+          - {os: ubuntu-22.04, json-image: '{"image": "rockylinux:9"}', os-family: linux-64}
+          - {os: windows-2019, json-image: '{"image": null}', os-family: win-64}
+          - {os: windows-2022, json-image: '{"image": null}', os-family: win-64}
+          - {os: macos-13, json-image: '{"image": null}', os-family: osx-64}
+          - {os: macos-14, json-image: '{"image": null}', os-family: osx-arm64}
+          - {os: macos-15, json-image: '{"image": null}', os-family: osx-arm64}
     runs-on: ${{ matrix.env.os }}
+    container: ${{ fromJSON(matrix.env.json-image) }}
     steps:
       - name: Install Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest  # needed for macOS 13
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
           channels: ./build/conda
           conda-remove-defaults: true
       - name: Download Conda Package Artifact
@@ -132,7 +135,8 @@ jobs:
       - name: Test the Khiops executables on the Iris dataset
         uses: ./.github/actions/test-khiops-on-iris
         with:
-          os-decription: ${{ matrix.env.os }}-${{ matrix.env.os-family }}
+          os-decription: ${{ matrix.env.os }}-${{ fromJSON(matrix.env.json-image)
+            }}-${{ matrix.env.os-family }}
 
   # Release is only executed on tags
   # Note: For this job to work the secrets variables KHIOPS_ANACONDA_CHANNEL_TOKEN and


### PR DESCRIPTION
Various backports from v11 (cherry-picked commits from various V11 branches):

- use Docker images for testing the Conda package on Ubuntu 20.04;
- test the Conda package on Rocky 8 and 9;
- fix Python version to 3.12 when setting-up Miniconda for tests;
- download Conda build artifact before setting-up Miniconda; on Python 3.12, Miniconda reads the high-priority channel contents upon set-up.