### PR TITLE
646 handle werrorstrict prototypes with kni

### DIFF
--- a/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.h
+++ b/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.h
@@ -116,7 +116,7 @@ extern "C"
 	 * Return code:
 	 *    version number, an integer constant
 	 */
-	KNI_API int KNIGetVersion();
+	KNI_API int KNIGetVersion(void);
 
 	/*
 	 * Get full version of KNI
@@ -125,7 +125,7 @@ extern "C"
 	 * Return code:
 	 *    full version as a sequence-based identifier (ex: "9.0.1")
 	 */
-	KNI_API const char* KNIGetFullVersion();
+	KNI_API const char* KNIGetFullVersion(void);
 
 	/**********************************************************************************************
 	 * Management of streams
@@ -316,7 +316,7 @@ extern "C"
 	 * This accounts for the memory necessary to store the stream dictionaries, external tables
 	 * as well as the secondary records under preparation for recoding.
 	 */
-	KNI_API int KNIGetStreamMaxMemory();
+	KNI_API int KNIGetStreamMaxMemory(void);
 
 	/*
 	 * Set the maximum amount of memory (in MB) available for the next opened stream.

--- a/src/Norm/base/Portability.h
+++ b/src/Norm/base/Portability.h
@@ -37,7 +37,7 @@
 #endif
 
 // Verification que l'OS est supporte
-#if !defined(__gnu_linux__) && !defined(__ANDROID__) && !defined(__APPLE__) && !defined(_WIN32)
+#if !defined(__gnu_linux__) && !defined(__linux__) && !defined(__ANDROID__) && !defined(__APPLE__) && !defined(_WIN32)
 #error current OS is not supported
 #endif
 


### PR DESCRIPTION
2 commits for 2 issues:
- Add "void" parameter functions without parameter in KNI:  #646 
- Add __linux__ as allowed os for Norm library:  #641

Notes:
- To be squashed under "Improve compilation on prplOS".
- To be ported on branch dev