### PR TITLE
Fix sort algorithm: singleton and differents file separators

### DIFF
--- a/src/Learning/KWDataUtils/KWChunkSorterTask.h
+++ b/src/Learning/KWDataUtils/KWChunkSorterTask.h
@@ -141,10 +141,6 @@ protected:
 	// Resultat en plus du fichier trie
 	longint lSortedLinesNumber;
 
-	/////////////////////////////////////////////////////////////////
-	// Variables du Slave
-	boolean bSameSeparator;
-
 	///////////////////////////////////////////////////////////
 	// Parametres partages
 
@@ -153,6 +149,7 @@ protected:
 	// d'un ou plusieurs fichiers constitues par une tache precedente
 	PLShared_Int input_nBucketIndex;         // Index du bucket a trier
 	PLShared_StringVector input_svFileNames; // Liste des noms des fichier constituant le chunk a trier
+	PLShared_Boolean input_bSingleton; // Est-ce que le fichier est un singleton (il ne contient qu'une seule clef)
 
 	// En sortie des taches
 	PLShared_Int output_nBucketIndex; // Index du bucket trie (recopie d'apres la variable correspondante en entree)
@@ -165,7 +162,8 @@ protected:
 	PLShared_Boolean shared_bOnlyOneBucket;
 	PLShared_Longint shared_lBucketSize;
 	PLShared_Char shared_cOutputSeparator; // Separateur du fichier de sortie
-	PLShared_Char shared_cInputSeparator;  // Separetur du fichier d'entree
+	PLShared_Char shared_cInputSeparator;  // Separateur du fichier d'entree
+	PLShared_Boolean shared_bSameSeparator;
 
 	/////////////////////////////////////////////////////////////////
 	// Methodes techniques

--- a/src/Learning/KWDataUtils/KWSortBuckets.cpp
+++ b/src/Learning/KWDataUtils/KWSortBuckets.cpp
@@ -767,7 +767,7 @@ void KWSortBucket::SetSorted()
 
 boolean KWSortBucket::GetSorted() const
 {
-	return bSorted or IsSingleton();
+	return bSorted;
 }
 
 ///////////////////////////////////////////////////////////////////////

--- a/src/Learning/KWDataUtils/KWSortBuckets.h
+++ b/src/Learning/KWDataUtils/KWSortBuckets.h
@@ -200,7 +200,6 @@ public:
 	CharVector* GetChunk();
 
 	// Est-ce que le chunk est trie
-	// C'est forcement le cas pour les chunks singletons, sinon, le tri doit positionner le flag
 	void SetSorted();
 	boolean GetSorted() const;
 


### PR DESCRIPTION
The singleton chunks don't need to be sorted, but if the input and output file separators are different, they need to be rewritten to change the file separator.

The rewrite is handled in the slaveProcess: it is the same process used for the chunk to be sorted, the only difference being that the keys are not sorted if it is a singleton. This can be optimised, of course, but singletons are rare, and optimising would make the code (which is already big enough) more complex.