### PR TITLE
fix sort algorithm: singleton vs sorted buckets (#700)

### DIFF
--- a/src/Learning/KWDataUtils/KWChunkSorterTask.h
+++ b/src/Learning/KWDataUtils/KWChunkSorterTask.h
@@ -22,6 +22,7 @@
 // Chaque fichier de bucket doit tenir en memoire
 // Les esclaves chargent un fichier different lors de chaque SlaveProcess
 // Les fichiers en entree sont supprimes a la fin de la tache
+// En cas d'erreur les fichiers de sortie (et les fichier d'entree) sont supprimes
 //
 class KWChunkSorterTask : public PLParallelTask
 {

--- a/src/Learning/KWDataUtils/KWSortBuckets.h
+++ b/src/Learning/KWDataUtils/KWSortBuckets.h
@@ -175,7 +175,7 @@ public:
 	///////////////////////////////////////////////////////////////////////////
 	// Gestion du contenu du chunk
 
-	// Fichier pour le contenu du chunk
+	// Fichier resultant de la concatenation des chunks
 	void SetOutputFileName(const ALString& sValue);
 	const ALString& GetOutputFileName() const;
 
@@ -191,17 +191,21 @@ public:
 	longint GetChunkSize();
 
 	// Affectation de la taille du chunck
-	void SetChunkFileSize(longint lSize);
+	void SetChunkSize(longint lSize);
 
-	// Acces au lignes contenues dans le chunk
+	// Ajout d'une ligne au chunk
 	void AddLine(const CharVector* cvline);
 
 	// Acces au buffer
-	CharVector* GetChunk();
+	CharVector* GetBuffer();
 
 	// Est-ce que le chunk est trie
 	void SetSorted();
 	boolean GetSorted() const;
+
+	// Renvoie le nombre de lignes contenues dans le bucket
+	longint GetLineNumber() const;
+	void SetLineNumber(longint lNumber);
 
 	///////////////////////////////////////////////////////////////////////////
 	// Services divers
@@ -236,6 +240,7 @@ protected:
 	boolean bLowerBoundExcluded;
 	boolean bUpperBoundExcluded;
 	boolean bSorted;
+	longint lLineNumber;
 
 	// Classes friend
 	friend class KWSortBuckets;
@@ -247,6 +252,7 @@ int KWSortBucketCompareChunkSize(const void* first, const void* second);
 ///////////////////////////////////////////////////
 // Classe PLShared_SortBucket
 // Serialisation de la classe KWSortBucket
+// Serialise tout sauf le contenu du bucket et le fichier de sortie
 class PLShared_SortBucket : public PLSharedObject
 {
 public:

--- a/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.h
+++ b/src/Learning/KWDataUtils/KWSortedChunkBuilderTask.h
@@ -58,6 +58,10 @@ public:
 	// En sortie chaque bucket contient un ensemble de fichiers (les chunks)
 	// Ces fichiers ne sont pas concatenes, les fichiers d'un bucket seront
 	// tous charges en memoire lors de la phase de tri (tache KWChunkSorterTask)
+	// En sortie, chaque bucket contient :
+	// - la liste des fichiers qui le constitue
+	// - le nombre de lignes de l'ensemble de ses fichiers
+	// - la taille de l'ensemble de ses fichiers
 	boolean BuildSortedChunks(const KWSortBuckets* buckets);
 
 	// Methode de test
@@ -101,9 +105,9 @@ protected:
 	ALString sFileURI;
 	boolean bHeaderLineUsed;
 	boolean bLastSlaveProcessDone;
-	ObjectDictionary
-	    odBucketsFiles; // Dictionnaire qui pour chaque bucketId donne la liste (StringVector) de ses fichiers
-	ObjectDictionary odIdBucketsSize_master; // Dictionnaire qui pour chaque bucketId donne sa taille
+
+	// Dictionnaire bucket ID / bucket size
+	ObjectDictionary odIdBucketsSize_master;
 	longint lInputFileSize;
 	longint lFilePos;
 
@@ -125,9 +129,6 @@ protected:
 
 	// Memoire utilisee par l'ensemble des buckets
 	longint lBucketsUsedMemory;
-
-	// Dictionnaire bucket ID / bucket size
-	ObjectDictionary odIdBucketsSize_slave;
 
 	// Fichier en lecture
 	InputBufferedFile inputFile;
@@ -154,8 +155,6 @@ protected:
 	///////////////////////////////////////////////////////////
 	// Parametres en entree et sortie des esclaves
 	PLShared_Boolean input_bLastRound;
-	PLShared_StringVector output_svBucketIds;
-	PLShared_StringVector output_svBucketFilePath;
 
 	// Taille du buffer en entree
 	PLShared_Int input_nBufferSize;
@@ -163,7 +162,5 @@ protected:
 	// Position dans le fichier
 	PLShared_Longint input_lFilePos;
 
-	// Serialization du dictionnaire bucket ID / Bucket size dans la derniere phase du SlaveProcess
-	PLShared_StringVector output_svBucketIds_dictionary;
-	PLShared_LongintVector output_ivBucketSize_dictionary;
+	PLShared_ObjectArray* output_oaBuckets;
 };


### PR DESCRIPTION
* fix sort algorithm: singleton vs sorted buckets

bucket->GetSorted() return false if bucket is a singleton (new behavior in 10.3.1) Buckets must be concatenated if they are sorted OR singletons.

* Remove files in KWChunkSorterTask in case of errors (previously done outside the task)

* Fix GetSortedLineNumber() in KWChunkSorterTask

Line number is computed during the sort in the SlaveProcess. Singleton chunks, are not processed by SlaveProcess unless the separators are different. Therefore, lines are not counted. We now increment the lines of the singleton in the MasterPrepareInput.

Lines number is now aggregated in KWSortedChunkBuilderTask: the built buckets contains the size of the bucket and the lines number. Minor refactoring in KWSortedChunkBuilderTask: we no longer use an ObjectDictionary to store and access buckets, instead we access the buckets directly from the shared object array.