### PR TITLE
723 do not install pdf docs in windows installer

### DIFF
--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -47,13 +47,27 @@ jobs:
         uses: robinraju/release-downloader@v1.9
         with:
           repository: khiopsml/khiops-win-install-assets
-          tag: 11.0.0
+          tag: 11.0.1
       - name: Extract Windows installer assets and load assets-info.env
         shell: bash
         run: |
           assets_tar_gz=$(ls khiops-win-install-assets*.tar.gz)
           tar -zxvf "$assets_tar_gz"
           cat assets/assets-info.env >> "$GITHUB_ENV"
+      # We download the latest version of visualization tools: 
+      # - They are backward compatible.
+      # - The process is made easier by getting automatically the latest version
+      - name: Download latest releases of khiops-*visualization
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh --repo https://github.com/KhiopsML/kc-electron release download --pattern *.exe -D visualizations 
+          gh --repo https://github.com/KhiopsML/kv-electron release download --pattern *.exe -D visualizations
+          cd visualizations
+          ls *
+          echo "KHIOPS_VIZ_FILENAME=$(ls khiops-covisualization-Setup*)" >> "$GITHUB_ENV" 
+          echo "KHIOPS_COVIZ_FILENAME=$(ls khiops-visualization-Setup*)" >> "$GITHUB_ENV" 
       - name: Build the Khiops Binaries
         uses: ./.github/actions/build-khiops
         with:
@@ -115,8 +129,8 @@ jobs:
             /DJRE_PATH=..\..\..\assets\jre `
             /DMSMPI_INSTALLER_PATH=..\..\..\assets\${{ env.MSMPI_FILENAME }} `
             /DMSMPI_VERSION=${{ env.MSMPI_VERSION }} `
-            /DKHIOPS_VIZ_INSTALLER_PATH=..\..\..\assets\${{ env.KHIOPS_VIZ_FILENAME }} `
-            /DKHIOPS_COVIZ_INSTALLER_PATH=..\..\..\assets\${{ env.KHIOPS_COVIZ_FILENAME }} `
+            /DKHIOPS_VIZ_INSTALLER_PATH=..\..\..\visualizations\${{ env.KHIOPS_VIZ_FILENAME }} `
+            /DKHIOPS_COVIZ_INSTALLER_PATH=..\..\..\visualizations\${{ env.KHIOPS_COVIZ_FILENAME }} `
             /DKHIOPS_SAMPLES_DIR=..\..\..\assets\samples `
             /DSIGN `
             /DKEYPAIR_ALIAS=$Env:KEYPAIR `
@@ -134,8 +148,8 @@ jobs:
             /DJRE_PATH=..\..\..\assets\jre `
             /DMSMPI_INSTALLER_PATH=..\..\..\assets\${{ env.MSMPI_FILENAME }} `
             /DMSMPI_VERSION=${{ env.MSMPI_VERSION }} `
-            /DKHIOPS_VIZ_INSTALLER_PATH=..\..\..\assets\${{ env.KHIOPS_VIZ_FILENAME }} `
-            /DKHIOPS_COVIZ_INSTALLER_PATH=..\..\..\assets\${{ env.KHIOPS_COVIZ_FILENAME }} `
+            /DKHIOPS_VIZ_INSTALLER_PATH=..\..\..\visualizations\${{ env.KHIOPS_VIZ_FILENAME }} `
+            /DKHIOPS_COVIZ_INSTALLER_PATH=..\..\..\visualizations\${{ env.KHIOPS_COVIZ_FILENAME }} `
             /DKHIOPS_SAMPLES_DIR=..\..\..\assets\samples `
             khiops.nsi
       - name: Signing installer

--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -118,7 +118,6 @@ jobs:
             /DKHIOPS_VIZ_INSTALLER_PATH=..\..\..\assets\${{ env.KHIOPS_VIZ_FILENAME }} `
             /DKHIOPS_COVIZ_INSTALLER_PATH=..\..\..\assets\${{ env.KHIOPS_COVIZ_FILENAME }} `
             /DKHIOPS_SAMPLES_DIR=..\..\..\assets\samples `
-            /DKHIOPS_DOC_DIR=..\..\..\assets\doc `
             /DSIGN `
             /DKEYPAIR_ALIAS=$Env:KEYPAIR `
             /DPATH_TO_CONFIG_FILE=C:\Users\RUNNER~1\AppData\Local\Temp\smtools-windows-x64\pkcs11properties.cfg `
@@ -138,7 +137,6 @@ jobs:
             /DKHIOPS_VIZ_INSTALLER_PATH=..\..\..\assets\${{ env.KHIOPS_VIZ_FILENAME }} `
             /DKHIOPS_COVIZ_INSTALLER_PATH=..\..\..\assets\${{ env.KHIOPS_COVIZ_FILENAME }} `
             /DKHIOPS_SAMPLES_DIR=..\..\..\assets\samples `
