### PR TITLE
fix sort algorithm: singleton vs sorted buckets

### DIFF
--- a/src/Learning/KWDataUtils/KWChunkSorterTask.cpp
+++ b/src/Learning/KWDataUtils/KWChunkSorterTask.cpp
@@ -332,6 +332,9 @@ boolean KWChunkSorterTask::MasterPrepareTaskInput(double& dTaskPercent, boolean&
 {
 	KWSortBucket* bucketToSort;
 	int nTreatedBucketNumber;
+	InputBufferedFile ib;
+	int i;
+	longint lBeginPos;
 
 	// Recherche du prochain bucket a trier
 	bucketToSort = NULL;
@@ -341,13 +344,18 @@ boolean KWChunkSorterTask::MasterPrepareTaskInput(double& dTaskPercent, boolean&
 		bucketToSort = buckets->GetBucketAt(nCurrentBucketIndexToSort);
 		nTreatedBucketNumber++;
 
-		// On doit trier un fichier si il n'est pas un sigleton.
+		// On doit trier un fichier si il n'est pas un singleton.
 		// De plus, les esclaves doivent egalement traiter les singletons quand les separateur sont differents.
 		// Dans ce dernier cas, les esclaves ne vont pas trier mais seulement reecrire le fichier pour changer le separateur.
 		if (not bucketToSort->IsSingleton() or not shared_bSameSeparator)
 		{
 			assert(bucketToSort->GetOutputFileName() == "");
 			break;
+		}
+		else
+		{
+			// Comptage des lignes
+			lSortedLinesNumber += bucketToSort->GetLineNumber();
 		}
 		nCurrentBucketIndexToSort++;
 	}
@@ -419,7 +427,7 @@ boolean KWChunkSorterTask::MasterFinalize(boolean bProcessEndedCorrectly)
 		// Sinon: c'est qu'il y a eu un arret utilisateur
 		else
 		{
-			// Suppression des fichiers non tries (normalement, ils sont supprimes apres le tri dans le SlaveProcess, mais on suppose qu'ils nont pas ete supprimes pusiqu'il y a une erreur)
+			// Suppression des fichiers non tries (normalement, ils sont supprimes apres le tri dans le SlaveProcess, mais on suppose qu'ils n'ont pas ete supprimes puisqu'il y a une erreur)
 			// (sauf dans le cas du tri InMemory, ou le chunk est le fichier d'entree)
 			if (not shared_bOnlyOneBucket)
 			{

--- a/src/Learning/KWDataUtils/KWChunkSorterTask.cpp
+++ b/src/Learning/KWDataUtils/KWChunkSorterTask.cpp
@@ -395,6 +395,7 @@ boolean KWChunkSorterTask::MasterFinalize(boolean bProcessEndedCorrectly)
 	int i;
 	int j;
 	KWSortBucket* bucket;
+	PLFileConcatenater concatenater;
 
 	// Construction de la liste des fichiers a concatener (et detruire ensuite)
 	bOk = bProcessEndedCorrectly;
@@ -413,16 +414,15 @@ boolean KWChunkSorterTask::MasterFinalize(boolean bProcessEndedCorrectly)
 				}
 			}
 			else
-				svResultFileNames.Add(buckets->GetBucketAt(i)->GetOutputFileName());
+				svResultFileNames.Add(bucket->GetOutputFileName());
 		}
 		// Sinon: c'est qu'il y a eu un arret utilisateur
 		else
 		{
-			// Suppression des fichiers non tries
+			// Suppression des fichiers non tries (normalement, ils sont supprimes apres le tri dans le SlaveProcess, mais on suppose qu'ils nont pas ete supprimes pusiqu'il y a une erreur)
 			// (sauf dans le cas du tri InMemory, ou le chunk est le fichier d'entree)
 			if (not shared_bOnlyOneBucket)
 			{
-				bucket = buckets->GetBucketAt(i);
 				for (j = 0; j < bucket->GetChunkFileNames()->GetSize(); j++)
 				{
 					PLRemoteFileService::RemoveFile(bucket->GetChunkFileNames()->GetAt(j));
@@ -433,7 +433,12 @@ boolean KWChunkSorterTask::MasterFinalize(boolean bProcessEndedCorrectly)
 	}
 
 	if (not bOk)
+	{
+		// Suppression des fichiers tries
+		concatenater.RemoveChunks(&svResultFileNames);
 		svResultFileNames.SetSize(0);
+	}
+
 	return bOk;
 }
 

--- a/src/Learning/KWDataUtils/KWChunkSorterTask.cpp
+++ b/src/Learning/KWDataUtils/KWChunkSorterTask.cpp
@@ -403,7 +403,7 @@ boolean KWChunkSorterTask::MasterFinalize(boolean bProcessEndedCorrectly)
 		bucket = buckets->GetBucketAt(i);
 
 		// Collecte du nom de fichier trie a concatener (puis detruire)
-		if (bucket->GetSorted())
+		if (bucket->GetSorted() or bucket->IsSingleton())
 		{
 			if (bucket->IsSingleton() and shared_bSameSeparator)
 			{

--- a/src/Learning/KWDataUtils/KWChunkSorterTask.h
+++ b/src/Learning/KWDataUtils/KWChunkSorterTask.h
@@ -22,6 +22,7 @@
 // Chaque fichier de bucket doit tenir en memoire
 // Les esclaves chargent un fichier different lors de chaque SlaveProcess
 // Les fichiers en entree sont supprimes a la fin de la tache
+// En cas d'erreur les fichiers de sortie (et les fichier d'entree) sont supprimes
 //
 class KWChunkSorterTask : public PLParallelTask
 {

--- a/src/Learning/KWDataUtils/KWFileSorter.cpp
+++ b/src/Learning/KWDataUtils/KWFileSorter.cpp
@@ -409,33 +409,6 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 					    SecondsToString(parallelSorter.GetMasterFinalizeElapsedTime()) + ")");
 				lObjectNumber = parallelSorter.GetSortedLinesNumber();
 
-				// Nettoyage des chunks en cas d'erreur
-				// sauf dans la cas (rare) ou on trie directement le fichier d'entree (auquel cas
-				// nSplitNumber==0) (on devrait etre en InMemory)
-				if (not bOk and nSplitNumber > 0)
-				{
-					assert(svChunkFileNames.GetSize() == 0);
-					for (i = 0; i < sortedBuckets.GetBucketNumber(); i++)
-					{
-						if (sortedBuckets.GetBucketAt(i)->GetSorted())
-							svChunkFileNames.Add(
-							    sortedBuckets.GetBucketAt(i)->GetOutputFileName());
-						else
-						{
-							for (j = 0; j < sortedBuckets.GetBucketAt(i)
-									    ->GetChunkFileNames()
-									    ->GetSize();
-							     j++)
-							{
-								svChunkFileNames.Add(sortedBuckets.GetBucketAt(i)
-											 ->GetChunkFileNames()
-											 ->GetAt(j));
-							}
-						}
-					}
-					concatenater.RemoveChunks(&svChunkFileNames);
-				}
-
 				// Concatenation
 				if (bOk)
 				{

--- a/src/Learning/KWDataUtils/KWFileSorter.cpp
+++ b/src/Learning/KWDataUtils/KWFileSorter.cpp
@@ -237,6 +237,7 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 			// Lancement de la tache KWChunkSorterTask sur un seul bucket
 			smallBucket = new KWSortBucket;
 			smallBucket->AddChunkFileName(sInputFileName);
+			smallBucket->SetChunkSize(lFileSize);
 			sortedBuckets.AddBucket(smallBucket);
 			parallelSorter.SetTaskUserLabel("In memory sort");
 			parallelSorter.SetBuckets(&sortedBuckets);
@@ -260,7 +261,7 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 				concatenater.SetDisplayProgression(false);
 
 				// Concatenation
-				concatenater.Concatenate(parallelSorter.GetSortedFiles(), this, true);
+				bOk = concatenater.Concatenate(parallelSorter.GetSortedFiles(), this, true);
 			}
 
 			bIsInterruptedByUser = parallelSorter.IsTaskInterruptedByUser();
@@ -296,6 +297,7 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 				sNewFileName = sInputFileName;
 
 			initBucket->AddChunkFileName(sNewFileName);
+			initBucket->SetChunkSize(lFileSize);
 			sortedBuckets.AddBucket(initBucket);
 			overweightBucket = sortedBuckets.GetOverweightBucket(nChunkSize);
 
@@ -398,7 +400,11 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 				parallelSorter.SetInputFieldSeparator(cInputFieldSeparator);
 				parallelSorter.SetInputHeaderLineUsed(bInputHeaderLineUsed);
 				parallelSorter.SetOutputFieldSeparator(cOutputFieldSeparator);
+
+				// Tri des fichiers.
+				// En cas d'erreur, les fichiers d'entree et de sortie sont nettoyes.
 				bOk = parallelSorter.Sort();
+				lObjectNumber = parallelSorter.GetSortedLinesNumber();
 				bIsInterruptedByUser = parallelSorter.IsTaskInterruptedByUser();
 				if (bTrace)
 					AddSimpleMessage(
@@ -407,7 +413,6 @@ boolean KWFileSorter::Sort(boolean bDisplayUserMessage)
 					    SecondsToString(parallelSorter.GetMasterInitializeElapsedTime()) +
 					    " finalize : " +
 					    SecondsToString(parallelSorter.GetMasterFinalizeElapsedTime()) + ")");
-				lObjectNumber = parallelSorter.GetSortedLinesNumber();
 
 				// Concatenation
 				if (bOk)

--- a/src/Learning/KWDataUtils/KWSortBuckets.cpp
+++ b/src/Learning/KWDataUtils/KWSortBuckets.cpp
@@ -563,7 +563,8 @@ KWSortBucket::KWSortBucket()
 	bLowerBoundExcluded = true;
 	bUpperBoundExcluded = true;
 	bSorted = false;
-	lFileSize = -1;
+	lFileSize = 0;
+	lLineNumber = 0;
 }
 
 KWSortBucket::~KWSortBucket() {}
@@ -588,6 +589,7 @@ void KWSortBucket::CopyFrom(const KWSortBucket* bSource)
 	sId = bSource->sId;
 	sOutputFileName = bSource->sOutputFileName;
 	lFileSize = bSource->lFileSize;
+	lLineNumber = bSource->lLineNumber;
 }
 
 boolean KWSortBucket::Check() const
@@ -714,9 +716,11 @@ void KWSortBucket::AddLine(const CharVector* cvLine)
 	// Ajout de la ligne
 	for (i = 0; i < cvLine->GetSize(); i++)
 		cvLines.Add(cvLine->GetAt(i));
+
+	lLineNumber++;
 }
 
-CharVector* KWSortBucket::GetChunk()
+CharVector* KWSortBucket::GetBuffer()
 {
 	return &cvLines;
 }
@@ -733,29 +737,10 @@ ALString KWSortBucket::GetId() const
 
 longint KWSortBucket::GetChunkSize()
 {
-	int i;
-
-	// Si on n'a pas la taille (deja calculee ou affectee) on la calcule
-	if (lFileSize == -1)
-	{
-		lFileSize = 0;
-		if (svChunkFileNames.GetSize() > 0)
-		{
-			for (i = 0; i < svChunkFileNames.GetSize(); i++)
-			{
-				lFileSize += PLRemoteFileService::GetFileSize(svChunkFileNames.GetAt(i));
-			}
-		}
-		else
-		{
-			ensure(GetSorted() or IsSingleton());
-			lFileSize = PLRemoteFileService::GetFileSize(sOutputFileName);
-		}
-	}
 	return lFileSize;
 }
 
-void KWSortBucket::SetChunkFileSize(longint lSize)
+void KWSortBucket::SetChunkSize(longint lSize)
 {
 	lFileSize = lSize;
 }
@@ -768,6 +753,16 @@ void KWSortBucket::SetSorted()
 boolean KWSortBucket::GetSorted() const
 {
 	return bSorted;
+}
+
+longint KWSortBucket::GetLineNumber() const
+{
+	return lLineNumber;
+}
+
+void KWSortBucket::SetLineNumber(longint lNumber)
+{
+	lLineNumber = lNumber;
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -816,6 +811,11 @@ void PLShared_SortBucket::SerializeObject(PLSerializer* serializer, const Object
 
 	// Id
 	serializer->PutString(bucket->sId);
+	serializer->PutLongint(bucket->lLineNumber);
+	serializer->PutLongint(bucket->lFileSize);
+
+	// Liste des fichiers
+	serializer->PutStringVector(&(bucket->svChunkFileNames));
 }
 
 void PLShared_SortBucket::DeserializeObject(PLSerializer* serializer, Object* o) const
@@ -834,6 +834,9 @@ void PLShared_SortBucket::DeserializeObject(PLSerializer* serializer, Object* o)
 	bucket->bLowerBoundExcluded = serializer->GetBoolean();
 	bucket->bUpperBoundExcluded = serializer->GetBoolean();
 	bucket->SetId(serializer->GetString());
+	bucket->lLineNumber = serializer->GetLongint();
+	bucket->lFileSize = serializer->GetLongint();
+	serializer->GetStringVector(&(bucket->svChunkFileNames));
 }
 
 int KWSortBucketCompareChunkSize(const void* first, const void* second)
@@ -844,7 +847,7 @@ int KWSortBucketCompareChunkSize(const void* first, const void* second)
 	aFirst = cast(KWSortBucket*, *(Object**)first);
 	aSecond = cast(KWSortBucket*, *(Object**)second);
 
-	return (aFirst->GetChunk()->GetSize() == aSecond->GetChunk()->GetSize()
+	return (aFirst->GetBuffer()->GetSize() == aSecond->GetBuffer()->GetSize()
 		    ? 0
-		    : (aFirst->GetChunk()->GetSize() > aSecond->GetChunk()->GetSize() ? -1 : 1));
+		    : (aFirst->GetBuffer()->GetSize() > aSecond->GetBuffer()->GetSize() ? -1 : 1));
 }

