### PR TITLE
Fix bugs in debug mode

### DIFF
--- a/src/Learning/KWData/KWKey.cpp
+++ b/src/Learning/KWData/KWKey.cpp
@@ -82,8 +82,6 @@ void KWKey::BuildDistinctObjectLabels(const KWKey* otherKey, ALString& sObjectLa
 	int nFirstDistinctChar;
 	int i;
 
-	assert(svFields.GetSize() == otherKey->GetSize());
-
 	// Cas de libelles utilisateurs deja distincts
 	if (GetObjectLabel() != otherKey->GetObjectLabel())
 	{
@@ -93,6 +91,8 @@ void KWKey::BuildDistinctObjectLabels(const KWKey* otherKey, ALString& sObjectLa
 	// Sinon construction de libelles distincts
 	else
 	{
+		assert(svFields.GetSize() == otherKey->GetSize());
+
 		// Recherche du 1er champ qui differe
 		nFirstDistinctField = 0;
 		while (nFirstDistinctField < svFields.GetSize() and

--- a/src/Learning/KWDataPreparation/KWDataPreparationBivariateTask.cpp
+++ b/src/Learning/KWDataPreparation/KWDataPreparationBivariateTask.cpp
@@ -347,7 +347,7 @@ boolean KWDataPreparationBivariateTask::MasterFinalize(boolean bProcessEndedCorr
 	// Nettoyage des resultats en cas d'erreur
 	if (not bProcessEndedCorrectly or TaskProgression::IsInterruptionRequested())
 		oaMasterOutputAttributePairStats->DeleteAll();
-	assert(not bProcessEndedCorrectly or
+	assert(not bProcessEndedCorrectly or TaskProgression::IsInterruptionRequested() or
 	       oaMasterOutputAttributePairStats->GetSize() == oaInputAttributePairStats.GetSize());
 
 	// Appel de la methode ancetre


### PR DESCRIPTION
deplacements d'assertion qui n'etaient pas toujours verifiees la ou elles etaient testees

Suite au lancement de tout Learning en mode debug (-p 4 --max-test-time 10), il reste quelque bugs résiduels:

Assert failed in file src\Learning\KWData\KWKey.cpp line 85d	svFields.GetSize() == otherKey->GetSize()
TestKhiops MultiTables MultipleKey
TestKhiops MultiTables MultipleKeyNoHeaderLine
TestKhiops MultiTables OrphanRecords
TestKhiops ParallelTask TransferMTTinyRootTable
Assert failed in file src\Learning\KWDataPreparation\KWDataPreparationBivariateTask.cpp line 351d	not bProcessEndedCorrectly or oaMasterOutputAttributePairStats->GetSize() == oaInputAttributePairStats.GetSize()
TestKhiops CrashTests trainclassifier_KWDataPreparationBivariateTask