### PR TITLE
Fix LearningTest V11 issues

### DIFF
--- a/test/LearningTestTool/py/_kht_utils.py
+++ b/test/LearningTestTool/py/_kht_utils.py
@@ -455,7 +455,7 @@ def read_file_lines(file_path, log_file=None, show=False):
     """
     # lecture des lignes du fichier
     try:
-        with open(file_path, "r", errors="ignore") as file:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as file:
             file_lines = file.readlines()
     except BaseException as exception:
         write_message(
@@ -476,7 +476,7 @@ def write_file_lines(
     """
     # lecture des lignes du fichier
     try:
-        with open(file_path, "w", errors="ignore") as file:
+        with open(file_path, "w", encoding="utf-8", errors="ignore") as file:
             for line in file_lines:
                 file.write(line)
                 if len(line) == 0 or line[-1] != "\n":


### PR DESCRIPTION
Correction dans _kht_utils.py
- read_file_lines: ouverture en forcant l'encodage a utf-8
  - les erreurs detectees sous linux ne l'étaient pas sous windows
  - peut-etre en raison d'un encodage implicite different
  - on detecte maintenant les erreur correctement

Traitement des differences de resultats provenant du LearningTest linux
- par mise a jour de la reference Windows, qui était fauuse mais avec des erreurs non detectees
  - TestKhiops  Advanced  MixedAsciiUTF8Chars  errors  17    Problem file types: .kdic, .kdicj, .khj
  - TestKhiops  TextVariables  BugEncoding  errors  2    Problem file types: .xls
- par prise en compte de la nouvelle version de la reference Windows, qui avait change
  - TestKhiops  JsonParameters  ErrorInconsistentJsonArray  errors  5    Problem file types: err.txt    Portability: Recovery of type 'Batch mode failure'
- par prise en compte de la nouvelle version de la reference Linuw
  - TestKhiops  CharacterEncoding  MultipleEncodingsFileSystem  errors  1    Problem file types: err.txt    Portability: used results.ref-Darwin_Linux dir among (results.ref, results.ref-Darwin_Linux), Recovery of type 'Batch mode failure'
  - TestKhiops  TextVariables  TextLoadFile  errors  6    Problem file types: err.txt    Portability: used results.ref-Darwin_Linux dir among (results.ref, results.ref-Darwin_Linux)
- non resolu: probleme de TIMOUT a ajuster?
  - TestKhiops  CrashTests  sort_KWKeySampleExtractorTask  errors  25    Problem file types: err.txt, .txt  TIMEOUT ERROR
  - TestKhiops  CrashTests  sort_KWSortedChunkBuilderTask  errors  21    Problem file types: err.txt, .txt  TIMEOUT ERROR