--- a/src/Learning/KWDataUtils/KWSortBuckets.cpp
+++ b/src/Learning/KWDataUtils/KWSortBuckets.cpp
@@ -748,7 +748,7 @@ longint KWSortBucket::GetChunkSize()
 		}
 		else
 		{
-			ensure(GetSorted());
+			ensure(GetSorted() or IsSingleton());
 			lFileSize = PLRemoteFileService::GetFileSize(sOutputFileName);
 		}
 	}

--- a/src/Learning/KWDataUtils/KWSortBuckets.h
+++ b/src/Learning/KWDataUtils/KWSortBuckets.h
@@ -191,17 +191,21 @@ public:
 	longint GetChunkSize();
 
 	// Affectation de la taille du chunck
-	void SetChunkFileSize(longint lSize);
+	void SetChunkSize(longint lSize);
 
-	// Acces au lignes contenues dans le chunk
+	// Ajout d'une ligne au chunk
 	void AddLine(const CharVector* cvline);
 
 	// Acces au buffer
-	CharVector* GetChunk();
+	CharVector* GetBuffer();
 
 	// Est-ce que le chunk est trie
 	void SetSorted();
 	boolean GetSorted() const;
+
+	// Renvoie le nombre de lignes contenues dans le bucket
+	longint GetLineNumber() const;
+	void SetLineNumber(longint lNumber);
 
 	///////////////////////////////////////////////////////////////////////////
 	// Services divers
