### PR TITLE
Extend interpretation models to classification with grouped target values

### DIFF
--- a/src/Learning/KIInterpretation/KIDRReinforcement.cpp
+++ b/src/Learning/KIInterpretation/KIDRReinforcement.cpp
@@ -488,7 +488,7 @@ void KIDRClassifierReinforcer::ComputeReinforcementAt(KIAttributeReinforcement* 
 	// Acces a l'attribut source de la grille
 	dataGridRule->GetAttributePartNumberAt(0);
 
-	// Recheche des index source et cible dans la grille correspondante
+	// Recheche de l'index source dans la grille correspondante
 	nSourcePartIndex = ivDataGridSourceIndexes.GetAt(nAttributeIndex);
 
 	// Score initial avant renforcement

--- a/src/Learning/KIInterpretation/KIShapleyTable.cpp
+++ b/src/Learning/KIInterpretation/KIShapleyTable.cpp
@@ -12,79 +12,126 @@ KIShapleyTable::KIShapleyTable()
 
 KIShapleyTable::~KIShapleyTable() {}
 
-void KIShapleyTable::InitializeFromDataGridStats(const KWDataGridStats* dataGridStats, double dAttributeWeight)
+void KIShapleyTable::InitializeFromDataGridStats(const SymbolVector* svTargetValues,
+						 const IntVector* ivTargetValueFrequencies,
+						 const KWDataGridStats* dataGridStats, double dAttributeWeight)
 {
-	IntVector ivSourceFrequencies;
-	IntVector ivTargetFrequencies;
+	const KWDGSAttributePartition* targetPartition;
+	IntVector ivSourcePartFrequencies;
+	IntVector ivTargetPartFrequencies;
 	int nTotalFrequency;
-	int nSourceNumber;
-	int nTargetNumber;
-	int nSource;
+	int nSourcePartNumber;
+	int nTargetPartNumber;
+	int nSourcePart;
+	int nTargetPart;
 	int nTarget;
 	double dLaplaceEpsilon;
+	double dConditionalOneFrequency;
+	double dConditionalOneLaplaceEpsilon;
+	double dConditionalAllFrequency;
+	double dConditionalAllLaplaceEpsilon;
 	double dProbOne;
 	double dProbAll;
 	double dTerm;
 	double dExpectedTerm;
 	double dShapleyValue;
 
+	require(svTargetValues != NULL);
+	require(svTargetValues->GetSize() > 1);
+	require(ivTargetValueFrequencies != NULL);
+	require(ivTargetValueFrequencies->GetSize() == svTargetValues->GetSize());
 	require(dataGridStats != NULL);
 	require(dataGridStats->GetAttributeNumber() == 2);
+	require(dataGridStats->GetAttributeAt(1)->GetAttributeType() == KWType::Symbol);
 	require(dataGridStats->GetAttributeAt(0)->GetPartNumber() > 1);
 	require(dataGridStats->GetAttributeAt(1)->GetPartNumber() > 1);
+	require(dataGridStats->GetAttributeAt(1)->GetPartNumber() <= svTargetValues->GetSize());
 	require(0 < dAttributeWeight);
 
-	// Initialisation de la taille
-	Initialize(dataGridStats->GetAttributeAt(0)->GetPartNumber(),
-		   dataGridStats->GetAttributeAt(1)->GetPartNumber());
+	// Acces a la partition cible
+	targetPartition = dataGridStats->GetAttributeAt(1);
 
 	// Calcul des effectifs par partie pour l'attribut source et cible de la grille
-	dataGridStats->ExportAttributePartFrequenciesAt(0, &ivSourceFrequencies);
-	dataGridStats->ExportAttributePartFrequenciesAt(1, &ivTargetFrequencies);
-	nSourceNumber = ivSourceFrequencies.GetSize();
-	nTargetNumber = ivTargetFrequencies.GetSize();
+	dataGridStats->ExportAttributePartFrequenciesAt(0, &ivSourcePartFrequencies);
+	dataGridStats->ExportAttributePartFrequenciesAt(1, &ivTargetPartFrequencies);
+	nSourcePartNumber = ivSourcePartFrequencies.GetSize();
+	nTargetPartNumber = ivTargetPartFrequencies.GetSize();
 	nTotalFrequency = dataGridStats->ComputeGridFrequency();
 
+	// Initialisation de la taille avec le nombre de parties sources et le nombre de valeurs cibles
+	// Attention, le cacul des valeurs de Shapley se fait par valeur cible, et non par partie cible,
+	// notamment pour le cas avec groupement des valeurs cibles
+	// Dans le cas avec groupement des valeurs cibles, on exploite l'hypothese de densite uniforme
+	// par morceaux pour faire le calcul des valeurs de Shapley en repartissant les effectifs de chaque
+	// groupe de valeurs cibles au prorata des effectifs des valeurs du groupe
+	Initialize(dataGridStats->GetAttributeAt(0)->GetPartNumber(), svTargetValues->GetSize());
+
 	// On calcul d'abord les log(p(x_i|yOne)/p(x_i|yAll)) pour chaque x_i et chaque y_j
-	// en mode one versus all pour chaque classe y_j
+	// en mode One versus All pour chaque classe y_j
 	//
 	// Utilisation d'un epsilon de Laplace pour eviter les probabilite nulles
 	// On prend l'effectif total plus un pour eviter les effets de bord (cf. classe KWProbabilityTable)
 	// Pour etre au plus proche des calculs de probabilites utilises dans le SNB, on considere toujours
 	// le meme nombre de valeurs cibles dans l'utilisation de l'epsilon de Laplace, en utilisant 1 espilon pour
-	// la probabilite de la cible d'interet et (nTargetNumber-1) epsilon pour l'ensemble des autres valeurs cibles
+	// la probabilite de la partie cible d'interet et (nTargetNumber-1) epsilon pour l'ensemble des autres parties cibles
 	dLaplaceEpsilon = 1.0 / (nTotalFrequency + 1);
 	for (nTarget = 0; nTarget < GetTargetSize(); nTarget++)
 	{
+		// Index de la partie cible correspondant a la valeur cible
+		nTargetPart = targetPartition->ComputeSymbolPartIndex(svTargetValues->GetAt(nTarget));
+
+		// Epsilon de Laplace associe a la valeur cible, reparti au prorata de l'effectif
+		// de la valeur cible dans son eventuelle partie cible, dans le cas One
+		dConditionalOneLaplaceEpsilon = dLaplaceEpsilon;
+		if (not targetPartition->ArePartsSingletons())
+			dConditionalOneLaplaceEpsilon =
+			    (dConditionalOneLaplaceEpsilon * ivTargetValueFrequencies->GetAt(nTarget)) /
+			    ivTargetPartFrequencies.GetAt(nTargetPart);
+
+		// Idem pour la cas All
+		dConditionalAllLaplaceEpsilon = nTargetPartNumber * dLaplaceEpsilon - dConditionalOneLaplaceEpsilon;
+
 		// Premiere passe pour calcul le terme de valeur et d'esperance
 		dExpectedTerm = 0;
-		for (nSource = 0; nSource < GetSourceSize(); nSource++)
+		for (nSourcePart = 0; nSourcePart < GetSourceSize(); nSourcePart++)
 		{
+			// Effectif de la cellule (partie source, valeur cible) pour la valeur dans le cas One
+			// - effectif exact dans le cas de valeurs cible singleton
+			// - effectif au prorata des valeurs de la partie dans le cas avec groupement de valeur cibles
+			dConditionalOneFrequency = dataGridStats->GetBivariateCellFrequencyAt(nSourcePart, nTargetPart);
+			if (not targetPartition->ArePartsSingletons())
+				dConditionalOneFrequency =
+				    (dConditionalOneFrequency * ivTargetValueFrequencies->GetAt(nTarget)) /
+				    ivTargetPartFrequencies.GetAt(nTargetPart);
+
+			// Effectif de la cellule et epsilon de Laplace dans le cas All
+			dConditionalAllFrequency =
+			    ivSourcePartFrequencies.GetAt(nSourcePart) - dConditionalOneFrequency;
+
 			// Probabilite conditionnelle pour la valeur source sachant la valeur cible
-			dProbOne = (dataGridStats->GetBivariateCellFrequencyAt(nSource, nTarget) + dLaplaceEpsilon) /
-				   (ivTargetFrequencies.GetAt(nTarget) + nSourceNumber * dLaplaceEpsilon);
+			dProbOne = (dConditionalOneFrequency + dConditionalOneLaplaceEpsilon) /
+				   (ivTargetValueFrequencies->GetAt(nTarget) +
+				    nSourcePartNumber * dConditionalOneLaplaceEpsilon);
 
 			// Probabilite conditionnelle pour la valeur source sachant toutes les autres valeurs cibles
-			dProbAll = (ivSourceFrequencies.GetAt(nSource) -
-				    dataGridStats->GetBivariateCellFrequencyAt(nSource, nTarget) +
-				    (nTargetNumber - 1) * dLaplaceEpsilon) /
-				   (nTotalFrequency - ivTargetFrequencies.GetAt(nTarget) +
-				    nSourceNumber * (nTargetNumber - 1) * dLaplaceEpsilon);
+			dProbAll = (dConditionalAllFrequency + dConditionalAllLaplaceEpsilon) /
+				   (nTotalFrequency - ivTargetValueFrequencies->GetAt(nTarget) +
+				    nSourcePartNumber * dConditionalAllLaplaceEpsilon);
 
 			// Memorisation du resultats intermediaire
 			dTerm = log(dProbOne / dProbAll);
-			SetShapleyValueAt(nSource, nTarget, dTerm);
+			SetShapleyValueAt(nSourcePart, nTarget, dTerm);
 
 			// Mise a jour du calcul d'esperance de la valeur
-			dExpectedTerm += (ivSourceFrequencies.GetAt(nSource) / (double)nTotalFrequency) * dTerm;
+			dExpectedTerm += (ivSourcePartFrequencies.GetAt(nSourcePart) / (double)nTotalFrequency) * dTerm;
 		}
 
-		// Deuiemme passe pour soustraire l'esperance et obtenir la valeur de Shapley
-		for (nSource = 0; nSource < GetSourceSize(); nSource++)
+		// Deuxieme passe pour soustraire l'esperance et obtenir la valeur de Shapley
+		for (nSourcePart = 0; nSourcePart < GetSourceSize(); nSourcePart++)
 		{
-			dTerm = GetShapleyValueAt(nSource, nTarget);
+			dTerm = GetShapleyValueAt(nSourcePart, nTarget);
 			dShapleyValue = dAttributeWeight * (dTerm - dExpectedTerm);
-			SetShapleyValueAt(nSource, nTarget, dShapleyValue);
+			SetShapleyValueAt(nSourcePart, nTarget, dShapleyValue);
 		}
 	}
 }

--- a/src/Learning/KIInterpretation/KIShapleyTable.h
+++ b/src/Learning/KIInterpretation/KIShapleyTable.h
@@ -20,8 +20,12 @@ public:
 
 	// Initialisation complete a partir d'une grille dont le dernier attribut contient l'attribut cible
 	// et d'un poids de variable
+	// Les valeur cibles passees en entree sont utilisees pour le parametrage de la table de valeur de Shapley,
+	// et sont potentiellement dans un ordre different de celle de la grille, voire avec en nombre different
+	// du nombre de parties cibles de la grille si celle-ci exploite un groupement de valeur pour l'attribut cible
 	// Un epsilon de Laplace minimal (1/(N+1)) est utilise pour eviter les probabilites nulles
-	void InitializeFromDataGridStats(const KWDataGridStats* dataGridStats, double dAttributeWeight);
+	void InitializeFromDataGridStats(const SymbolVector* svTargetValues, const IntVector* ivTargetValueFrequencies,
+					 const KWDataGridStats* dataGridStats, double dAttributeWeight);
 
 	///////////////////////////////////////////////////////////////////////////
 	// Initialisation


### PR DESCRIPTION
Impacts principaux
- KIInterpretationClassBuilder::ImportPredictor
  - supression du warning en cas de classifieur avec groupement de la cible
  - robustification au passage, par ajout systematique de messages d'erreur en cas d'un dictionnaire de classification incorrect
- KIShapleyTable::InitializeFromDataGridStats
  - calcul desormais les valeurs de Shapley par valeur cible elementaire, et non par partie cible de la grille
  - on passe ls valeurs cibles du predicteur, systematiquement dans le meme ordre
  - on s'adapate ainsi au cas du groupement des avleur cible, en distribuant les effectifs de chaque partie cible au prorata des effectifs des valeurs de la partie
  - traitement similaire pour repartir les epsilon de Laplace
  - impacts:
    - KIDRClassifierInterpreter::Compile, pour le pilotage du calcul des table de valeurs de Shapley
    - KIDRClassifierInterpreter::GetContributionAt, pour un acces direct en fonction de la valeur cible
    - KIDRClassifierInterpreter::ComputeRankedContributions: idem

LearningTest\TestKhiops\KIInterpretation\AdultAndTargetGrouping
- Tests systematiques en interpretation globale et individuelle, plus en renforcement
- Vérification poussee des resultats