### PR TITLE
Fix Start/End TaskProgression in Master

### DIFF
--- a/src/Parallel/PLMPI/PLMPIMaster.cpp
+++ b/src/Parallel/PLMPI/PLMPIMaster.cpp
@@ -506,7 +506,6 @@ boolean PLMPIMaster::Process()
 			}
 		}
 	}
-	TaskProgression::EndTask();
 
 	// A partir d'ici on est sur que les esclaves n'enverront plus de messages
 	MPI_Barrier(*PLMPITaskDriver::GetTaskComm()); // BARRIER MSG
@@ -537,6 +536,8 @@ boolean PLMPIMaster::Process()
 			ReceivePendingMessage(receivedStatus);
 		}
 	}
+
+	TaskProgression::EndTask();
 
 	// Tout les messages on ete traites par les esclaves, on peut continuer
 	MPI_Barrier(*PLMPITaskDriver::GetTaskComm()); // BARRIER MSG 2


### PR DESCRIPTION
A previous fix was not well made: the progression task was not ended. Here, it is properly ended, furthemore, I checked that TaskProgression is always ended if it is start even in case of errors triggred by master or slaves.