@@ -236,6 +240,7 @@ protected:
 	boolean bLowerBoundExcluded;
 	boolean bUpperBoundExcluded;
 	boolean bSorted;
+	longint lLineNumber;
 
 	// Classes friend
 	friend class KWSortBuckets;
@@ -247,6 +252,7 @@ int KWSortBucketCompareChunkSize(const void* first, const void* second);
 ///////////////////////////////////////////////////
 // Classe PLShared_SortBucket
 // Serialisation de la classe KWSortBucket
+// Serialise tout sauf le contenu du bucket et le fichier de sortie
 class PLShared_SortBucket : public PLSharedObject
 {
 public:

--- a/src/Learning/KWDataUtils/KWSortBuckets.h
+++ b/src/Learning/KWDataUtils/KWSortBuckets.h
@@ -175,7 +175,7 @@ public:
 	///////////////////////////////////////////////////////////////////////////
 	// Gestion du contenu du chunk
 
-	// Fichier pour le contenu du chunk
+	// Fichier resultant de la concatenation des chunks
 	void SetOutputFileName(const ALString& sValue);
 	const ALString& GetOutputFileName() const;
 

--- a/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.cpp
+++ b/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.cpp
@@ -32,10 +32,8 @@ KWSortedChunkBuilderTask::KWSortedChunkBuilderTask()
 	DeclareTaskInput(&input_nBufferSize);
 	DeclareTaskInput(&input_lFilePos);
 
-	DeclareTaskOutput(&output_svBucketIds);
-	DeclareTaskOutput(&output_svBucketFilePath);
-	DeclareTaskOutput(&output_svBucketIds_dictionary);
-	DeclareTaskOutput(&output_ivBucketSize_dictionary);
+	output_oaBuckets = new PLShared_ObjectArray(new PLShared_SortBucket);
+	DeclareTaskOutput(output_oaBuckets);
 
 	shared_cInputFieldSeparator.SetValue('\t');
 }
