### PR TITLE
Pin windows install assets to 11.0.0

### DIFF
--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -45,7 +45,7 @@ jobs:
         uses: robinraju/release-downloader@v1.9
         with:
           repository: khiopsml/khiops-win-install-assets
-          latest: true
+          tag: 11.0.0
       - name: Extract Windows installer assets and load assets-info.env
         shell: bash
         run: |


### PR DESCRIPTION
These new assets replace the *minimal* JRE with the *full* JRE

#673 becomes obsolete (as it is pin with 11.0. instead of 10.7), it will be closed without merging it. 

close #642 
close #662 