### PR TITLE
Signing on GitHub backport

### DIFF
--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
     }}
   cancel-in-progress: true
+env:
+  KEYPAIR_TEST: KP_Khiops_Test
+  KEYPAIR_PROD: KP_Khiops_HSM
 jobs:
   build:
     outputs:
@@ -59,6 +62,45 @@ jobs:
           targets: MODL MODL_Coclustering norm_jar khiops_jar KhiopsNativeInterface
             KNITransfer _khiopsgetprocnumber
           override-flags: -DTESTING=OFF -DBUILD_JARS=ON
+      - name: Install DigiCert Client tools from Github Custom Actions marketplace
+        uses: digicert/ssm-code-signing@v1.0.1
+      - name: Set up certificate
+        run: |
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12 
+        shell: bash
+      - name: Set variables for signature
+        id: variables-used-by-smctl
+        run: |
+          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV" 
+          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV" 
+          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV" 
+          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
+
+          # The production key is only used for releases from tags that are not release candidates or alpha
+          # Note: We use the production key for the beta releases because they are distributed to external users 
+          if [[ "${{ github.ref_type }}" == "tag" ]] && [[ "${{ github.ref_name  }}" != *"-rc."* ]] && [[ "${{ github.ref_name  }}" != *"-a."* ]]; then
+             echo "KEYPAIR=$KEYPAIR_PROD" >> "$GITHUB_ENV"
+             echo "::notice::Using Production key for signature"
+          else
+            echo "KEYPAIR=$KEYPAIR_TEST" >> "$GITHUB_ENV"
+            echo "::notice::Using Test key for signature"
+          fi
+        shell: bash
+      - name: Signing using keypair alias
+        run: |
+          OUTPUT=$(smctl sign --keypair-alias $KEYPAIR --config-file C/Users/RUNNER~1/AppData/Local/Temp/smtools-windows-x64/pkcs11properties.cfg --input build/windows-msvc-release/bin/MODL.exe)
+          echo $OUTPUT
+          echo $OUTPUT | grep -q SUCCESSFUL
+          OUTPUT=$(smctl sign --keypair-alias $KEYPAIR --config-file C/Users/RUNNER~1/AppData/Local/Temp/smtools-windows-x64/pkcs11properties.cfg --input build/windows-msvc-release/bin/MODL_Coclustering.exe)
+          echo $OUTPUT
+          echo $OUTPUT | grep -q SUCCESSFUL
+          OUTPUT=$(smctl sign --keypair-alias $KEYPAIR --config-file C/Users/RUNNER~1/AppData/Local/Temp/smtools-windows-x64/pkcs11properties.cfg --input build/windows-msvc-release/bin/_khiopsgetprocnumber.exe)
+          echo $OUTPUT
+          echo $OUTPUT | grep -q SUCCESSFUL
+          OUTPUT=$(smctl sign --keypair-alias $KEYPAIR --config-file C/Users/RUNNER~1/AppData/Local/Temp/smtools-windows-x64/pkcs11properties.cfg --input build/windows-msvc-release/bin/KhiopsNativeInterface.dll)
+          echo $OUTPUT
+          echo $OUTPUT | grep -q SUCCESSFUL
+        shell: bash
       - name: Build NSIS package
         shell: pwsh
         run: |-
@@ -75,6 +117,12 @@ jobs:
             /DKHIOPS_SAMPLES_DIR=..\..\..\assets\samples `
             /DKHIOPS_DOC_DIR=..\..\..\assets\doc `
             khiops.nsi
+      - name: Signing installer
+        run: |
+          OUTPUT=$(smctl sign --keypair-alias $KEYPAIR --config-file C/Users/RUNNER~1/AppData/Local/Temp/smtools-windows-x64/pkcs11properties.cfg --input packaging/windows/nsis/khiops-${{ env.KHIOPS_VERSION }}-setup.exe)
+          echo $OUTPUT
+          echo $OUTPUT | grep -q SUCCESSFUL
+        shell: bash
       - name: Build ZIP packages
         shell: bash
         run: |-
