### PR TITLE
Fix Unit Test framework

### DIFF
--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -13,8 +13,13 @@ on:
   pull_request:
     paths:
       - '**CMakeLists.txt'
+      - '!test/**CMakeLists.txt'
+      - '!test/UniTests/**'
+      - '!test/LearningTestTool/**'
+      - '!test/MemoryStatsVisualizer/**'
       - '**.cmake'
       - .github/workflows/pack-debian.yml
+
   push:
     tags: ['*']
 # Cancel any ongoing run of this workflow on the same PR or ref

--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     paths:
       - '**CMakeLists.txt'
+      - '!test/**CMakeLists.txt'
+      - '!test/UniTests/**'
+      - '!test/LearningTestTool/**'
+      - '!test/MemoryStatsVisualizer/**'
       - packaging/windows/nsis/*.nsh
       - packaging/windows/nsis/*.nsi
       - .github/workflows/pack-nsis.yml

--- a/.github/workflows/pack-rpm.yml
+++ b/.github/workflows/pack-rpm.yml
@@ -9,7 +9,11 @@ on:
         default: openmpi
         options: [mpich, openmpi]
   pull_request:
-    paths: ['**CMakeLists.txt', '**.cmake', .github/workflows/pack-rpm.yml]
+    paths:
+      - '**CMakeLists.txt'
+      - '!test/**CMakeLists.txt'
+      - '**.cmake'
+      - .github/workflows/pack-rpm.yml]
   push:
     tags: ['*']
 # Cancel any ongoing run of this workflow on the same PR or ref

--- a/test/UnitTests/Parallel-mpi/CMakeLists.txt
+++ b/test/UnitTests/Parallel-mpi/CMakeLists.txt
@@ -11,4 +11,23 @@ endif()
 target_include_directories(parallel_mpi_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(parallel_mpi_test PUBLIC ${GTEST_CFLAGS})
 include(GoogleTest)
+
 gtest_discover_tests(parallel_mpi_test DISCOVERY_TIMEOUT 10)
+
+# cmake-format: off
+# Add the same test in CTest framework. It allows to run the test directly with the right mpi command.  
+# The command "ctest --preset linux-gcc-release -L mpi" will run (depending on the mpi implementation and the core number): 
+# mpiexec -n 4  build/linux-gcc-release/parallel_mpi_test 
+# We set the proc number to 4 (rather than using the variable MPIEXEC_MAX_NUMPROCS) to ensure a parallel execution even on monoproc machines 
+# cmake-format: on
+
+# Add flag --oversubscibe for openmpi
+if("${MPI_IMPL}" STREQUAL "openmpi")
+  set(MPIEXEC_OVERSUBSCRIBE "--oversubscribe")
+endif()
+
+add_test(NAME ctest_parallel_mpi_test COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_OVERSUBSCRIBE} ${MPIEXEC_NUMPROC_FLAG} 4
+                                              ${MPIEXEC_PREFLAGS} $<TARGET_FILE:parallel_mpi_test> ${MPIEXEC_POSTFLAGS})
+
+# Add "mpi" label to the test
+set_tests_properties(ctest_parallel_mpi_test PROPERTIES LABELS "mpi")


### PR DESCRIPTION
MPI Unit Tests were actually not launched with mpi. A (forgotten) cherry-pick from dev fixes it