### PR TITLE
587 forbid to select the cloud as a temporary directory

### DIFF
--- a/src/Learning/KWLearningProblem/KWLearningProject.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProject.cpp
@@ -408,6 +408,22 @@ boolean KWLearningProject::ShowSystemInformation(const ALString& sValue)
 	ShowVersion(sTmp);
 	cout << endl;
 
+	// Verification que le repertoire temporaire est licite
+	// On verifie que c'est un un disque local
+	if (not FileService::IsLocalURI(FileService::GetUserTmpDir()))
+	{
+		cout << "Error: Invalid temporary directory (Temp file directory must be located on the local file "
+			"system)"
+		     << endl
+		     << endl;
+	}
+	// On verifie ensuite que le chemin est absolu
+	else if (not FileService::IsAbsoluteFilePathName(FileService::GetUserTmpDir()))
+	{
+		cout << "Error: Invalid temporary directory (Temp file directory must be an absolute path)" << endl
+		     << endl;
+	}
+
 	// Drivers
 	if (SystemFileDriverCreator::GetDriverNumber() > 0)
 	{

--- a/src/Learning/KWLearningProblem/KWLearningProject.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProject.cpp
@@ -147,6 +147,15 @@ void KWLearningProject::StartMaster(int argc, char** argv)
 
 	require(PLParallelTask::IsMasterProcess());
 
+	// Parametrage du repertoire temporaire via les variables d'environnement
+	// (la valeur du repertoire temporaire peut etre modifiee par l'IHM)
+	sTmpDirFromEnv = p_getenv("KHIOPS_TMP_DIR");
+	if (sTmpDirFromEnv != "")
+		FileService::SetUserTmpDir(sTmpDirFromEnv);
+
+	// Evaluation des ressources disponibles
+	PLParallelTask::GetDriver()->MasterInitializeResourceSystem();
+
 	// Verification que le packing des structures est correct pour KWValueBlock
 	// Cette verification technique permet d'automatiser la detection de problemes
 	// lies a la compilation croisee, pour le portage vers les plate-formes linux
@@ -187,15 +196,6 @@ void KWLearningProject::StartMaster(int argc, char** argv)
 
 	// Parametrage du mode fast exist
 	UIObject::SetFastExitMode(GetLearningFastExitMode());
-
-	// Parametrage du repertoire temporaire via les variables d'environnement
-	// (la valeur du repertoire temporaire peut etre modifiee par l'IHM)
-	sTmpDirFromEnv = p_getenv("KHIOPS_TMP_DIR");
-	if (sTmpDirFromEnv != "")
-		FileService::SetUserTmpDir(sTmpDirFromEnv);
-
-	// Evaluation des ressources disponibles
-	PLParallelTask::GetDriver()->MasterInitializeResourceSystem();
 
 	// Acces au projet et a sa vue
 	learningProblem = CreateGenericLearningProblem();

--- a/src/Norm/base/FileService.cpp
+++ b/src/Norm/base/FileService.cpp
@@ -1248,8 +1248,15 @@ boolean FileService::CreateApplicationTmpDir()
 	// Creation du repertoire temporaire utilisateur si different de la valeur par defaut (vide)
 	if (bOk and sUserTmpDir != "")
 	{
-		// On verifie d'abord que le chemin est absolu
-		if (not IsAbsoluteFilePathName(sUserTmpDir))
+		// On verifie que c'est un un disque local
+		if (not IsLocalURI(sUserTmpDir))
+		{
+			bOk = false;
+			Global::AddError("Temp file directory", sUserTmpDir,
+					 "Temp file directory must be located on the local file system");
+		}
+		// On verifie ensuite que le chemin est absolu
+		else if (not IsAbsoluteFilePathName(sUserTmpDir))
 		{
 			bOk = false;
 			Global::AddError("Temp file directory", sUserTmpDir,


### PR DESCRIPTION
Temporary dir is checked in `FileService::CreateApplicationTmpDir()` and in `KWLearningProject::ShowSystemInformation`. It handles all the cases except on clusters. I wrote a specific issue for this #753.
 