### PR TITLE
Accept boolean values in key-value pairs in json files for search-replace in khiops scenarios

### DIFF
--- a/src/Norm/base/CommandFile.cpp
+++ b/src/Norm/base/CommandFile.cpp
@@ -1388,7 +1388,8 @@ const ALString CommandFile::RecodeCurrentLineUsingJsonParameters(boolean& bOk)
 			}
 			// Erreur si type de valeur invalide
 			else if (jsonValue->GetType() != JSONValue::NumberValue and
-				 jsonValue->GetType() != JSONValue::StringValue)
+				 jsonValue->GetType() != JSONValue::StringValue and
+				 jsonValue->GetType() != JSONValue::BooleanValue)
 			{
 				bOk = false;
 				AddInputCommandFileError(
@@ -1400,11 +1401,22 @@ const ALString CommandFile::RecodeCurrentLineUsingJsonParameters(boolean& bOk)
 			else
 			{
 				assert(jsonValue->GetType() == JSONValue::NumberValue or
-				       jsonValue->GetType() == JSONValue::StringValue);
+				       jsonValue->GetType() == JSONValue::StringValue or
+				       jsonValue->GetType() == JSONValue::BooleanValue);
+
+				// Cas numerique
 				if (jsonValue->GetType() == JSONValue::NumberValue)
 					sRecodedLine += jsonValue->GetNumberValue()->WriteString();
+				// Cas booleen
+				else if (jsonValue->GetType() == JSONValue::BooleanValue)
+				{
+					sRecodedLine += jsonValue->GetBooleanValue()->WriteString();
+				}
+				// Cas chaine de caracteres
 				else
 				{
+					assert(jsonValue->GetType() == JSONValue::StringValue);
+
 					// Cas avec recodage base64
 					if (bIsByteJsonKey)
 					{


### PR DESCRIPTION
Actuellement, les valeurs booleennes n'étaient utilisables que pour le conditionnement des blocs IF dans le pilotage de Khiops via des scénario et des fichiers de paramètre Khiops.

La specification evolue en acceptant les valeurs booleennes pour les paires cle-valeur utilisees pour le search/replace. Cela permet de prendre en compte simplement les valeurs de type boolean, qui correspondent naturellement aux parametres booleens de l'API core de pykhiops, lies aux checkbox de la GUI, et se traduisant par des 'true' ou 'false' dans les scenarios.