@@ -43,6 +41,7 @@ KWSortedChunkBuilderTask::KWSortedChunkBuilderTask()
 KWSortedChunkBuilderTask::~KWSortedChunkBuilderTask()
 {
 	delete shared_oaBuckets;
+	delete output_oaBuckets;
 }
 
 void KWSortedChunkBuilderTask::SetFileURI(const ALString& sValue)
@@ -415,10 +414,11 @@ boolean KWSortedChunkBuilderTask::MasterPrepareTaskInput(double& dTaskPercent, b
 
 boolean KWSortedChunkBuilderTask::MasterAggregateResults()
 {
+	KWSortBucket* receivedBucket;
+	KWSortBucket* aggregatedBucket;
+	Object* object;
 	int i;
-	StringVector* svPath;
-	LongintObject* lBucketSize;
-	ALString sBucketId;
+	int j;
 
 	// Si tous les esclaves sont en sommeil, c'est qu'ils ont tous execute le dernier SlaveProcess
 	// Il faut les reveiller pour recevoir l'ordre d'arret
@@ -428,34 +428,31 @@ boolean KWSortedChunkBuilderTask::MasterAggregateResults()
 		bLastSlaveProcessDone = true;
 	}
 
-	// Pour chaque bucket
-	for (i = 0; i < output_svBucketIds.GetSize(); i++)
+	// Reception des buckets (il sont tous envoyes lors du dernier slaveProcess)
+	for (i = 0; i < output_oaBuckets->GetObjectArray()->GetSize(); i++)
 	{
-		svPath = cast(StringVector*, odBucketsFiles.Lookup(output_svBucketIds.GetAt(i)));
+		receivedBucket = cast(KWSortBucket*, output_oaBuckets->GetObjectArray()->GetAt(i));
+		aggregatedBucket = cast(KWSortBucket*, shared_oaBuckets->GetObjectArray()->GetAt(i));
 
-		// Creation d'une nouvelle clef si cet Id n'est pas deja present
-		if (svPath == NULL)
-		{
-			svPath = new StringVector;
-			odBucketsFiles.SetAt(output_svBucketIds.GetAt(i), svPath);
-		}
+		assert(aggregatedBucket->GetId() == receivedBucket->GetId());
 
-		// Ajout du chemin pour cet Id
-		svPath->Add(output_svBucketFilePath.GetAt(i));
-	}
+		// Aggregation des fichiers
+		for (j = 0; j < receivedBucket->GetChunkFileNames()->GetSize(); j++)
+			aggregatedBucket->AddChunkFileName(receivedBucket->GetChunkFileNames()->GetAt(j));
 
-	// Reception du dictionaire id bucket / size bucket
-	for (i = 0; i < output_svBucketIds_dictionary.GetSize(); i++)
-	{
-		sBucketId = output_svBucketIds_dictionary.GetAt(i);
+		// ... de la taille du chunk
+		aggregatedBucket->SetChunkSize(aggregatedBucket->GetChunkSize() + receivedBucket->GetChunkSize());
 
-		lBucketSize = cast(LongintObject*, odIdBucketsSize_master.Lookup(sBucketId));
-		if (lBucketSize == NULL)
-		{
-			lBucketSize = new LongintObject;
-			odIdBucketsSize_master.SetAt(sBucketId, lBucketSize);
-		}
-		lBucketSize->SetLongint(lBucketSize->GetLongint() + output_ivBucketSize_dictionary.GetAt(i));
+		// ... et du nombre de lignes
+		aggregatedBucket->SetLineNumber(aggregatedBucket->GetLineNumber() + receivedBucket->GetLineNumber());
+
+		// Verification que la taille calculee correspond a ce qui est sur le disque
+		debug(; longint lCheckedSize = 0;
+		      for (j = 0; j < aggregatedBucket->GetChunkFileNames()->GetSize(); j++) {
+			      lCheckedSize +=
+				  PLRemoteFileService::GetFileSize(aggregatedBucket->GetChunkFileNames()->GetAt(j));
+		      };
+		      ensure(aggregatedBucket->GetChunkSize() == lCheckedSize););
 	}
 
 	return true;
@@ -467,53 +464,9 @@ boolean KWSortedChunkBuilderTask::MasterFinalize(boolean bProcessEndedCorrectly)
 	KWSortBucket* bucket;
 	StringVector svChunks;
 	ALString sSortedFileName;
-	StringVector* svChunkFileNames;
 	StringVector svFilesToRemove;
 	PLFileConcatenater concatenater;
 	LongintObject* loBucketSize;
-
-	svChunkFileNames = NULL;
-
-	// Verification que la taille des buckets enregistree au long des slaveProcess est bien la bonne (par rapport a
-	// GetFileSize())
-	debug(; ALString sBucketID; Object * oElement; longint lComputeFileSize; StringVector * svBucketFiles;
-	      POSITION position = odIdBucketsSize_master.GetStartPosition(); while (position != NULL) {
-		      odIdBucketsSize_master.GetNextAssoc(position, sBucketID, oElement);
-		      loBucketSize = cast(LongintObject*, oElement);
-		      svBucketFiles = cast(StringVector*, odBucketsFiles.Lookup(sBucketID));
-		      assert(svBucketFiles != NULL);
-		      lComputeFileSize = 0;
-		      for (i = 0; i < svBucketFiles->GetSize(); i++)
-		      {
-			      lComputeFileSize += PLRemoteFileService::GetFileSize(svBucketFiles->GetAt(i));
-		      }
-		      assert(lComputeFileSize == loBucketSize->GetLongint());
-	      });
-
-	// Assignation de la liste des chunks a chaque bucket
-	if (bProcessEndedCorrectly and not TaskProgression::IsInterruptionRequested())
-	{
-		for (i = 0; i < shared_oaBuckets->GetObjectArray()->GetSize(); i++)
-		{
-			// Acces au bucket
-			bucket = cast(KWSortBucket*, shared_oaBuckets->GetObjectArray()->GetAt(i));
-
-			// Acces aux chunks de ce bucket
-			svChunkFileNames = cast(StringVector*, odBucketsFiles.Lookup(bucket->GetId()));
-			assert(svChunkFileNames != NULL);
-
-			// Si le bucket contient des fichiers on les ajoute
-			// (ce n'est pas forcement le cas on peur avoir un singleton [a,a] suivi de ]a,b[ qui peut etre
-			// vide)
-			if (svChunkFileNames != NULL)
-			{
-				bucket->SetChunkFileNames(svChunkFileNames);
-				loBucketSize = cast(LongintObject*, odIdBucketsSize_master.Lookup(bucket->GetId()));
-				if (loBucketSize != NULL)
-					bucket->SetChunkFileSize(loBucketSize->GetLongint());
-			}
-		}
-	}
 
 	// Nettoyage des resultats si erreur
 	if (not bProcessEndedCorrectly or TaskProgression::IsInterruptionRequested())
@@ -532,13 +485,9 @@ boolean KWSortedChunkBuilderTask::MasterFinalize(boolean bProcessEndedCorrectly)
 			else
 			{
 				// Acces aux chunks de ce bucket
-				svChunkFileNames = cast(StringVector*, odBucketsFiles.Lookup(bucket->GetId()));
-				if (svChunkFileNames != NULL)
+				for (j = 0; j < bucket->GetChunkFileNames()->GetSize(); j++)
 				{
-					for (j = 0; j < svChunkFileNames->GetSize(); j++)
-					{
-						svFilesToRemove.Add(svChunkFileNames->GetAt(j));
-					}
+					svFilesToRemove.Add(bucket->GetChunkFileNames()->GetAt(j));
 				}
 			}
 		}