-            /DKHIOPS_DOC_DIR=..\..\..\assets\doc `
             khiops.nsi
       - name: Signing installer
         if: env.SIGN == 'ON'

--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -17,6 +17,8 @@ concurrency:
   cancel-in-progress: true
 env:
   KEYPAIR: KP_Khiops_HSM
+  SAMPLES_VERSION: 11.0.0
+  ASSETS_VERSION: 11.0.1
 jobs:
   build:
     outputs:
@@ -47,7 +49,7 @@ jobs:
         uses: robinraju/release-downloader@v1.9
         with:
           repository: khiopsml/khiops-win-install-assets
-          tag: 11.0.1
+          tag: ${{ env.ASSETS_VERSION }}
       - name: Extract Windows installer assets and load assets-info.env
         shell: bash
         run: |
@@ -67,7 +69,15 @@ jobs:
           cd visualizations
           ls *
           echo "KHIOPS_VIZ_FILENAME=$(ls khiops-covisualization-Setup*)" >> "$GITHUB_ENV" 
-          echo "KHIOPS_COVIZ_FILENAME=$(ls khiops-visualization-Setup*)" >> "$GITHUB_ENV" 
+          echo "KHIOPS_COVIZ_FILENAME=$(ls khiops-visualization-Setup*)" >> "$GITHUB_ENV"
+      - name: Download samples
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh --repo https://github.com/KhiopsML/khiops-samples release download $SAMPLES_VERSION
+          unzip khiops-samples* -d samples
+          ls samples
       - name: Build the Khiops Binaries
         uses: ./.github/actions/build-khiops
         with:
@@ -131,7 +141,7 @@ jobs:
             /DMSMPI_VERSION=${{ env.MSMPI_VERSION }} `
             /DKHIOPS_VIZ_INSTALLER_PATH=..\..\..\visualizations\${{ env.KHIOPS_VIZ_FILENAME }} `
             /DKHIOPS_COVIZ_INSTALLER_PATH=..\..\..\visualizations\${{ env.KHIOPS_COVIZ_FILENAME }} `
-            /DKHIOPS_SAMPLES_DIR=..\..\..\assets\samples `
+            /DKHIOPS_SAMPLES_DIR=..\..\..\samples `
             /DSIGN `
             /DKEYPAIR_ALIAS=$Env:KEYPAIR `
             /DPATH_TO_CONFIG_FILE=C:\Users\RUNNER~1\AppData\Local\Temp\smtools-windows-x64\pkcs11properties.cfg `
@@ -150,7 +160,7 @@ jobs:
             /DMSMPI_VERSION=${{ env.MSMPI_VERSION }} `
             /DKHIOPS_VIZ_INSTALLER_PATH=..\..\..\visualizations\${{ env.KHIOPS_VIZ_FILENAME }} `
             /DKHIOPS_COVIZ_INSTALLER_PATH=..\..\..\visualizations\${{ env.KHIOPS_COVIZ_FILENAME }} `
-            /DKHIOPS_SAMPLES_DIR=..\..\..\assets\samples `
+            /DKHIOPS_SAMPLES_DIR=..\..\..\samples `
             khiops.nsi
       - name: Signing installer
         if: env.SIGN == 'ON'