@@ -100,7 +148,7 @@ jobs:
             ./build/windows-msvc-release/packages/khiops-core-${{ env.KHIOPS_VERSION }}.zip
   test-khiops:
     needs: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Download NSIS installer artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -116,6 +116,9 @@ jobs:
             /DKHIOPS_COVIZ_INSTALLER_PATH=..\..\..\assets\${{ env.KHIOPS_COVIZ_FILENAME }} `
             /DKHIOPS_SAMPLES_DIR=..\..\..\assets\samples `
             /DKHIOPS_DOC_DIR=..\..\..\assets\doc `
+            /DSIGN `
+            /DKEYPAIR_ALIAS=$Env:KEYPAIR `
+            /DPATH_TO_CONFIG_FILE=C:\Users\RUNNER~1\AppData\Local\Temp\smtools-windows-x64\pkcs11properties.cfg `
             khiops.nsi
       - name: Signing installer
         run: |

--- a/packaging/windows/nsis/README.md
+++ b/packaging/windows/nsis/README.md
@@ -68,12 +68,11 @@ _Note 2_: If your are using powershell replace the `^` characters by backticks `
 multi-line command.
 
 ## Signature of the uninstaller
-The unsinstaller is signed during the packaging with [jsign](https://docs.digicert.com/en/software-trust-manager/code-signing/sign-with-third-party-signing-tools/general-packages/sign-authenticode-with-jsign-using-pkcs11-library.html). There are 4 additional parameters to enable the uninstaller signing:
+The unsinstaller is signed during the packaging with [smctl](https://docs.digicert.com/en/software-trust-manager/client-tools/signing-tools/smctl.html). There are 3 additional parameters to enable the uninstaller signing:
 
-- SIGN: if defined, enables the signing of the uninstaller. The 3 parameters below are mandatory only if SIGN is defined.
-- PATH_TO_JSIGN: path to [jsign.jar](https://docs.digicert.com/en/software-trust-manager/client-tools/signing-tools/third-party-signing-tool-integrations/jsign.html)
-- PKCS11_CONF: the SunPKCS11 configuration file.
-- KEY_PASSWORD: The password to open the keystore.
+- SIGN: if defined, enables the signing of the uninstaller. The 2 parameters below are mandatory only if SIGN is defined.
+- KEYPAIR_ALIAS: Keypair alias to be used for signing.
+- PATH_TO_CONFIG_FILE: Provide the path to the PKCS11 config file.
 
 ## Github Workflow
 This process is automatized in the [pack-nsis.yml workflow](../../../.github/workflows/pack-nsis.yml).

--- a/packaging/windows/nsis/khiops.nsi
+++ b/packaging/windows/nsis/khiops.nsi
@@ -53,10 +53,9 @@ ManifestDPIAware true
 
 # Sign uninstaller if requested
 !ifdef SIGN
-  !insertmacro CheckInputParameter PATH_TO_JSIGN
-  !insertmacro CheckInputParameter PKCS11_CONF
-  !insertmacro CheckInputParameter KEY_PASSWORD
-  !uninstfinalize java -Djava.security.debug=sunpkcs11,pkcs11 -jar ${PATH_TO_JSIGN} --keystore ${PKCS11_CONF} --storepass ${KEY_PASSWORD} --storetype PKCS11 --alias 'Orange SA' %1
+  !insertmacro CheckInputParameter KEYPAIR_ALIAS
+  !insertmacro CheckInputParameter PATH_TO_CONFIG_FILE
+  !uninstfinalize "smctl sign --keypair-alias ${KEYPAIR_ALIAS} --config-file ${PATH_TO_CONFIG_FILE} --input %1"
 !endif
 
 # Application name and installer file name


### PR DESCRIPTION
- Backport of the signature process done on dev-v10
- Modify nsi file to handle signature of the uninstaller inside the NSIS build.
- Unfortunately this last signature fails with the message "There were no files found for signing" but this problem does not affect the installation. I suggest to merge these features anyway and to create an issue about it.