@@ -548,7 +497,6 @@ boolean KWSortedChunkBuilderTask::MasterFinalize(boolean bProcessEndedCorrectly)
 	}
 
 	// Nettoyage
-	odBucketsFiles.DeleteAll();
 	odIdBucketsSize_master.DeleteAll();
 	return not TaskProgression::IsInterruptionRequested();
 }
@@ -602,9 +550,6 @@ boolean KWSortedChunkBuilderTask::SlaveProcess()
 	int nBucketToWriteIndex;
 	ObjectArray oaSortBucketsOnUsedMemory;
 	longint lBucketSizeMean;
-	POSITION position;
-	ALString sBucketID;
-	LongintObject* nBucketSize;
 	Object* oElement;
 	longint lBeginPos;
 	longint lMaxEndPos;
@@ -614,6 +559,10 @@ boolean KWSortedChunkBuilderTask::SlaveProcess()
 	PeriodicTest periodicTestInterruption;
 	boolean bIsLineOk;
 
+	// Le SlaveProcess a 2 phases:
+	// - la premiere phase (input_bLastRound==true) consite a lire le fichier, remplir les buckets et ecrire le contenu des bucket si il est trop gros
+	// - la seconde phase a lieu quand le fichier a ete lu completement, c'est l'ecriture de tous les buckets. C'est seulement dans cette phase que les buckets
+	//   sont envoyes au maitre (il n'y a rien a aggreger par le maitre avant la derniere phase).
 	if (not input_bLastRound)
 	{
 		// Specification de la portion du fichier a traiter
@@ -652,8 +601,7 @@ boolean KWSortedChunkBuilderTask::SlaveProcess()
 		keyExtractor.SetBufferedFile(&inputFile);
 
 		// Remplissage du buffer avec des lignes entieres dans la limite de la taille du buffer
-		// On reitere tant que l'on a pas atteint la derniere position pour lire toutes les ligne, y compris la
-		// derniere
+		// On reitere tant que l'on a pas atteint la derniere position pour lire toutes les ligne, y compris la derniere
 		while (bOk and lBeginPos < lMaxEndPos)
 		{
 			bOk = inputFile.FillOuterLinesUntil(lBeginPos, lMaxEndPos, bLineTooLong);
@@ -719,8 +667,7 @@ boolean KWSortedChunkBuilderTask::SlaveProcess()
 						// Mise a jour de la memoire utilisee
 						lBucketsUsedMemory += (nLineEndPos - nLineBeginPos) * sizeof(char);
 
-						// Ecriture des plus gros bucket si depassement de la memoire de
-						// l'esclave
+						// Ecriture des plus gros bucket si depassement de la memoire de l'esclave
 						if (lBucketsUsedMemory > shared_lMaxSlaveBucketMemory)
 						{
 							// Tri des bucket suivant la memoire utilise
@@ -737,8 +684,7 @@ boolean KWSortedChunkBuilderTask::SlaveProcess()
 							lBucketSizeMean =
 							    lBucketsUsedMemory / slaveBuckets.GetBucketNumber();
 
-							// Tant que la memoire utilise depasse la moitie de la memoire
-							// autorisee
+							// Tant que la memoire utilise depasse la moitie de la memoire autorisee
 							while (bOk and
 							       lBucketsUsedMemory > shared_lMaxSlaveBucketMemory / 2 and
 							       nBucketToWriteIndex <
@@ -751,12 +697,12 @@ boolean KWSortedChunkBuilderTask::SlaveProcess()
 
 								// Ecriture du bucket seulement il est plus gros que la
 								// moyenne des tailles des buckets stockes
-								if ((longint)(bucket->GetChunk()->GetSize() *
+								if ((longint)(bucket->GetBuffer()->GetSize() *
 									      sizeof(char)) > lBucketSizeMean)
 								{
 									// Mise a jour de la memoire utilisee
 									lBucketsUsedMemory -=
-									    bucket->GetChunk()->GetSize() *
+									    bucket->GetBuffer()->GetSize() *
 									    sizeof(char);
 
 									// Ecriture du bucket
@@ -780,17 +726,19 @@ boolean KWSortedChunkBuilderTask::SlaveProcess()
 		if (bOk)
 			SetLocalLineNumber(nCumulatedLineNumber);
 	}
-	else
+	else // if (not input_bLastRound)
 	{
+		// Deniere phase : ecriture du contenu de tous les chunks et serialisation des chunks
+
 		// On determine les buckets a ecrire
 		for (i = 0; i < slaveBuckets.GetBucketNumber(); i++)
 		{
 			bucket = slaveBuckets.GetBucketAt(i);
-			if (bucket->GetChunk()->GetSize() > 0)
+			if (bucket->GetBuffer()->GetSize() > 0)
 				oaBucketsToWrite.Add(bucket);
 		}
 
-		// Parcours des buckets a ecrire
+		// Ecriture des buckets
 		for (i = 0; i < oaBucketsToWrite.GetSize(); i++)
 		{
 			bucket = cast(KWSortBucket*, oaBucketsToWrite.GetAt(i));
@@ -802,24 +750,18 @@ boolean KWSortedChunkBuilderTask::SlaveProcess()
 				break;
 		}
 
-		// Transfert du dictionnaire bucket Id / bucket size
-		position = odIdBucketsSize_master.GetStartPosition();
-		while (position != NULL)
-		{
-			odIdBucketsSize_master.GetNextAssoc(position, sBucketID, oElement);
-			nBucketSize = cast(LongintObject*, oElement);
-			if (nBucketSize != NULL)
-			{
-				output_ivBucketSize_dictionary.Add(nBucketSize->GetLongint());
-				output_svBucketIds_dictionary.Add(sBucketID);
-			}
-		}
+		// Serialisation des buckets
+		output_oaBuckets->GetObjectArray()->CopyFrom(slaveBuckets.GetBuckets());
 	}
 
 	// Nettoyage en cas d'interruption (les noms des fichiers ne sont pas envoyes au maitre)
 	if (not bOk)
 	{
-		concatenater.RemoveChunks(output_svBucketFilePath.GetConstStringVector());
+		for (i = 0; i < slaveBuckets.GetBucketNumber(); i++)
+		{
+			bucket = slaveBuckets.GetBucketAt(i);
+			concatenater.RemoveChunks(bucket->GetChunkFileNames());
+		}
 	}
 	return bOk;
 }
@@ -828,13 +770,11 @@ boolean KWSortedChunkBuilderTask::SlaveFinalize(boolean bProcessEndedCorrectly)
 {
 	boolean bOk = true;
 
-	odIdBucketsSize_master.DeleteAll();
-
 	// Nettoyage
 	if (inputFile.IsOpened())
 		bOk = inputFile.Close();
 	keyExtractor.Clean();
-	slaveBuckets.DeleteAll();
+	slaveBuckets.RemoveAll();
 	return bOk;
 }
 
@@ -859,8 +799,7 @@ boolean KWSortedChunkBuilderTask::WriteBucket(KWSortBucket* bucketToWrite)
 			bucketToWrite->SetOutputFileName(sBucketFilePath);
 
 			// Envoi au master du nom du chunk associe au bucket
-			output_svBucketIds.Add(bucketToWrite->GetId());
-			output_svBucketFilePath.Add(FileService::BuildLocalURI(sBucketFilePath));
+			bucketToWrite->AddChunkFileName(FileService::BuildLocalURI(sBucketFilePath));
 			bufferedFile.SetFileName(sBucketFilePath);
 			bOk = bufferedFile.Open();
 		}
@@ -875,23 +814,14 @@ boolean KWSortedChunkBuilderTask::WriteBucket(KWSortBucket* bucketToWrite)
 	// Ecriture du contenu du bucket
 	if (bOk)
 	{
-		bOk = bufferedFile.Write(bucketToWrite->GetChunk());
+		bOk = bufferedFile.Write(bucketToWrite->GetBuffer());
 		bOk = bufferedFile.Close() and bOk;
 
 		// Mise a jour de la taille du bucket
-		lBucketSize = cast(LongintObject*, odIdBucketsSize_master.Lookup(bucketToWrite->GetId()));
-		if (lBucketSize == NULL)
-		{
-			lBucketSize = new LongintObject;
-			odIdBucketsSize_master.SetAt(bucketToWrite->GetId(), lBucketSize);
-		}
-		assert(lBucketSize->GetLongint() + bucketToWrite->GetChunk()->GetSize() ==
-		       PLRemoteFileService::GetFileSize(bufferedFile.GetFileName()));
+		bucketToWrite->SetChunkSize(bucketToWrite->GetChunkSize() + bucketToWrite->GetBuffer()->GetSize());
 
-		lBucketSize->SetLongint(lBucketSize->GetLongint() + bucketToWrite->GetChunk()->GetSize());
-
-		// On vide le bucket
-		bucketToWrite->GetChunk()->SetSize(0);
+		// On vide le contenu du bucket
+		bucketToWrite->GetBuffer()->SetSize(0);
 	}
 	else
 		AddError("Cannot open file  " + bufferedFile.GetFileName());

--- a/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.h
+++ b/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.h
@@ -56,6 +56,10 @@ public:
 	// En sortie chaque bucket contient un ensemble de fichiers (les chunks)
 	// Ces fichiers ne sont pas concatenes, les fichiers d'un bucket seront
 	// tous charges en memoire lors de la phase de tri (tache KWChunkSorterTask)
+	// En sortie, chaque bucket contient :
+	// - la liste des fichiers qui le constitue
+	// - le nombre de lignes de l'ensemble de ses fichiers
+	// - la taille de l'ensemble de ses fichiers
 	boolean BuildSortedChunks(const KWSortBuckets* buckets);
 
 	// Methode de test
@@ -99,9 +103,9 @@ protected:
 	ALString sFileURI;
 	boolean bHeaderLineUsed;
 	boolean bLastSlaveProcessDone;
-	ObjectDictionary
-	    odBucketsFiles; // Dictionnaire qui pour chaque bucketId donne la liste (StringVector) de ses fichiers
-	ObjectDictionary odIdBucketsSize_master; // Dictionnaire qui pour chaque bucketId donne sa taille
+
+	// Dictionnaire bucket ID / bucket size
+	ObjectDictionary odIdBucketsSize_master;
 	longint lInputFileSize;
 	longint lFilePos;
 
@@ -123,9 +127,6 @@ protected:
 
 	// Memoire utilisee par l'ensemble des buckets
 	longint lBucketsUsedMemory;
-
-	// Dictionnaire bucket ID / bucket size
-	ObjectDictionary odIdBucketsSize_slave;
 
 	// Fichier en lecture
 	InputBufferedFile inputFile;
@@ -152,8 +153,6 @@ protected:
 	///////////////////////////////////////////////////////////
 	// Parametres en entree et sortie des esclaves
 	PLShared_Boolean input_bLastRound;
-	PLShared_StringVector output_svBucketIds;
-	PLShared_StringVector output_svBucketFilePath;
 
 	// Taille du buffer en entree
 	PLShared_Int input_nBufferSize;
@@ -161,7 +160,5 @@ protected:
 	// Position dans le fichier
 	PLShared_Longint input_lFilePos;
 
-	// Serialization du dictionnaire bucket ID / Bucket size dans la derniere phase du SlaveProcess
-	PLShared_StringVector output_svBucketIds_dictionary;
-	PLShared_LongintVector output_ivBucketSize_dictionary;
+	PLShared_ObjectArray* output_oaBuckets;
 };

--- a/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
+++ b/src/Parallel/PLParallelTask/PLFileConcatenater.cpp
@@ -229,7 +229,10 @@ boolean PLFileConcatenater::Concatenate(const StringVector* svChunkURIs, const O
 
 			// Interruption ?
 			if (not bOk or TaskProgression::IsInterruptionRequested())
+			{
+				bOk = false;
 				break;
+			}
 
 			// Concatenation d'un nouveau chunk
 			if (PLRemoteFileService::FileExists(sChunkURI))


### PR DESCRIPTION
The bug was introduced in version 10.3.1. This occurs when there are singleton buckets (also known as 'elephant keys') and the same separator is used in the input and output files.