--- a/packaging/windows/nsis/README.md
+++ b/packaging/windows/nsis/README.md
@@ -17,7 +17,6 @@ It also installs:
 - The JRE from [Eclipse Temurin](https://adoptium.net/fr/temurin/releases/)
 - The [sample datasets](https://github.com/KhiopsML/khiops-samples/releases/latest).
 - Documentation files:
-  - PDF Guides .
   - README.txt and WHATSNEW.txt (obtained from the sources at (../../common/khiops))
 
 ## How to obtain the package assets
@@ -51,7 +50,6 @@ makensis ^
    /DKHIOPS_VIZ_INSTALLER_PATH=.\assets\khiops-visualization-Setup-11.0.2.exe ^
    /DKHIOPS_COVIZ_INSTALLER_PATH=.\assets\khiops-covisualization-Setup-10.2.4.exe ^
    /DKHIOPS_SAMPLES_DIR=.\assets\samples ^
-   /DKHIOPS_DOC_DIR=.\assets\doc ^
    khiops.nsi
 ```
 The resulting installer will be at `packaging/windows/nsis/khiops-10.2.0-rc.1-setup.exe`.
@@ -92,4 +90,3 @@ All the arguments are mandatory except for `DEBUG` and `SIGN`, they must be pref
 - `KHIOPS_VIZ_INSTALLER_PATH`: Path to the Khiops Visualization installer.
 - `KHIOPS_COVIZ_INSTALLER_PATH`: Path to the Khiops Covisualization installer.
 - `KHIOPS_SAMPLES_DIR`: Path to the sample datasets directory.
-- `KHIOPS_DOC_DIR`: Path to the directory containing the documentation.

--- a/packaging/windows/nsis/khiops.nsi
+++ b/packaging/windows/nsis/khiops.nsi
@@ -49,7 +49,6 @@ ManifestDPIAware true
 !insertmacro CheckInputParameter MSMPI_INSTALLER_PATH
 !insertmacro CheckInputParameter MSMPI_VERSION
 !insertmacro CheckInputParameter KHIOPS_SAMPLES_DIR
-!insertmacro CheckInputParameter KHIOPS_DOC_DIR
 
 # Sign uninstaller if requested
 !ifdef SIGN
@@ -180,8 +179,6 @@ Section "Install" SecInstall
   File "/oname=LICENSE.txt" "..\..\..\LICENSE"
   File "..\..\common\khiops\README.txt"
   File "..\..\common\khiops\WHATSNEW.txt"
-  SetOutPath "$INSTDIR\doc"
-  File /nonfatal /a /r "${KHIOPS_DOC_DIR}\"
 
   # Install icons
   SetOutPath "$INSTDIR\bin\icons"
@@ -376,7 +373,7 @@ Section "Install" SecInstall
   ExpandEnvStrings $R0 "%COMSPEC%"
   CreateShortCut "$INSTDIR\Shell Khiops.lnk" "$INSTDIR\bin\shell_khiops.cmd" "" "$R0"
 
-  # Create start menu shortcuts for the executables and documentation
+  # Create start menu shortcuts for the executables
   DetailPrint "Installing Start menu Shortcut..."
   CreateDirectory "$SMPROGRAMS\Khiops"
   CreateShortCut "$SMPROGRAMS\Khiops\Khiops.lnk" "$INSTDIR\bin\khiops.cmd" "" "$INSTDIR\bin\icons\khiops.ico" 0 SW_SHOWMINIMIZED
@@ -384,12 +381,6 @@ Section "Install" SecInstall
   ExpandEnvStrings $R0 "%COMSPEC%"
   CreateShortCut "$SMPROGRAMS\Khiops\Shell Khiops.lnk" "$INSTDIR\bin\shell_khiops.cmd" "" "$R0"
   CreateShortCut "$SMPROGRAMS\Khiops\Uninstall.lnk" "$INSTDIR\uninstall-khiops.exe"
-  CreateDirectory "$SMPROGRAMS\Khiops\doc"
-  CreateShortCut "$SMPROGRAMS\Khiops\doc\Tutorial.lnk" "$INSTDIR\doc\KhiopsTutorial.pdf"
-  CreateShortCut "$SMPROGRAMS\Khiops\doc\Khiops.lnk" "$INSTDIR\doc\KhiopsGuide.pdf"
-  CreateShortCut "$SMPROGRAMS\Khiops\doc\Khiops Coclustering.lnk" "$INSTDIR\doc\KhiopsCoclusteringGuide.pdf"
-  CreateShortCut "$SMPROGRAMS\Khiops\doc\Khiops Visualization.lnk" "$INSTDIR\doc\KhiopsVisualizationGuide.pdf"
-  CreateShortCut "$SMPROGRAMS\Khiops\doc\Khiops Covisualization.lnk" "$INSTDIR\doc\KhiopsCovisualizationGuide.pdf"
   SetOutPath "$INSTDIR"
 
   # Define aliases for the following registry keys (also used in the uninstaller section)
@@ -521,7 +512,6 @@ Section "Uninstall"
   Delete "$INSTDIR\LICENSE.txt"
   Delete "$INSTDIR\README.txt"
   Delete "$INSTDIR\WHATSNEW.txt"
-  RMDir /r "$INSTDIR\doc"
 
   # Delete jre
   RMDir /r "$INSTDIR\jre"


### PR DESCRIPTION
The documentation is no longer packaged in the Windows installer.
Furthermore, the [assets repository](https://github.com/KhiopsML/khiops-win-install-assets) has been cleaned up (starting from tag 11.0.1). We removed:
- documentation
- Visualization tools
- samples

Only `msmpi` and `jre` remain. The samples and visualization tools are downloaded directly from their repositories before packaging.