### PR TITLE
500 optimize task dimensioning for table creation rules

### DIFF
--- a/src/Learning/KWDRRuleLibrary/KWDRBuildRelation.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRBuildRelation.cpp
@@ -319,10 +319,14 @@ ObjectArray* KWDRBuildDummyTable::ComputeObjectArrayResult(const KWObject* kwoOb
 	}
 
 	// Creation des instances
+	oaResult.SetSize(nTableSize);
 	for (nObject = 0; nObject < nTableSize; nObject++)
 	{
 		kwoTargetContainedObject = NewTargetObject(kwoObject, liAttributeLoadIndex);
-		oaResult.Add(kwoTargetContainedObject);
+
+		// Alimentation de type calcul pour les operandes en entree correspondant
+		FillComputeModeTargetAttributesForVariableOperandNumber(kwoObject, kwoTargetContainedObject);
+		oaResult.SetAt(nObject, kwoTargetContainedObject);
 	}
 	return &oaResult;
 }

--- a/src/Learning/KWDRRuleLibrary/KWDRBuildRelation.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRBuildRelation.cpp
@@ -11,6 +11,7 @@ void KWDRRegisterBuildRelationRules()
 	KWDerivationRule::RegisterDerivationRule(new KWDRBuildEntityView);
 	KWDerivationRule::RegisterDerivationRule(new KWDRBuildEntityAdvancedView);
 	KWDerivationRule::RegisterDerivationRule(new KWDRBuildEntity);
+	KWDerivationRule::RegisterDerivationRule(new KWDRBuildDummyTable);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
@@ -253,6 +254,80 @@ KWObject* KWDRBuildEntity::ComputeObjectResult(const KWObject* kwoObject, const 
 }
 
 boolean KWDRBuildEntity::IsViewModeActivated() const
+{
+	return false;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////
+// Classe KWDRBuildDummyTable
+
+KWDRBuildDummyTable::KWDRBuildDummyTable()
+{
+	SetName("BuildDummyTable");
+	SetLabel("Build dummy table");
+	SetType(KWType::ObjectArray);
+
+	// Un operande, pour specifier le nombre d'instance a cree
+	SetOperandNumber(1);
+	GetFirstOperand()->SetType(KWType::Continuous);
+
+	// Variables en entree: une pour le nombre d'instance a cree,
+	// et un nombre variable d'operande pour alimenter les variables en sortie
+	SetOperandNumber(2);
+	GetFirstOperand()->SetType(KWType::Continuous);
+	GetSecondOperand()->SetType(KWType::Unknown);
+	SetVariableOperandNumber(true);
+
+	// Variables en sortie: nombre variable d'operandes pour alimenter la table en sortie
+	SetOutputOperandNumber(1);
+	GetOutputOperandAt(0)->SetType(KWType::Unknown);
+	SetVariableOutputOperandNumber(true);
+}
+
+KWDRBuildDummyTable::~KWDRBuildDummyTable() {}
+
+KWDerivationRule* KWDRBuildDummyTable::Create() const
+{
+	return new KWDRBuildDummyTable;
+}
+
+ObjectArray* KWDRBuildDummyTable::ComputeObjectArrayResult(const KWObject* kwoObject,
+							   const KWLoadIndex liAttributeLoadIndex) const
+{
+	const int nMaxTableSize = 1000000;
+	Continuous cTableSize;
+	int nTableSize;
+	KWObject* kwoTargetContainedObject;
+	int nObject;
+
+	require(IsCompiled());
+
+	// Calcul du resultat
+	oaResult.SetSize(0);
+
+	// Taille de la table a cree
+	cTableSize = GetFirstOperand()->GetContinuousValue(kwoObject);
+	nTableSize = 0;
+	if (cTableSize != KWContinuous::GetMissingValue())
+	{
+		if (cTableSize < 0)
+			nTableSize = 0;
+		else if (cTableSize > nMaxTableSize)
+			nTableSize = nMaxTableSize;
+		else
+			nTableSize = int(floor(cTableSize + 0.5));
+	}
+
+	// Creation des instances
+	for (nObject = 0; nObject < nTableSize; nObject++)
+	{
+		kwoTargetContainedObject = NewTargetObject(kwoObject, liAttributeLoadIndex);
+		oaResult.Add(kwoTargetContainedObject);
+	}
+	return &oaResult;
+}
+
+boolean KWDRBuildDummyTable::IsViewModeActivated() const
 {
 	return false;
 }

--- a/src/Learning/KWDRRuleLibrary/KWDRBuildRelation.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRBuildRelation.h
@@ -12,6 +12,7 @@ class KWDRBuildTableAdvancedView;
 class KWDRBuildEntityView;
 class KWDRBuildEntityAdvancedView;
 class KWDRBuildEntity;
+class KWDRBuildDummyTable;
 
 #include "KWDerivationRule.h"
 #include "KWRelationCreationRule.h"
@@ -118,6 +119,31 @@ public:
 	///////////////////////////////////////////////////////
 	///// Implementation
 protected:
-	// Pas d'alimenattionde type vue
+	// Pas d'alimentation de type vue
+	boolean IsViewModeActivated() const override;
+};
+
+////////////////////////////////////////////////////////////////////////////
+// Classe KWDRBuildDummyTable
+// Creation d'une table factice avec autant d'instances que specifie en parametre
+// Regle interne, uniquement pour des raison de test de volumetrie
+class KWDRBuildDummyTable : public KWDRTableCreationRule
+{
+public:
+	// Constructeur
+	KWDRBuildDummyTable();
+	~KWDRBuildDummyTable();
+
+	// Creation
+	KWDerivationRule* Create() const override;
+
+	// Calcul de l'attribut derive
+	ObjectArray* ComputeObjectArrayResult(const KWObject* kwoObject,
+					      const KWLoadIndex liAttributeLoadIndex) const override;
+
+	///////////////////////////////////////////////////////
+	///// Implementation
+protected:
+	// Pas d'alimentation de type vue
 	boolean IsViewModeActivated() const override;
 };

--- a/src/Learning/KWData/KWClass.h
+++ b/src/Learning/KWData/KWClass.h
@@ -46,8 +46,8 @@ class KWDerivationRule;
 //    false: objet interne
 //    true: objet reference
 //
-// MEMORY
-// Une KWClass contient et gere sa description(a savoir ses variables,
+// Memoire
+// Une KWClass contient et gere sa description (a savoir ses variables,
 // ses containers, et le contenu de ses containers)
 // Les KWClass referencees sont par contre independantes.
 class KWClass : public Object
@@ -455,6 +455,18 @@ public:
 
 	// Export des noms des attributs cles dans l'ordre des cles
 	void ExportKeyAttributeNames(StringVector* svAttributedNames) const;
+
+	////////////////////////////////////////////////////////
+	// Services de dimensionnement
+
+	// Estimation heuristique de la memoire utilise par KWObject en se basant sur les
+	// variables utilisees, natives ou calculees
+	// La memoire utilisee par les sous-objet de la composition n'est pas prise en compte
+	longint GetEstimatedUsedMemoryPerObject() const;
+
+	// Constantes pour l'estimation heuristique de la taille des champs en memoire
+	static const int nTextValueSize = 200;
+	static const int nKeyFieldSize = 5;
 
 	////////////////////////////////////////////////////////
 	// Services standard

--- a/src/Learning/KWData/KWDataPath.cpp
+++ b/src/Learning/KWData/KWDataPath.cpp
@@ -4,12 +4,16 @@
 
 #include "KWDataPath.h"
 
+// Inclusion de ce header dans le source pour eviter une dependance cyclique
+#include "KWClass.h"
+
 ////////////////////////////////////////////////////////////
 // Classe KWDataPath
 
 KWDataPath::KWDataPath()
 {
 	bExternalTable = false;
+	dataPathManager = NULL;
 }
 
 KWDataPath::~KWDataPath() {}
@@ -149,6 +153,7 @@ void KWDataPath::CopyFrom(const KWDataPath* aSource)
 	sOriginClassName = aSource->sOriginClassName;
 	svAttributeNames.CopyFrom(&aSource->svAttributeNames);
 	sClassName = aSource->sClassName;
+	dataPathManager = aSource->dataPathManager;
 }
 
 KWDataPath* KWDataPath::Create() const
@@ -343,238 +348,7 @@ longint KWDataPath::GetUsedMemory() const
 }
 
 ////////////////////////////////////////////////////////////
-// Classe KWObjectDataPath
-
-KWObjectDataPath::KWObjectDataPath()
-{
-	bCreatedObjects = false;
-	lMainCreationIndex = 0;
-	lCreationNumber = 0;
-	dataPathManager = NULL;
-	nCompiledRandomSeed = 0;
-	nCompiledRandomLeap = 0;
-	nCompileHash = 0;
-}
-
-KWObjectDataPath::~KWObjectDataPath() {}
-
-boolean KWObjectDataPath::IsRuleCreationManaged() const
-{
-	return true;
-}
-
-void KWObjectDataPath::ResetCreationNumber(longint lNewMainCreationIndex) const
-{
-	int n;
-	KWObjectDataPath* componentDataPath;
-
-	require(IsCompiled());
-	require(lNewMainCreationIndex >= 0);
-
-	// Reinitialisation des index
-	lMainCreationIndex = lNewMainCreationIndex;
-	lCreationNumber = 0;
-
-	// Propagation aux sous data paths
-	for (n = 0; n < oaComponents.GetSize(); n++)
-	{
-		componentDataPath = cast(KWObjectDataPath*, oaComponents.GetAt(n));
-		componentDataPath->ResetCreationNumber(lMainCreationIndex);
-	}
-}
-
-void KWObjectDataPath::CopyFrom(const KWDataPath* aSource)
-{
-	const KWObjectDataPath* sourceObjectDataPath;
-
-	require(aSource != NULL);
-
-	// Methode ancetre
-	KWDataPath::CopyFrom(aSource);
-
-	// Specialisation
-	sourceObjectDataPath = cast(const KWObjectDataPath*, aSource);
-	bCreatedObjects = sourceObjectDataPath->bCreatedObjects;
-
-	// Nettoyage des attributs de composition ou de gestion
-	lCreationNumber = 0;
-	oaComponents.SetSize(0);
-	dataPathManager = NULL;
-	liCompiledTerminalAttributeLoadIndex.Reset();
-	nCompiledRandomSeed = 0;
-	nCompiledRandomLeap = 0;
-	oaCompiledComponentDataPathsByLoadIndex.SetSize(0);
-	nCompileHash = 0;
-}
-
-KWDataPath* KWObjectDataPath::Create() const
-{
-	return new KWObjectDataPath;
-}
-
-int KWObjectDataPath::Compare(const KWDataPath* aSource) const
-{
-	int nCompare;
-
-	require(aSource != NULL);
-
-	// Methode ancetre
-	nCompare = KWDataPath::Compare(aSource);
-
-	// Specialisation
-	if (nCompare == 0)
-		nCompare =
-		    CompareBoolean(GetCreatedObjects(), cast(const KWObjectDataPath*, aSource)->GetCreatedObjects());
-	return nCompare;
-}
-
-void KWObjectDataPath::Write(ostream& ost) const
-{
-	KWDataPath::Write(ost);
-	ost << "Created objects\t" << BooleanToString(GetCreatedObjects()) << "\n";
-}
-
-void KWObjectDataPath::WriteHeaderLineReport(ostream& ost) const
-{
-	KWDataPath::WriteHeaderLineReport(ost);
-	ost << "\tCreated";
-}
-
-void KWObjectDataPath::WriteLineReport(ostream& ost) const
-{
-	KWDataPath::WriteLineReport(ost);
-	ost << "\t";
-	if (GetCreatedObjects())
-		ost << "*";
-}
-
-longint KWObjectDataPath::GetUsedMemory() const
-{
-	longint lUsedMemory;
-
-	// Methode ancetre
-	lUsedMemory = KWDataPath::GetUsedMemory();
-	lUsedMemory += sizeof(KWObjectDataPath) - sizeof(KWDataPath);
-
-	// Specialisation
-	lUsedMemory += oaComponents.GetUsedMemory();
-	lUsedMemory += oaCompiledComponentDataPathsByLoadIndex.GetUsedMemory();
-	return lUsedMemory;
-}
-
-void KWObjectDataPath::Compile(const KWClass* mainClass)
-{
-	KWClass* kwcOriginClass;
-	KWClass* currentClass;
-	KWAttribute* currentAttribute;
-	int n;
-	KWObjectDataPath* componentDataPath;
-	ALString sSeedEncoding;
-	ALString sLeapEncoding;
-	ALString sTmp;
-
-	require(mainClass != NULL);
-	require(mainClass->IsCompiled());
-	require(Check());
-
-	// Arret si deja compile
-	if (IsCompiled())
-		return;
-
-	// Recherche de la classe origine
-	kwcOriginClass = mainClass->GetDomain()->LookupClass(sOriginClassName);
-	assert(kwcOriginClass != NULL);
-	assert(kwcOriginClass == mainClass or kwcOriginClass->GetName() != mainClass->GetName());
-
-	// Recherche de l'index de chargement du dernier attribut du data path et de sa class extremite
-	liCompiledTerminalAttributeLoadIndex.Reset();
-	currentClass = kwcOriginClass;
-	for (n = 0; n < GetDataPathAttributeNumber(); n++)
-	{
-		// Recherche de l'attribut
-		currentAttribute = currentClass->LookupAttribute(GetDataPathAttributeNameAt(n));
-		assert(currentAttribute != NULL);
-		assert(currentAttribute->GetLoaded());
-		assert(currentAttribute->GetLoadIndex().IsDense());
-		assert(KWType::IsRelation(currentAttribute->GetType()));
-		assert(currentAttribute->GetDerivationRule() == NULL or
-		       not currentAttribute->GetDerivationRule()->GetReference());
-
-		// Memorisation de son index de chargement
-		liCompiledTerminalAttributeLoadIndex.lFullIndex = currentAttribute->GetLoadIndex().lFullIndex;
-
-		// Changement de classe courante
-		currentClass = currentAttribute->GetClass();
-	}
-
-	// Compilation des sous data paths, por acceder a leurs services
-	for (n = 0; n < oaComponents.GetSize(); n++)
-	{
-		componentDataPath = cast(KWObjectDataPath*, oaComponents.GetAt(n));
-		componentDataPath->Compile(mainClass);
-	}
-
-	// Utilisation de la partie dense des index de chargement des attributs pour un acces direct aux sous data path
-	// Cet index ne peut depasser le nombre d'attributs charges en memoire de la classe terminale du data path
-	oaCompiledComponentDataPathsByLoadIndex.RemoveAll();
-	if (oaComponents.GetSize() > 0)
-	{
-		// Acces au dernier sous data path, pour avoir la valeur max d'index
-		componentDataPath = cast(KWObjectDataPath*, oaComponents.GetAt(oaComponents.GetSize() - 1));
-
-		// Retaillage du tableau compile
-		oaCompiledComponentDataPathsByLoadIndex.SetSize(
-		    componentDataPath->GetTerminalLoadIndex().GetDenseIndex() + 1);
-
-		// Memorisation de chaque sous data path selon son index dense
-		for (n = 0; n < oaComponents.GetSize(); n++)
-		{
-			componentDataPath = cast(KWObjectDataPath*, oaComponents.GetAt(n));
-			oaCompiledComponentDataPathsByLoadIndex.SetAt(
-			    componentDataPath->GetTerminalLoadIndex().GetDenseIndex(), componentDataPath);
-		}
-	}
-
-	// Initialisation des parametres de generateur aleatoire par hashage de chaines de caractere
-	// dependant du nom de la classe origine et du data path
-	sSeedEncoding = sTmp + "DataPathSeed" + kwcOriginClass->GetName() + "///" + GetDataPath() + "DataPathSeed";
-	sLeapEncoding = sTmp + "DataPathLeap" + kwcOriginClass->GetName() + "///" + GetDataPath() + "DataPathLeap";
-	sLeapEncoding.MakeReverse();
-	nCompiledRandomSeed = HashValue(sSeedEncoding);
-	nCompiledRandomLeap = HashValue(sLeapEncoding);
-
-	// On interdit un Leap de 0
-	n = 0;
-	while (nCompiledRandomLeap == 0)
-	{
-		sLeapEncoding += "_";
-		sLeapEncoding += IntToString(n);
-		nCompiledRandomLeap = HashValue(sLeapEncoding);
-		n++;
-	}
-
-	// Calcul de hash de compilation
-	nCompileHash = HashValue(GetDataPath());
-
-	ensure(IsCompiled());
-}
-
-boolean KWObjectDataPath::IsCompiled() const
-{
-	return nCompiledRandomLeap != 0 and nCompileHash == HashValue(GetDataPath());
-}
-
-const KWObjectDataPathManager* KWObjectDataPath::GetDataPathManager() const
-{
-	return dataPathManager;
-}
-
-void KWObjectDataPath::SetDataPathManager(const KWObjectDataPathManager* manager)
-{
-	dataPathManager = manager;
-}
-
-////////////////////////////////////////////////////////////
+// Classe KWDataPathManager
 
 KWDataPathManager::KWDataPathManager()
 {
@@ -993,6 +767,7 @@ KWDataPath* KWDataPathManager::CreateDataPath(ObjectDictionary* odReferenceClass
 	dataPath->SetClassName(mappedClass->GetName());
 	dataPath->SetOriginClassName(sOriginClassName);
 	dataPath->GetAttributeNames()->CopyFrom(svAttributeNames);
+	dataPath->SetDataPathManager(this);
 	assert(LookupDataPath(dataPath->GetDataPath()) == NULL);
 
 	// Memorisation de ce dataPath dans le tableau exhaustif de tous les dataPath
@@ -1128,62 +903,4 @@ void KWDataPathManager::WriteDataPathArray(ostream& ost, const ALString& sTitle,
 		dataPath->WriteLineReport(ost);
 		ost << "\n";
 	}
-}
-
-////////////////////////////////////////////////////////////
-// Classe KWObjectDataPathManager
-
-KWObjectDataPathManager::KWObjectDataPathManager()
-{
-	// Specifialisation des objet data path crees par la classe
-	delete dataPathCreator;
-	dataPathCreator = new KWObjectDataPath;
-}
-
-KWObjectDataPathManager::~KWObjectDataPathManager() {}
-
-void KWObjectDataPathManager::ComputeAllDataPaths(const KWClass* mainClass)
-{
-	int i;
-	KWObjectDataPath* objectDataPath;
-
-	// Methode ancetre
-	KWDataPathManager::ComputeAllDataPaths(mainClass);
-
-	// Specialisation par optimisation des data paths
-	for (i = 0; i < oaDataPaths.GetSize(); i++)
-	{
-		objectDataPath = cast(KWObjectDataPath*, oaDataPaths.GetAt(i));
-
-		// Compilation
-		objectDataPath->Compile(mainClass);
-	}
-}
-
-void KWObjectDataPathManager::CopyFrom(const KWDataPathManager* aSource)
-{
-	int i;
-	KWObjectDataPath* objectDataPath;
-	KWClass* kwcMainClass;
-
-	// Methode ancetre
-	KWDataPathManager::CopyFrom(aSource);
-
-	// Specialisation par optimisation des data paths
-	kwcMainClass = KWClassDomain::GetCurrentDomain()->LookupClass(GetMainClassName());
-	if (kwcMainClass != NULL)
-	{
-		for (i = 0; i < oaDataPaths.GetSize(); i++)
-		{
-			objectDataPath = cast(KWObjectDataPath*, oaDataPaths.GetAt(i));
-
-			// Compilation
-			objectDataPath->Compile(kwcMainClass);
-		}
-	}
-}
-
-KWDataPathManager* KWObjectDataPathManager::Create() const
-{
-	return new KWObjectDataPathManager;
 }

--- a/src/Learning/KWData/KWDataPath.h
+++ b/src/Learning/KWData/KWDataPath.h
@@ -5,11 +5,12 @@
 #pragma once
 
 class KWDataPath;
-class KWObjectDataPath;
 class KWDataPathManager;
-class KWObjectDataPathManager;
+class KWClass;
 
-#include "KWClass.h"
+#include "Object.h"
+#include "Vector.h"
+#include "KWLoadIndex.h"
 
 ////////////////////////////////////////////////////////////
 // Classe KWDataPath
@@ -176,154 +177,21 @@ public:
 	////////////////////////////////////////////////////////
 	//// Implementation
 protected:
+	friend class KWDataPathManager;
+
+	// Gestionnaire de DataPath
+	const KWDataPathManager* GetDataPathManager() const;
+	void SetDataPathManager(const KWDataPathManager* manager);
+
 	// Attributs de la classe
 	boolean bExternalTable;
 	ALString sOriginClassName;
 	StringVector svAttributeNames;
 	ALString sClassName;
 	ObjectArray oaComponents;
-};
-
-////////////////////////////////////////////////////////////
-// Classe KWObjectDataPath
-//
-// Specialisation de KWDataPath a destination des KWObject pour identifier de facon unique
-// chaque objet, qu'il soient stocke ou cree par une regle de derivation
-// Cet identifiant unique des KWObject exploite
-// - le data path de l'objet, qu'il soit lu ou cree par une regle
-// - le CreationIndex de l'object
-//   - s'il s'agit d'un objet lu: numero de ligne
-//   - s'il s'agit d'un objet cree par une regle
-//     - numero de creation local a son instance principale, plus CreationIndex de l'instance principal
-//     - dans le cas des table externe, le numero est local a l'ensemble de toutes les instances
-// Cette identication permet a la regle de derivation Random de generer des suites de valeurs aleatoires
-// de facon reproductible, et independantes entre elles si la regle Random est utilisee plusieurs fois.
-class KWObjectDataPath : public KWDataPath
-{
-public:
-	// Constructeur
-	KWObjectDataPath();
-	~KWObjectDataPath();
-
-	// Indique que la classe gere les data paths correspondant a des instances crees par des regle de creation d'instance
-	boolean IsRuleCreationManaged() const override;
-
-	// Indique si le data path correspond a des objets crees par des regles de creation d'instances
-	// (defaut: false, correspondant a des objet stockes dans des fichiers)
-	boolean GetCreatedObjects() const override;
-	void SetCreatedObjects(boolean bValue) override;
-
-	////////////////////////////////////////////////////////////////////////
-	// Service de navigation dans les data paths
-
-	// Acces au data path fils pour un index d'attribut relationnel du dictionnaire extremite
-	const KWObjectDataPath* GetComponentDataPath(const KWLoadIndex liAttributeLoadIndex) const;
-
-	////////////////////////////////////////////////////////////////////////
-	// Service d'identification des objets d'un schema multi-table
-	//
-	// Identifiant unique d'un objet dans une hierarchie de donnees multi-table,
-	//  que les donnees soit stockee et lue depuis des fichier ou crees en memoire
-	//  via des regles de derivation de creation d'instance
-	// Utilisation des CreationIndex: cf. KWObject::GetCreationIndex()
-	//   - objets stockes: CreationIndex unique et reproductible, base sur un numero de ligne dans un fichier
-	//   - objets crees: CreationIndex unique, base sur un compteur de creation d'instance local au data path
-	// Les objets crees peuvent alors etre identifie de facon unique par le CreationIndex de leur instance
-	// principale (main ou Root), et leur CreationIndex localement a cette instance stockee.
-
-	// Reinitialisation du compteur de creation d'instance, a appeler a chaque changement
-	// d'objet principal (racine de l'objet principal d'un schema multi-table), ou Root (racine dans le cas d'une table externe)
-	// Cette reinitialisation est propagee a tous
-	void ResetCreationNumber(longint lNewMainCreationIndex) const;
-
-	// Index de creation principal, servant de reference aux instances crees dans son contexte
-	longint GetMainCreationIndex() const;
-
-	// Obtention d'un nouvel index de creation, a memoirser our chaque nouvel objet cree
-	longint NewCreationIndex() const;
-
-	// Acces au nombre d'objet crees
-	longint GetCreationNumber() const;
-
-	////////////////////////////////////////////////////////////////////////
-	// Services de parametrage (Seed, Leap) de generateur pseudo-aleatoire par hashage du data path,
-	// pour le parametrage des generateur de nombre aleatoire, avec garantie de reproductibilite
-	// en calcul distribue, et d'independance entre les series aleatoire generes par differents
-	// appels a la regle de derivation Random
-
-	// Graine de generateur aleatoire
-	int GetRandomSeed() const;
-
-	// Saut de type leap frog d'un generateur aleatoire
-	int GetRandomLeap() const;
-
-	////////////////////////////////////////////////////////
-	// Divers
-
-	// Copie
-	void CopyFrom(const KWDataPath* aSource) override;
-
-	// Creation pour renvoyer une instance du meme type dynamique
-	KWDataPath* Create() const override;
-
-	// Comparaison
-	int Compare(const KWDataPath* aSource) const override;
-
-	// Ecriture
-	void Write(ostream& ost) const override;
-	void WriteHeaderLineReport(ostream& ost) const override;
-	void WriteLineReport(ostream& ost) const override;
-
-	// Memoire utilisee par le mapping
-	longint GetUsedMemory() const override;
-
-	////////////////////////////////////////////////////////
-	//// Implementation
-protected:
-	friend class KWObjectDataPathManager;
-
-	// Compilation pour avoir acces efficacement aux services avances
-	void Compile(const KWClass* mainClass);
-	boolean IsCompiled() const;
-
-	// Index de chargement de la derniere variable du data path, aboutissant a son extremite
-	const KWLoadIndex GetTerminalLoadIndex() const;
-
-	// Gestionnaire de DataPath
-	const KWObjectDataPathManager* GetDataPathManager() const;
-	void SetDataPathManager(const KWObjectDataPathManager* manager);
-
-	/////////////////////////////////////////////////////////////////////
-	// Attributs de base
-
-	// Indicateur de data path dedie a des objets crees par des regles de creation d'instances
-	boolean bCreatedObjects;
-
-	// Index de creation principal, servant de reference aux instances crees dans son contexte
-	mutable longint lMainCreationIndex;
-
-	// Nombre d'index de creation generes
-	mutable longint lCreationNumber;
 
 	// Gestionnaire de data path
-	const KWObjectDataPathManager* dataPathManager;
-
-	/////////////////////////////////////////////////////////////////////
-	// Attributs de gestion de la compilation du data path
-
-	// Index de chargement de la derniere variable du data path, aboutissant a son extremite
-	KWLoadIndex liCompiledTerminalAttributeLoadIndex;
-
-	// Tableau des data path indexes par leur index de chargement
-	// On utilise la partie dense de l'index de chargement pour avoir un acces direct a un data path
-	ObjectArray oaCompiledComponentDataPathsByLoadIndex;
-
-	// Parametres pour le generateur de nombre aleatoire
-	int nCompiledRandomSeed;
-	int nCompiledRandomLeap;
-
-	// Valeur de hash du data path au moment de compilation, permettant de verifier sa validite
-	int nCompileHash;
+	const KWDataPathManager* dataPathManager;
 };
 
 ////////////////////////////////////////////////////////////
@@ -446,37 +314,6 @@ protected:
 };
 
 ////////////////////////////////////////////////////////////
-// Classe KWObjectDataPathManager
-// Specialisation dans le cas de KWObjectDataPath
-class KWObjectDataPathManager : public KWDataPathManager
-{
-public:
-	// Constructeur
-	KWObjectDataPathManager();
-	~KWObjectDataPathManager();
-
-	// Calcul de tous les data path a partir du dictionnaire principal
-	// d'une base multi-table
-	void ComputeAllDataPaths(const KWClass* mainClass) override;
-
-	// Acces aux data paths avec le type specialise
-	const KWObjectDataPath* GetObjectDataPathAt(int nIndex) const;
-	const KWObjectDataPath* GetExternalRootObjectDataPathAt(int nIndex) const;
-	const KWObjectDataPath* GetMainObjectDataPath() const;
-	const KWObjectDataPath* LookupObjectDataPath(const ALString& sDataPath) const;
-
-	////////////////////////////////////////////////////////
-	// Divers
-
-	// Copie
-	void CopyFrom(const KWDataPathManager* aSource) override;
-
-	// Creation pour renvoyer une instance du meme type dynamique
-	// Doit etre reimplemente dans les sous-classes
-	KWDataPathManager* Create() const override;
-};
-
-////////////////////////////////////////////////////////////
 // Implementations inline
 
 inline boolean KWDataPath::GetExternalTable() const
@@ -545,67 +382,14 @@ inline const ObjectArray* KWDataPath::GetConstComponents() const
 	return &oaComponents;
 }
 
-inline boolean KWObjectDataPath::GetCreatedObjects() const
+inline const KWDataPathManager* KWDataPath::GetDataPathManager() const
 {
-	return bCreatedObjects;
+	return dataPathManager;
 }
 
-inline void KWObjectDataPath::SetCreatedObjects(boolean bValue)
+inline void KWDataPath::SetDataPathManager(const KWDataPathManager* manager)
 {
-	bCreatedObjects = bValue;
-}
-
-inline const KWObjectDataPath* KWObjectDataPath::GetComponentDataPath(const KWLoadIndex liAttributeLoadIndex) const
-{
-	const KWObjectDataPath* foundComponentDataPath;
-
-	require(IsCompiled());
-	require(liAttributeLoadIndex.IsValid());
-	require(liAttributeLoadIndex.IsDense());
-	require(liAttributeLoadIndex.GetDenseIndex() < oaCompiledComponentDataPathsByLoadIndex.GetSize());
-
-	foundComponentDataPath =
-	    cast(const KWObjectDataPath*,
-		 oaCompiledComponentDataPathsByLoadIndex.GetAt(liAttributeLoadIndex.GetDenseIndex()));
-	ensure(foundComponentDataPath->GetTerminalLoadIndex().GetDenseIndex() == liAttributeLoadIndex.GetDenseIndex());
-	return foundComponentDataPath;
-}
-
-inline longint KWObjectDataPath::GetMainCreationIndex() const
-{
-	require(IsCompiled());
-	return lMainCreationIndex;
-}
-
-inline longint KWObjectDataPath::NewCreationIndex() const
-{
-	require(IsCompiled());
-	lCreationNumber++;
-	return lCreationNumber;
-}
-
-inline longint KWObjectDataPath::GetCreationNumber() const
-{
-	require(IsCompiled());
-	return lCreationNumber;
-}
-
-inline const KWLoadIndex KWObjectDataPath::GetTerminalLoadIndex() const
-{
-	require(IsCompiled());
-	return liCompiledTerminalAttributeLoadIndex;
-}
-
-inline int KWObjectDataPath::GetRandomSeed() const
-{
-	require(IsCompiled());
-	return nCompiledRandomSeed;
-}
-
-inline int KWObjectDataPath::GetRandomLeap() const
-{
-	require(IsCompiled());
-	return nCompiledRandomLeap;
+	dataPathManager = manager;
 }
 
 inline const ALString KWDataPathManager::GetMainClassName() const
@@ -649,24 +433,4 @@ inline const KWDataPath* KWDataPathManager::LookupDataPath(const ALString& sData
 inline const StringVector* KWDataPathManager::GetUnusedRootDictionaryWarnings() const
 {
 	return &svUnusedRootDictionaryWarnings;
-}
-
-inline const KWObjectDataPath* KWObjectDataPathManager::GetObjectDataPathAt(int nIndex) const
-{
-	return cast(const KWObjectDataPath*, GetDataPathAt(nIndex));
-}
-
-inline const KWObjectDataPath* KWObjectDataPathManager::GetMainObjectDataPath() const
-{
-	return cast(const KWObjectDataPath*, GetMainDataPath());
-}
-
-inline const KWObjectDataPath* KWObjectDataPathManager::GetExternalRootObjectDataPathAt(int nIndex) const
-{
-	return cast(const KWObjectDataPath*, GetExternalRootDataPathAt(nIndex));
-}
-
-inline const KWObjectDataPath* KWObjectDataPathManager::LookupObjectDataPath(const ALString& sDataPath) const
-{
-	return cast(const KWObjectDataPath*, LookupDataPath(sDataPath));
 }

--- a/src/Learning/KWData/KWDataTableDriverTextFile.h
+++ b/src/Learning/KWData/KWDataTableDriverTextFile.h
@@ -84,10 +84,6 @@ public:
 	// du dictionnaire
 	longint GetEstimatedUsedInputDiskSpacePerObject() const;
 
-	// Estimation heuristique de la memoire utilise par KWObject en se basant sur les variables utilisee du
-	// dictionnaire, natives ou calculees
-	longint GetEstimatedUsedMemoryPerObject() const;
-
 	// Estimation heuristique de la place disque par record d'un fichier a ecrire en se basant sur les variables
 	// utilisees du dictionnaire logique
 	longint GetEstimatedUsedOutputDiskSpacePerObject(const KWClass* kwcLogicalClass) const;
@@ -199,10 +195,8 @@ protected:
 
 	// Constantes pour l'estimation heuristique conservatrice de la taille des champs sur fichier
 	static const int nMinRecordSize = 5;
-	static const int nDenseValueSize = 2;
-	static const int nSparseValueSize = 7;
-	static const int nTextValueSize = 200;
-	static const int nKeyFieldSize = 5;
+	static const int nDiskDenseValueSize = 2;
+	static const int nDiskSparseValueSize = 7;
 };
 
 ////////////////////////////////////////

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -26,6 +26,11 @@ KWDatabase::KWDatabase()
 	timeDefaultConverter.SetFormatString(KWTimeFormat::GetDefaultFormatString());
 	timestampDefaultConverter.SetFormatString(KWTimestampFormat::GetDefaultFormatString());
 	timestampTZDefaultConverter.SetFormatString(KWTimestampTZFormat::GetDefaultFormatString());
+
+	// Parametrage du gestionnaire de data path par le service de protection memoire
+	// pour permettre aux regles de creation d'instances de controler les trop grands
+	// nombres d'instances creees
+	objectDataPathManager.SetMemoryGuard(&memoryGuard);
 }
 
 KWDatabase::~KWDatabase()
@@ -2347,7 +2352,8 @@ void KWDatabase::MutatePhysicalObject(KWObject* kwoPhysicalObject) const
 	// Il faut le faire sur l'objet physique avant sa mutation, car il contient
 	// necessairement les champs de la cle en multi-table, alors qu'ils sont potentiellement
 	// absent de l'objet logique si les champs de la cle sont en unused
-	if (memoryGuard.IsSingleInstanceMemoryLimitReached() or memoryGuard.IsMaxSecondaryRecordNumberReached())
+	if (memoryGuard.IsSingleInstanceMemoryLimitReached() or memoryGuard.IsMaxSecondaryRecordNumberReached() or
+	    memoryGuard.IsMaxCreatedRecordNumberReached())
 	{
 		// On se base sur la cle de l'objet s'il y en a une
 		if (kwoPhysicalObject->GetClass()->IsKeyLoaded())
@@ -2458,6 +2464,20 @@ longint KWDatabase::GetMemoryGuardMaxSecondaryRecordNumber() const
 	require(not IsOpenedForRead());
 	require(not IsOpenedForWrite());
 	return memoryGuard.GetMaxSecondaryRecordNumber();
+}
+
+void KWDatabase::SetMemoryGuardMaxCreatedRecordNumber(longint lValue)
+{
+	require(not IsOpenedForRead());
+	require(not IsOpenedForWrite());
+	memoryGuard.SetMaxCreatedRecordNumber(lValue);
+}
+
+longint KWDatabase::GetMemoryGuardMaxCreatedRecordNumber() const
+{
+	require(not IsOpenedForRead());
+	require(not IsOpenedForWrite());
+	return memoryGuard.GetMaxCreatedRecordNumber();
 }
 
 void KWDatabase::SetMemoryGuardSingleInstanceMemoryLimit(longint lValue)

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -82,6 +82,7 @@ void KWDatabase::CopyFrom(const KWDatabase* kwdSource)
 	sSelectionValue = "";
 	sSelectionSymbol = "";
 	ivMarkedInstances.SetSize(0);
+	memoryGuard.Reset();
 
 	// Recopie des parametres de specification de la base
 	SetDatabaseName(kwdSource->GetDatabaseName());
@@ -517,6 +518,7 @@ boolean KWDatabase::OpenForRead()
 	CompilePhysicalSelection();
 
 	// Initialisation de tous les data paths a destination des objets lus ou cree
+	assert(objectDataPathManager.GetDataPathNumber() == 0);
 	objectDataPathManager.ComputeAllDataPaths(kwcPhysicalClass);
 
 	// Ouverture physique de la base
@@ -2458,55 +2460,6 @@ boolean KWDatabase::CheckSelectionValue(const ALString& sValue) const
 		}
 	}
 	return bOk;
-}
-
-void KWDatabase::ResetMemoryGuard()
-{
-	require(not IsOpenedForRead());
-	require(not IsOpenedForWrite());
-	memoryGuard.Reset();
-}
-
-void KWDatabase::SetMemoryGuardMaxSecondaryRecordNumber(longint lValue)
-{
-	require(not IsOpenedForRead());
-	require(not IsOpenedForWrite());
-	memoryGuard.SetMaxSecondaryRecordNumber(lValue);
-}
-
-longint KWDatabase::GetMemoryGuardMaxSecondaryRecordNumber() const
-{
-	require(not IsOpenedForRead());
-	require(not IsOpenedForWrite());
-	return memoryGuard.GetMaxSecondaryRecordNumber();
-}
-
-void KWDatabase::SetMemoryGuardMaxCreatedRecordNumber(longint lValue)
-{
-	require(not IsOpenedForRead());
-	require(not IsOpenedForWrite());
-	memoryGuard.SetMaxCreatedRecordNumber(lValue);
-}
-
-longint KWDatabase::GetMemoryGuardMaxCreatedRecordNumber() const
-{
-	require(not IsOpenedForRead());
-	require(not IsOpenedForWrite());
-	return memoryGuard.GetMaxCreatedRecordNumber();
-}
-
-void KWDatabase::SetMemoryGuardSingleInstanceMemoryLimit(longint lValue)
-{
-	require(not IsOpenedForRead());
-	require(not IsOpenedForWrite());
-	memoryGuard.SetSingleInstanceMemoryLimit(lValue);
-}
-
-longint KWDatabase::GetMemoryGuardSingleInstanceMemoryLimit() const
-{
-	require(not IsOpenedForRead());
-	require(not IsOpenedForWrite());
-	return memoryGuard.GetSingleInstanceMemoryLimit();
 }
 
 boolean KWDatabase::Check() const

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -626,10 +626,25 @@ KWObject* KWDatabase::Read()
 		// Test si objet selectionne
 		if (kwoObject != NULL)
 		{
+			// Destruction si objet non selectionne
 			if (not IsPhysicalObjectSelected(kwoObject))
 			{
 				delete kwoObject;
 				kwoObject = NULL;
+
+				// Warning : Si le calcul de la selection entraine un depassement de capacite memoire,
+				// cela peut potentiellement conduire a une valeur de critere de selection incorrecte,
+				// et donc a une non-selection a tort.
+				// Ce warning sera emis en fin de methode si necessaire pour les instances selectionnees.
+				// Il est important d'informer l'utilisateur de ce probleme potentiel, car selon la passe de
+				// traitement des donnees (statistiques basiques, preparation, etc.), les instances selectionnees
+				// pourraient varier, entrainant une incoherence dans le nombre d'instances issues de chaque passe.
+				// Cette incoherence est detectee, mais elle peut avoir plusieurs causes:
+				// fichier modifie entre deux passes, critere de selection mal calcule (comme ici), ...
+				if (memoryGuard.IsSingleInstanceMemoryLimitReached())
+					AddWarning("Record not selected due to selection variable with possible "
+						   "incorrect value. " +
+						   memoryGuard.GetSingleInstanceMemoryLimitLabel());
 			}
 		}
 	}

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -26,9 +26,6 @@ KWDatabase::KWDatabase()
 	timeDefaultConverter.SetFormatString(KWTimeFormat::GetDefaultFormatString());
 	timestampDefaultConverter.SetFormatString(KWTimestampFormat::GetDefaultFormatString());
 	timestampTZDefaultConverter.SetFormatString(KWTimestampTZFormat::GetDefaultFormatString());
-
-	// Creation du gestionnaire de data path, qui est ici un pointeur pour un probleme de cyle de include dans les header
-	objectDataPathManager = new KWObjectDataPathManager;
 }
 
 KWDatabase::~KWDatabase()
@@ -36,7 +33,6 @@ KWDatabase::~KWDatabase()
 	assert(not IsOpenedForRead() and not IsOpenedForWrite());
 	assert(kwcPhysicalClass == NULL);
 	oaAllObjects.DeleteAll();
-	delete objectDataPathManager;
 }
 
 KWDatabase* KWDatabase::Clone() const
@@ -516,7 +512,7 @@ boolean KWDatabase::OpenForRead()
 	CompilePhysicalSelection();
 
 	// Initialisation de tous les data paths a destination des objets lus ou cree
-	objectDataPathManager->ComputeAllDataPaths(kwcPhysicalClass);
+	objectDataPathManager.ComputeAllDataPaths(kwcPhysicalClass);
 
 	// Ouverture physique de la base
 	bIsError = false;
@@ -717,7 +713,7 @@ boolean KWDatabase::Close()
 	nClassFreshness = 0;
 
 	// Destruction des data paths de gestion des objets
-	objectDataPathManager->Reset();
+	objectDataPathManager.Reset();
 
 	// Destruction de la classe physique
 	DeletePhysicalClass();
@@ -1279,7 +1275,7 @@ longint KWDatabase::GetUsedMemory() const
 		lUsedMemory += kwcPhysicalClass->GetDomain()->GetUsedMemory();
 
 	// Memoire du gestionnaire de data apth
-	lUsedMemory += objectDataPathManager->GetUsedMemory();
+	lUsedMemory += objectDataPathManager.GetUsedMemory();
 
 	// Objets charges en memoire
 	for (nObject = 0; nObject < oaAllObjects.GetSize(); nObject++)

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -662,7 +662,7 @@ KWObject* KWDatabase::Read()
 
 	// Warning selon l'etat du memory guard
 	// On emet que des warning, car on est toujours capable de "rattaper" l'erreur
-	// Par controle, on passe par handler des gestion des flow d'erreur pour emmetre ces warning meme
+	// Pour ce controle, on passe par handler de gestion des flow d'erreur pour emmetre ces warnings meme
 	// en cas de depassement du flow. Ce handler est parametre lors des ouverture-fermeture de base
 	if (kwoObject != NULL)
 	{

--- a/src/Learning/KWData/KWDatabase.h
+++ b/src/Learning/KWData/KWDatabase.h
@@ -304,6 +304,12 @@ public:
 	void SetMemoryGuardMaxSecondaryRecordNumber(longint lValue);
 	longint GetMemoryGuardMaxSecondaryRecordNumber() const;
 
+	// Nombre d'instances crees au dela duquel une alerte est declenchee
+	// Cela ne declenche qu'un warning informatif en cas de depassement
+	// Parametrage inactif si 0
+	void SetMemoryGuardMaxCreatedRecordNumber(longint lValue);
+	longint GetMemoryGuardMaxCreatedRecordNumber() const;
+
 	// Limite a ne pas depasser de la memoire utilisable dans la heap pour gerer l'ensemble de la lecture et du
 	// calcul des attributs derivee Parametrage inactif si 0
 	void SetMemoryGuardSingleInstanceMemoryLimit(longint lValue);
@@ -646,7 +652,7 @@ protected:
 	KWTimestampFormat timestampDefaultConverter;
 	KWTimestampTZFormat timestampTZDefaultConverter;
 
-	// Service de protection memoire pour gerer les enregistrement trop volumineux, notamment dans le cas
+	// Service de protection memoire pour gerer les enregistrements trop volumineux, notamment dans le cas
 	// multi-tables ou le nombre d'enregistrements secondaires peut etre tres important
 	mutable KWDatabaseMemoryGuard memoryGuard;
 

--- a/src/Learning/KWData/KWDatabase.h
+++ b/src/Learning/KWData/KWDatabase.h
@@ -6,7 +6,7 @@
 
 class KWDatabase;
 
-#include "KWDataPath.h"
+#include "KWObjectDataPath.h"
 #include "KWClass.h"
 #include "KWObject.h"
 #include "KWTypeAutomaticRecognition.h"
@@ -584,7 +584,7 @@ protected:
 	// Chaque KWObject lu depuis un fichier ou cree depuis une regle reference son data path, ce qui lui permet
 	// d'etre identifier de facon unique.
 	// Meme en mono-table, les data path sont utiles pour identifier les eventuelles instances crees pard es regles de derivation
-	KWObjectDataPathManager* objectDataPathManager;
+	KWObjectDataPathManager objectDataPathManager;
 
 	// Dictionnaire des classes de mutation, avec en cle la classe physique des objets a muter
 	// et en valeur la classe suite a la mutation

--- a/src/Learning/KWData/KWDatabase.h
+++ b/src/Learning/KWData/KWDatabase.h
@@ -291,29 +291,14 @@ public:
 	longint GetLastReadMarkIndex() const;
 
 	////////////////////////////////////////////////////////////////////////////////
-	// Pametrage de la protection memoire des acces en lecture
-	// Permet d'eviter de depasser la memoire en cas d'instance volumineuse a lire et traiter
+	// Acces au service de protection memoire des acces en lecture pour en parametrer
+	// son dimensionnement
+	// Ce service permet d'eviter de depasser la memoire en cas d'instance volumineuse a lire et traiter
 	// Ce parametrage est a effectuer avant ouverture de la base
 
-	// Reinitialisation des parametres la protection memoire
-	void ResetMemoryGuard();
-
-	// Nombre d'enregistrements secondaires au dela duquel une alerte est declenchee
-	// Cela ne declenche qu'un warning informatif en cas de depassement
-	// Parametrage inactif si 0
-	void SetMemoryGuardMaxSecondaryRecordNumber(longint lValue);
-	longint GetMemoryGuardMaxSecondaryRecordNumber() const;
-
-	// Nombre d'instances crees au dela duquel une alerte est declenchee
-	// Cela ne declenche qu'un warning informatif en cas de depassement
-	// Parametrage inactif si 0
-	void SetMemoryGuardMaxCreatedRecordNumber(longint lValue);
-	longint GetMemoryGuardMaxCreatedRecordNumber() const;
-
-	// Limite a ne pas depasser de la memoire utilisable dans la heap pour gerer l'ensemble de la lecture et du
-	// calcul des attributs derivee Parametrage inactif si 0
-	void SetMemoryGuardSingleInstanceMemoryLimit(longint lValue);
-	longint GetMemoryGuardSingleInstanceMemoryLimit() const;
+	// Service de protection memoire
+	KWDatabaseMemoryGuard* GetMemoryGuard();
+	const KWDatabaseMemoryGuard* GetConstMemoryGuard() const;
 
 	////////////////////////////////////////////////////////////////////////////////
 	// Fonctionnalites de base
@@ -827,6 +812,20 @@ inline IntVector* KWDatabase::GetMarkedInstances()
 inline longint KWDatabase::GetLastReadMarkIndex() const
 {
 	return GetPhysicalRecordIndex();
+}
+
+inline KWDatabaseMemoryGuard* KWDatabase::GetMemoryGuard()
+{
+	require(not IsOpenedForRead());
+	require(not IsOpenedForWrite());
+	return &memoryGuard;
+}
+
+inline const KWDatabaseMemoryGuard* KWDatabase::GetConstMemoryGuard() const
+{
+	require(not IsOpenedForRead());
+	require(not IsOpenedForWrite());
+	return &memoryGuard;
 }
 
 inline void KWDatabase::SetVerboseMode(boolean bValue)

--- a/src/Learning/KWData/KWDatabaseMemoryGuard.cpp
+++ b/src/Learning/KWData/KWDatabaseMemoryGuard.cpp
@@ -20,6 +20,8 @@ void KWDatabaseMemoryGuard::Reset()
 	lMaxSecondaryRecordNumber = 0;
 	lMaxCreatedRecordNumber = 0;
 	lSingleInstanceMemoryLimit = 0;
+	lEstimatedMinSingleInstanceMemoryLimit = 0;
+	lEstimatedMaxSingleInstanceMemoryLimit = 0;
 	Init();
 }
 
@@ -48,12 +50,48 @@ longint KWDatabaseMemoryGuard::GetMaxCreatedRecordNumber() const
 void KWDatabaseMemoryGuard::SetSingleInstanceMemoryLimit(longint lValue)
 {
 	require(lValue >= 0);
+	require(GetEstimatedMinSingleInstanceMemoryLimit() <= lValue);
+	require(lValue <= GetEstimatedMaxSingleInstanceMemoryLimit());
 	lSingleInstanceMemoryLimit = lValue;
 }
 
 longint KWDatabaseMemoryGuard::GetSingleInstanceMemoryLimit() const
 {
+	ensure(GetEstimatedMinSingleInstanceMemoryLimit() <= lSingleInstanceMemoryLimit);
+	ensure(lSingleInstanceMemoryLimit <= GetEstimatedMaxSingleInstanceMemoryLimit());
 	return lSingleInstanceMemoryLimit;
+}
+
+void KWDatabaseMemoryGuard::SetEstimatedMinSingleInstanceMemoryLimit(longint lValue)
+{
+	require(lValue >= 0);
+	lEstimatedMinSingleInstanceMemoryLimit = lValue;
+}
+
+longint KWDatabaseMemoryGuard::GetEstimatedMinSingleInstanceMemoryLimit() const
+{
+	return lEstimatedMinSingleInstanceMemoryLimit;
+}
+
+void KWDatabaseMemoryGuard::SetEstimatedMaxSingleInstanceMemoryLimit(longint lValue)
+{
+	require(lValue >= 0);
+	lEstimatedMaxSingleInstanceMemoryLimit = lValue;
+}
+
+longint KWDatabaseMemoryGuard::GetEstimatedMaxSingleInstanceMemoryLimit() const
+{
+	return lEstimatedMaxSingleInstanceMemoryLimit;
+}
+
+void KWDatabaseMemoryGuard::CopyFrom(const KWDatabaseMemoryGuard* aSource)
+{
+	Reset();
+	lMaxSecondaryRecordNumber = aSource->lMaxSecondaryRecordNumber;
+	lMaxCreatedRecordNumber = aSource->lMaxCreatedRecordNumber;
+	lSingleInstanceMemoryLimit = aSource->lSingleInstanceMemoryLimit;
+	lEstimatedMinSingleInstanceMemoryLimit = aSource->lEstimatedMinSingleInstanceMemoryLimit;
+	lEstimatedMaxSingleInstanceMemoryLimit = aSource->lEstimatedMaxSingleInstanceMemoryLimit;
 }
 
 void KWDatabaseMemoryGuard::Init()
@@ -402,23 +440,43 @@ longint KWDatabaseMemoryGuard::GetCrashTestSingleInstanceMemoryLimit()
 	return lCrashTestSingleInstanceMemoryLimit;
 }
 
+void KWDatabaseMemoryGuard::WriteParameters(ostream& ost) const
+{
+	ost << GetClassLabel() << "\n";
+	cout << "\tMaxSecondaryRecordNumber\t" << LongintToReadableString(lMaxSecondaryRecordNumber) << "\n";
+	cout << "\tMaxCreatedRecordNumber\t" << LongintToReadableString(lMaxCreatedRecordNumber) << "\n";
+	cout << "\tSingleInstanceMemoryLimit\t" << LongintToHumanReadableString(lSingleInstanceMemoryLimit) << "\n";
+	cout << "\tEstimatedMinSingleInstanceMemoryLimit\t"
+	     << LongintToHumanReadableString(lEstimatedMinSingleInstanceMemoryLimit) << "\n";
+	cout << "\tEstimatedMaxSingleInstanceMemoryLimit\t"
+	     << LongintToHumanReadableString(lEstimatedMaxSingleInstanceMemoryLimit) << "\n";
+}
+
 void KWDatabaseMemoryGuard::Write(ostream& ost) const
 {
 	ost << GetClassLabel() << "\n";
 	cout << "\tMainObjectKey\t" << sMainObjectKey << "\n";
-	cout << "\tMaxSecondaryRecordNumber\t" << lMaxSecondaryRecordNumber << "\n";
-	cout << "\tMaxCreatedRecordNumber\t" << lMaxCreatedRecordNumber << "\n";
-	cout << "\tSingleInstanceMemoryLimit\t" << lSingleInstanceMemoryLimit << "\n";
+	cout << "\tMaxSecondaryRecordNumber\t" << LongintToReadableString(lMaxSecondaryRecordNumber) << "\n";
+	cout << "\tMaxCreatedRecordNumber\t" << LongintToReadableString(lMaxCreatedRecordNumber) << "\n";
+	cout << "\tSingleInstanceMemoryLimit\t" << LongintToHumanReadableString(lSingleInstanceMemoryLimit) << "\n";
+	cout << "\tEstimatedMinSingleInstanceMemoryLimit\t"
+	     << LongintToHumanReadableString(lEstimatedMinSingleInstanceMemoryLimit) << "\n";
+	cout << "\tEstimatedMaxSingleInstanceMemoryLimit\t"
+	     << LongintToHumanReadableString(lEstimatedMaxSingleInstanceMemoryLimit) << "\n";
 	cout << "\tIsSingleInstanceMemoryLimitReached\t" << bIsSingleInstanceMemoryLimitReached << "\n";
-	cout << "\tInitialHeapMemory\t" << lInitialHeapMemory << "\n";
-	cout << "\tMaxHeapMemory\t" << lMaxHeapMemory << "\n";
-	cout << "\tCurrentHeapMemory\t" << lCurrentHeapMemory << "\n";
-	cout << "\tReadSecondaryRecordNumberBeforeLimit\t" << lReadSecondaryRecordNumberBeforeLimit << "\n";
-	cout << "\tTotalReadSecondaryRecordNumber\t" << lTotalReadSecondaryRecordNumber << "\n";
-	cout << "\tCreatedRecordNumberBeforeLimit\t" << lCreatedRecordNumberBeforeLimit << "\n";
-	cout << "\tTotalCreatedRecordNumber\t" << lTotalCreatedRecordNumber << "\n";
-	cout << "\tComputedAttributeNumberBeforeLimit\t" << nComputedAttributeNumberBeforeLimit << "\n";
-	cout << "\tTotalComputedAttributeNumber\t" << nTotalComputedAttributeNumber << "\n";
+	cout << "\tInitialHeapMemory\t" << LongintToHumanReadableString(lInitialHeapMemory) << "\n";
+	cout << "\tMaxHeapMemory\t" << LongintToHumanReadableString(lMaxHeapMemory) << "\n";
+	cout << "\tCurrentHeapMemory\t" << LongintToHumanReadableString(lCurrentHeapMemory) << "\n";
+	cout << "\tReadSecondaryRecordNumberBeforeLimit\t"
+	     << LongintToReadableString(lReadSecondaryRecordNumberBeforeLimit) << "\n";
+	cout << "\tTotalReadSecondaryRecordNumber\t" << LongintToReadableString(lTotalReadSecondaryRecordNumber)
+	     << "\n";
+	cout << "\tCreatedRecordNumberBeforeLimit\t" << LongintToReadableString(lCreatedRecordNumberBeforeLimit)
+	     << "\n";
+	cout << "\tTotalCreatedRecordNumber\t" << LongintToHumanReadableString(lTotalCreatedRecordNumber) << "\n";
+	cout << "\tComputedAttributeNumberBeforeLimit\t" << LongintToReadableString(nComputedAttributeNumberBeforeLimit)
+	     << "\n";
+	cout << "\tTotalComputedAttributeNumber\t" << LongintToReadableString(nTotalComputedAttributeNumber) << "\n";
 }
 
 const ALString KWDatabaseMemoryGuard::GetClassLabel() const

--- a/src/Learning/KWData/KWDatabaseMemoryGuard.cpp
+++ b/src/Learning/KWData/KWDatabaseMemoryGuard.cpp
@@ -241,8 +241,15 @@ const ALString KWDatabaseMemoryGuard::GetSingleInstanceVeryLargeLabel()
 
 	// Et dans le cas ou la memoire a du etre nettoyee
 	if (GetMemoryCleaningNumber() > 0)
+	{
 		sLabel += " : all derived variables have been computed using RAM sparingly at the expense of "
-			  "computation time";
+			  "computation time (";
+		sLabel += IntToString(GetMemoryCleaningNumber());
+		if (GetMemoryCleaningNumber() == 1)
+			sLabel += " additional pass)";
+		else
+			sLabel += " additional passes)";
+	}
 	ensure(sLabel.Find(sMemoryGuardLabelPrefix) == 0);
 	return sLabel;
 }

--- a/src/Learning/KWData/KWDatabaseMemoryGuard.h
+++ b/src/Learning/KWData/KWDatabaseMemoryGuard.h
@@ -41,6 +41,12 @@ public:
 	void SetMaxSecondaryRecordNumber(longint lValue);
 	longint GetMaxSecondaryRecordNumber() const;
 
+	// Nombre d'instances crees au dela duquel une alerte est declenchee
+	// Cela ne declenche qu'un warning informatif en cas de depassement
+	// Parametrage inactif si 0
+	void SetMaxCreatedRecordNumber(longint lValue);
+	longint GetMaxCreatedRecordNumber() const;
+
 	// Limite de la memoire utilisable pour une instance pour gerer l'ensemble de la lecture et du calcul des
 	// attributs derivee
 	// Attention: il s'agit ici d'une limite memoire physique dans la RAM, avec prise en compte de
@@ -65,6 +71,10 @@ public:
 	// A appeler apres la lecture des enregistrements
 	void AddReadSecondaryRecord();
 
+	// Prise en compte de la creation d'une nouvelle instance
+	// A appeler apres la creation d'une instance par une regle de creation d'instance
+	void AddCreatedRecord();
+
 	// Prise en compte du calcul d'un nouvel attribut
 	// A appeler apres la lecture de chaque nouvel enregistrement
 	void AddComputedAttribute();
@@ -77,8 +87,11 @@ public:
 	// Exploitation des limites
 	// On peut ici emettre des warning specialises en fonction du type de limite atteinte ou depassee
 
-	// Indique si le nombre max d'enregistrement est atteint, si le parametrage est actif
+	// Indique si le nombre max d'enregistrements secondaires est atteint, si le parametrage est actif
 	boolean IsMaxSecondaryRecordNumberReached() const;
+
+	// Indique si le nombre max d'enregistrements crees est atteint, si le parametrage est actif
+	boolean IsMaxCreatedRecordNumberReached() const;
 
 	// Nombre de fois ou on a du nettoyer la memoire pour continuer le calcul des attributs
 	int GetMemoryCleaningNumber() const;
@@ -96,6 +109,9 @@ public:
 
 	// Indique si la cause du depassement memoire est liee a la lecture des enregistrements
 	boolean IsSingleInstanceMemoryLimitReachedDuringRead() const;
+
+	// Indique si la cause du depassement memoire est liee a la creation d'instances
+	boolean IsSingleInstanceMemoryLimitReachedDuringCreation() const;
 
 	// Libelle personnalise associe au depassement de la limite memoire, dans le cas de la lecture des
 	// renregistrements ou dans le cas du calcul des attributs, avec perte du calcul des attributs derives,
@@ -117,6 +133,12 @@ public:
 
 	// Nombre total d'enregistrements secondaires lus
 	longint GetTotalReadSecondaryRecordNumber() const;
+
+	// Nombre d'instances creees avant atteinte de la limite
+	longint GetCreatedRecordNumberBeforeLimit() const;
+
+	// Nombre d'instance crees
+	longint GetTotalCreatedRecordNumber() const;
 
 	// Nombre d'attributs calcules avant atteinte de la limite
 	int GetComputedAttributeNumberBeforeLimit() const;
@@ -146,6 +168,12 @@ public:
 	// Parametrage inactif si 0
 	static void SetCrashTestMaxSecondaryRecordNumber(longint lValue);
 	static longint GetCrashTestMaxSecondaryRecordNumber();
+
+	// Nombre d'enregistrements crees au dela duquel une alerte est declenchee
+	// Cela ne declenche qu'un warning informatif en cas de depassement
+	// Parametrage inactif si 0
+	static void SetCrashTestMaxCreatedRecordNumber(longint lValue);
+	static longint GetCrashTestMaxCreatedRecordNumber();
 
 	// Limite a ne pas depasser de la memoire utilisable dans la heap pour gerer l'ensemble de la lecture et du
 	// calcul des attributs derivee Parametrage inactif si 0
@@ -234,8 +262,11 @@ protected:
 	longint lMaxHeapMemory;
 	longint lCurrentHeapMemory;
 	longint lMaxSecondaryRecordNumber;
+	longint lMaxCreatedRecordNumber;
 	longint lReadSecondaryRecordNumberBeforeLimit;
 	longint lTotalReadSecondaryRecordNumber;
+	longint lCreatedRecordNumberBeforeLimit;
+	longint lTotalCreatedRecordNumber;
 	int nComputedAttributeNumberBeforeLimit;
 	int nTotalComputedAttributeNumber;
 	int nMemoryCleaningNumber;
@@ -243,10 +274,12 @@ protected:
 
 	// Variables d'instance a prendre en compte, selon la valeur des parametres de crash test
 	longint lActualMaxSecondaryRecordNumber;
+	longint lActualMaxCreatedRecordNumber;
 	longint lActualSingleInstanceMemoryLimit;
 
 	// Parametres des crash tests
 	static longint lCrashTestMaxSecondaryRecordNumber;
+	static longint lCrashTestMaxCreatedRecordNumber;
 	static longint lCrashTestSingleInstanceMemoryLimit;
 
 	// Bornes inf et sup des nombres max de records secondaires
@@ -283,6 +316,11 @@ inline boolean KWDatabaseMemoryGuard::IsMaxSecondaryRecordNumberReached() const
 {
 	return lActualMaxSecondaryRecordNumber > 0 and
 	       GetTotalReadSecondaryRecordNumber() > lActualMaxSecondaryRecordNumber;
+}
+
+inline boolean KWDatabaseMemoryGuard::IsMaxCreatedRecordNumberReached() const
+{
+	return lActualMaxCreatedRecordNumber > 0 and GetTotalCreatedRecordNumber() > lActualMaxCreatedRecordNumber;
 }
 
 inline boolean KWDatabaseMemoryGuard::IsSingleInstanceMemoryLimitReached() const

--- a/src/Learning/KWData/KWDatabaseMemoryGuard.h
+++ b/src/Learning/KWData/KWDatabaseMemoryGuard.h
@@ -47,14 +47,25 @@ public:
 	void SetMaxCreatedRecordNumber(longint lValue);
 	longint GetMaxCreatedRecordNumber() const;
 
-	// Limite de la memoire utilisable pour une instance pour gerer l'ensemble de la lecture et du calcul des
-	// attributs derivee
+	// Limite de la memoire utilisable pour une instance pour gerer l'ensemble
+	// de la lecture et du calcul des attributs derivee
 	// Attention: il s'agit ici d'une limite memoire physique dans la RAM, avec prise en compte de
 	// l'overhead d'allocation
 	// Cela concerne toutes les methodes liees a la memoire de cette classe
 	// Parametrage inactif si 0
 	void SetSingleInstanceMemoryLimit(longint lValue);
 	longint GetSingleInstanceMemoryLimit() const;
+
+	// Estimation du minimum de la memoire utilisable pour une instance
+	void SetEstimatedMinSingleInstanceMemoryLimit(longint lValue);
+	longint GetEstimatedMinSingleInstanceMemoryLimit() const;
+
+	// Estimation du maximum de la memoire utilisable pour une instance
+	void SetEstimatedMaxSingleInstanceMemoryLimit(longint lValue);
+	longint GetEstimatedMaxSingleInstanceMemoryLimit() const;
+
+	// Copie, uniquement des attributs de base de la specification
+	void CopyFrom(const KWDatabaseMemoryGuard* aSource);
 
 	//////////////////////////////////////////////////////////////////////////////////////
 	// Gestion des lectures et des calculs d'attributs d'un enregistrement
@@ -183,7 +194,10 @@ public:
 	//////////////////////////////////////////////////////////////////////////////////////
 	// Services standards
 
-	// Affichage detaille des
+	// Affichage detaille du parametrage uniquement
+	void WriteParameters(ostream& ost) const;
+
+	// Affichage detaille des caracteristiques completes
 	void Write(ostream& ost) const override;
 
 	// Libelles utilisateurs
@@ -258,6 +272,8 @@ protected:
 	// Variables d'instance
 	ALString sMainObjectKey;
 	longint lSingleInstanceMemoryLimit;
+	longint lEstimatedMinSingleInstanceMemoryLimit;
+	longint lEstimatedMaxSingleInstanceMemoryLimit;
 	longint lInitialHeapMemory;
 	longint lMaxHeapMemory;
 	longint lCurrentHeapMemory;

--- a/src/Learning/KWData/KWDatabaseMemoryGuard.h
+++ b/src/Learning/KWData/KWDatabaseMemoryGuard.h
@@ -215,6 +215,9 @@ public:
 	static const int GetDefautMinSecondaryRecordNumberFactor();
 	static const int GetDefautMaxSecondaryRecordNumberFactor();
 
+	// Nombre max de passes de nettoyage de la memoire utilisees pour continuer le calcul des attributs
+	static const int GetMaxMemoryCleaningNumber();
+
 	//////////////////////////////////////////////////////////////////////////////////////
 	///// Implementation
 protected:
@@ -306,6 +309,9 @@ protected:
 	static const int nDefautMinSecondaryRecordNumberFactor = 100;
 	static const int nDefautMaxSecondaryRecordNumberFactor = 10000;
 
+	// Nombre max de passes de nettoyage de la memoire utilisees pour continuer le calcul des attributs
+	static const int nMaxMemoryCleaningNumber = 100;
+
 	///////////////////////////////////////////////////////////////////////////////////////////
 	// Gestion de la methode specifique pour ignorer le controle de flow des erreurs
 
@@ -362,4 +368,9 @@ inline const int KWDatabaseMemoryGuard::GetDefautMinSecondaryRecordNumberFactor(
 inline const int KWDatabaseMemoryGuard::GetDefautMaxSecondaryRecordNumberFactor()
 {
 	return nDefautMaxSecondaryRecordNumberFactor;
+}
+
+inline const int KWDatabaseMemoryGuard::GetMaxMemoryCleaningNumber()
+{
+	return nMaxMemoryCleaningNumber;
 }

--- a/src/Learning/KWData/KWDatabaseMemoryGuard.h
+++ b/src/Learning/KWData/KWDatabaseMemoryGuard.h
@@ -13,14 +13,14 @@ class KWDatabaseMemoryGuard;
 //////////////////////////////////////////////////////////////////////////////////////////////
 // Class KWDatabaseMemoryGuard;
 // Service de protection memoire pour la lecture des instances d'une base, notamment multi-table
-// En effet, la lecture d'un enregistrement da la table principale peut impliquer potentiellement
-// un tres grande nombre d'enregistrement de tables secondaires, pouvant potentiellement de pas
+// En effet, la lecture d'un enregistrement de la table principale peut impliquer potentiellement
+// un tres grand nombre d'enregistrements de tables secondaires, pouvant potentiellement de pas
 // tenir en memoire, et un graphe de calcul exploitant des variables de travail pouvant
-// egalement poser un probleme sur sur-utilisation de la memoire.
+// egalement poser un probleme de sur-utilisation de la memoire.
 // On parle dans ce cas d'instances "elephant".
 // Le service de protection des acces memoire permet de monitorer la memoire lors de la lecture
 // des enregistrements et du calcul des variables derivees de facon a eviter preventivement
-// les depassements memoires et a les disgnostiquer le plus precisement possible
+// les depassements memoires et a les diagnostiquer le plus precisement possible
 class KWDatabaseMemoryGuard : public Object
 {
 public:
@@ -42,9 +42,11 @@ public:
 	longint GetMaxSecondaryRecordNumber() const;
 
 	// Limite de la memoire utilisable pour une instance pour gerer l'ensemble de la lecture et du calcul des
-	// attributs derivee Attention: il s'agit ici d'une limite memoire physique dans la RAM, avec prise en compte de
-	// l'overhead d'allocation Cela concerne toutes les methdoes liees a la memoire de cette classe Parametrage
-	// inactif si 0
+	// attributs derivee
+	// Attention: il s'agit ici d'une limite memoire physique dans la RAM, avec prise en compte de
+	// l'overhead d'allocation
+	// Cela concerne toutes les methodes liees a la memoire de cette classe
+	// Parametrage inactif si 0
 	void SetSingleInstanceMemoryLimit(longint lValue);
 	longint GetSingleInstanceMemoryLimit() const;
 
@@ -67,8 +69,8 @@ public:
 	// A appeler apres la lecture de chaque nouvel enregistrement
 	void AddComputedAttribute();
 
-	// Mise a jour apres un nettoyage memoire, permettant potentiellement d'annuler le depassement de la limite
-	// memoire
+	// Mise a jour apres un nettoyage memoire, permettant potentiellement d'annuler
+	// le depassement de la limite memoire
 	void UpdateAfterMemoryCleaning();
 
 	//////////////////////////////////////////////////////////////////////////////////////
@@ -88,8 +90,8 @@ public:
 	const ALString GetSingleInstanceVeryLargeLabel();
 
 	// Indique si la limite memoire est atteinte, si le parametrage est actif
-	// Cet indicateur est declenchee des que la limite a ete depasse une seule fois, et n'est reinitialise qu'avec
-	// Init
+	// Cet indicateur est declenchee des que la limite a ete depasse une seule fois,
+	// et n'est reinitialise qu'avec Init
 	boolean IsSingleInstanceMemoryLimitReached() const;
 
 	// Indique si la cause du depassement memoire est liee a la lecture des enregistrements
@@ -100,10 +102,10 @@ public:
 	// remplaces par des valeur manquantes
 	const ALString GetSingleInstanceMemoryLimitLabel();
 
-	// Afin de permettre aux utilisateur d'obtenir ces warning, meme en cas de controle de flow des erreurs,
-	// il faut installer un handler specifique pour ignorer le controle de flow des erreurs (cf.
-	// Global::SetErrorFlowIgnoreFunction) Ces methodes sont a appeler a l'ouverture et la fermeture d'une
-	// datatebase
+	// Afin de permettre aux utilisateur d'obtenir ces warnings, meme en cas de controle de flow des erreurs,
+	// il faut installer un handler specifique pour ignorer le controle de flow des erreurs
+	// (cf. Global::SetErrorFlowIgnoreFunction)
+	// Ces methodes sont a appeler a l'ouverture et la fermeture d'une database
 	static void InstallMemoryGuardErrorFlowIgnoreFunction();
 	static void UninstallMemoryGuardErrorFlowIgnoreFunction();
 
@@ -179,7 +181,7 @@ protected:
 	// que l'instance ne peut pas etre traitee entierement en memoire.
 	//
 	// L'objet DatabaseMemoryGuard est un objet porte par une Database permettant de
-	// controler en permanence l'ocuppation memoire, apres chaque lecture de record
+	// controler en permanence l'occupation memoire, apres chaque lecture de record
 	// et apres chaque calcul d'attribut des KWObject.
 	// En effet, les calculs d'attribut impliquent une utilisation memoire potentiellement
 	// importante en presence de nombreux records secondaire. Par exemple, une seule selection
@@ -191,7 +193,7 @@ protected:
 	//   . erreur si pas assez de memoire pour calculer tous les attributs derives, apres
 	//     avoir lus correctement tous les records secondaires
 	// En cas d'erreur, on garde neanmoins les valeurs des variables natives de l'instance principale,
-	// et on met toutes les autre valeurs a missing. Il s'agit d'un erreur pour forcer l'utilisateur a
+	// et on met toutes les autre valeurs a missing. Il s'agit d'une erreur pour forcer l'utilisateur a
 	// analyser le probleme, mais cette erreur n'est pas bloquante dans le sens ou l'instance elephant
 	// est neanmoins traitee, meme si c'est en mode degrade.
 	//
@@ -207,12 +209,12 @@ protected:
 	// qui ne sont plus necessaires. Ce type de probleme est une variante de "graph topological ordering"
 	// proche du probleme de "one-shot (black) pebbling".
 	//  cf. https://cs.stackexchange.com/questions/60772/finding-an-optimal-topological-ordering
-	// Il s'agit d'un probleme dont meme l'aproximation est NP-complet.
+	// Il s'agit d'un probleme dont meme l'approximation est NP-complet.
 	// La solution optimale n'est donc pas atteignable, et les heuristiques de resolution du probleme
 	// sont non triviales a mettre au point. De plus, pour assurer une empreinte memoire minimale, on devra
 	// se ramener potentiellement a la solution pragmatique, qui periodiquement peut etre amenee a tout nettoyer.
 	// Le rapport cout-benefice de cette solution etendue est alors extrement defavorable, avec un cout
-	// exorbitant pour potentiellement ameliorer le temps de calcul dans des cas rares pour gerer le cas
+	// exorbitant pour potentiellement ameliorer le temps de calcul dans des cas rares, pour gerer le cas
 	// deja tres rare des instances elephants. Cette solution est abandonnee.
 	//
 	// Le dimensionnement des limites en nombre de records secondaires et en memoire est a la charge des taches.
@@ -239,7 +241,7 @@ protected:
 	int nMemoryCleaningNumber;
 	boolean bIsSingleInstanceMemoryLimitReached;
 
-	// Variable d'instances a prendre en compte, selon la valeur des parametres de crash test
+	// Variables d'instance a prendre en compte, selon la valeur des parametres de crash test
 	longint lActualMaxSecondaryRecordNumber;
 	longint lActualSingleInstanceMemoryLimit;
 
@@ -261,7 +263,7 @@ protected:
 	// Implementation de la methode specifique pour ignorer le controle de flow des erreurs
 	static boolean MemoryGuardErrorFlowIgnoreFunction(const Error* e, boolean bDisplay);
 
-	// Compteur d'installation de la methode specifiques, pour permettre plusieurs utilisation simultannees
+	// Compteur d'installation de la methode specifique, pour permettre plusieurs utilisation simultannees
 	// On ne desisnatelle que si ce compteur repasse a 0
 	static int nMemoryGuardFunctionUseCount;
 
@@ -269,7 +271,7 @@ protected:
 	static int nMemoryGuardInformationWarningNumber;
 	static int nMemoryGuardRecoveryWarningNumber;
 
-	// Partie des libelle permettant d'identifier  les message emius par le memory guard
+	// Partie des libelles permettant d'identifier les messages emis par le memory guard
 	static const ALString sMemoryGuardLabelPrefix;
 	static const ALString sMemoryGuardRecoveryLabelSuffix;
 };

--- a/src/Learning/KWData/KWDatabaseMemoryGuard.h
+++ b/src/Learning/KWData/KWDatabaseMemoryGuard.h
@@ -114,7 +114,7 @@ public:
 	boolean IsSingleInstanceMemoryLimitReachedDuringCreation() const;
 
 	// Libelle personnalise associe au depassement de la limite memoire, dans le cas de la lecture des
-	// renregistrements ou dans le cas du calcul des attributs, avec perte du calcul des attributs derives,
+	// enregistrements ou dans le cas du calcul des attributs, avec perte du calcul des attributs derives,
 	// remplaces par des valeur manquantes
 	const ALString GetSingleInstanceMemoryLimitLabel();
 

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -908,7 +908,7 @@ void KWMTDatabase::PhysicalReadAfterEndOfDatabase()
 			}
 
 			// Recherche du data path correspondant au mapping
-			objectDataPath = objectDataPathManager->LookupObjectDataPath(componentMapping->GetDataPath());
+			objectDataPath = objectDataPathManager.LookupObjectDataPath(componentMapping->GetDataPath());
 
 			// Lecture des sous-objets
 			kwoSubObject = NULL;
@@ -1426,8 +1426,8 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 	// differents, et par consequent, des suites de valeurs aleatoires differentes (puisqu'elles exploitent l'index
 	// de creation d'instance).
 	// Il vaut mieux donc eviter d'utiliser la regle Random dans les tables externes
-	for (nReference = 0; nReference < objectDataPathManager->GetExternalRootDataPathNumber(); nReference++)
-		objectDataPathManager->GetExternalRootObjectDataPathAt(nReference)->ResetCreationNumber(0);
+	for (nReference = 0; nReference < objectDataPathManager.GetExternalRootDataPathNumber(); nReference++)
+		objectDataPathManager.GetExternalRootObjectDataPathAt(nReference)->ResetCreationNumber(0);
 
 	// Calcul de tous les attributs derives pour les objets de chaque table secondaire
 	// Comme les regles peuvent se faire entre objets de tables differentes, ce calcul
@@ -1550,7 +1550,7 @@ longint KWMTDatabase::ComputeSamplingBasedNecessaryMemoryForReferenceObjects()
 
 	// Initialisation de tous les data paths a destination des objets lus ou cree
 	// le temps de la lecture des objet externes
-	objectDataPathManager->ComputeAllDataPaths(kwcPhysicalClass);
+	objectDataPathManager.ComputeAllDataPaths(kwcPhysicalClass);
 
 	// Ouverture et lecture des tables referencees, sans emission d'erreur
 	// ce qui permet de calculer la memoire necessaire a leur lecture
@@ -1568,7 +1568,7 @@ longint KWMTDatabase::ComputeSamplingBasedNecessaryMemoryForReferenceObjects()
 	lDeleteBasedNecessaryMemory = lHeapMemory - MemGetHeapMemory();
 
 	// Destruction des data paths de gestion des objets
-	objectDataPathManager->Reset();
+	objectDataPathManager.Reset();
 
 	// Memoire dediee aux objets references
 	// On prend le max des deux, car il peut y avoir des effet de bord dans l'allocateur, avec la gestion des
@@ -2062,7 +2062,7 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 	if (kwoObject != NULL)
 	{
 		// Recherche du data path a associe a l'objet
-		objectDataPath = objectDataPathManager->LookupObjectDataPath(mapping->GetDataPath());
+		objectDataPath = objectDataPathManager.LookupObjectDataPath(mapping->GetDataPath());
 
 		// Memorisation du data path dans l'objet
 		kwoObject->SetObjectDataPath(objectDataPath);
@@ -2071,8 +2071,8 @@ KWObject* KWMTDatabase::DMTMPhysicalRead(KWMTDatabaseMapping* mapping)
 		// sous data path dans le cas d'un objet princial
 		if (mapping->GetDataTableDriver()->GetClass() == kwcPhysicalClass)
 		{
-			assert(objectDataPath == objectDataPathManager->GetMainDataPath());
-			objectDataPathManager->GetMainObjectDataPath()->ResetCreationNumber(
+			assert(objectDataPath == objectDataPathManager.GetMainDataPath());
+			objectDataPathManager.GetMainObjectDataPath()->ResetCreationNumber(
 			    kwoObject->GetCreationIndex());
 		}
 	}

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -1232,6 +1232,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 	ALString sMessage;
 	boolean bIsInTask;
 	longint lCurrentMemoryGuardMaxSecondaryRecordNumber;
+	longint lCurrentMemoryGuardMaxCreatedRecordNumber;
 	longint lCurrentMemoryGuardSingleInstanceMemoryLimit;
 
 	require(objectReferenceResolver.GetClassNumber() == 0);
@@ -1241,8 +1242,9 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 
 	// On desactive temporairement le memory guard, le temps de la lecture des objets references
 	// En effet, le dimensionnement est calcule pour pouvoir charger en memoire l'ensemble de toutes
-	// les tables extertnes, et il n'y a pas a se soucier de la gestion des instances "elephants"
+	// les tables externes, et il n'y a pas a se soucier de la gestion des instances "elephants"
 	lCurrentMemoryGuardMaxSecondaryRecordNumber = memoryGuard.GetMaxSecondaryRecordNumber();
+	lCurrentMemoryGuardMaxCreatedRecordNumber = memoryGuard.GetMaxCreatedRecordNumber();
 	lCurrentMemoryGuardSingleInstanceMemoryLimit = memoryGuard.GetSingleInstanceMemoryLimit();
 	memoryGuard.Reset();
 
@@ -1496,6 +1498,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(double dSamplePercentage)
 
 	// On reactive le memory guard
 	memoryGuard.SetMaxSecondaryRecordNumber(lCurrentMemoryGuardMaxSecondaryRecordNumber);
+	memoryGuard.SetMaxCreatedRecordNumber(lCurrentMemoryGuardMaxCreatedRecordNumber);
 	memoryGuard.SetSingleInstanceMemoryLimit(lCurrentMemoryGuardSingleInstanceMemoryLimit);
 	return bOk;
 }

--- a/src/Learning/KWData/KWMTDatabaseMapping.h
+++ b/src/Learning/KWData/KWMTDatabaseMapping.h
@@ -137,7 +137,6 @@ public:
 	// Divers
 
 	// Creation pour renvoyer une instance du meme type dynamique
-	// Doit etre reimplemente dans les sous-classes
 	KWDataPathManager* Create() const override;
 
 	// Verification de la validite des specifications des tables par data path

--- a/src/Learning/KWData/KWObject.cpp
+++ b/src/Learning/KWData/KWObject.cpp
@@ -1672,6 +1672,7 @@ void KWObject::Mutate(const KWClass* kwcNewClass, const NumericKeyDictionary* nk
 	int i;
 	int nLoadedDataItemNumber;
 	int nTotalInternallyLoadedDataItemNumber;
+	KWValue previousValue;
 	KWAttribute* attribute;
 	KWObject* kwoUsedObject;
 	ObjectArray* oaUsedObjectArray;
@@ -1798,6 +1799,7 @@ void KWObject::Mutate(const KWClass* kwcNewClass, const NumericKeyDictionary* nk
 				liInternalLoadIndex = attribute->GetInternalLoadIndex();
 				assert(liInternalLoadIndex.IsDense());
 				assert(not GetAt(liInternalLoadIndex.GetDenseIndex()).IsObjectForbidenValue());
+				assert(not GetAt(liInternalLoadIndex.GetDenseIndex()).IsObjectArrayForbidenValue());
 
 				// Traitement si attribut precedent present dans la classe d'origine
 				previousAttribute = previousClass->LookupAttribute(attribute->GetName());
@@ -1806,13 +1808,20 @@ void KWObject::Mutate(const KWClass* kwcNewClass, const NumericKeyDictionary* nk
 					liLoadIndex = previousAttribute->GetLoadIndex();
 					assert(liLoadIndex.IsDense());
 
+					// Acces a la valeur
+					previousValue =
+					    GetValueAt(previousValues, bPreviousSmallSize, liLoadIndex.GetDenseIndex());
+
 					// Cas des Object
 					if (attribute->GetType() == KWType::Object)
 					{
 						// Acces a l'objet precedent
-						kwoUsedObject = GetValueAt(previousValues, bPreviousSmallSize,
-									   liLoadIndex.GetDenseIndex())
-								    .GetObject();
+						if (previousValue.IsObjectForbidenValue())
+							kwoUsedObject = NULL;
+						else
+							kwoUsedObject = GetValueAt(previousValues, bPreviousSmallSize,
+										   liLoadIndex.GetDenseIndex())
+									    .GetObject();
 
 						// Transfert de l'objet si necessaire, destruction sinon
 						if (kwoUsedObject != NULL)
@@ -1858,9 +1867,13 @@ void KWObject::Mutate(const KWClass* kwcNewClass, const NumericKeyDictionary* nk
 						assert(attribute->GetType() == KWType::ObjectArray);
 
 						// Acces au tableau precedent
-						oaUsedObjectArray = GetValueAt(previousValues, bPreviousSmallSize,
-									       liLoadIndex.GetDenseIndex())
-									.GetObjectArray();
+						if (previousValue.IsObjectArrayForbidenValue())
+							oaUsedObjectArray = NULL;
+						else
+							oaUsedObjectArray =
+							    GetValueAt(previousValues, bPreviousSmallSize,
+								       liLoadIndex.GetDenseIndex())
+								.GetObjectArray();
 
 						// Transfert des objets si necessaire, destruction sinon
 						if (oaUsedObjectArray != NULL)

--- a/src/Learning/KWData/KWObject.cpp
+++ b/src/Learning/KWData/KWObject.cpp
@@ -183,11 +183,16 @@ void KWObject::ComputeAllValues(KWDatabaseMemoryGuard* memoryGuard)
 			// exploitant ces instances creees sont faux et fluctuants selon la memoire disponible
 			if (not memoryGuard->IsSingleInstanceMemoryLimitReachedDuringCreation())
 			{
-				// Nettoyage des donnees de travail temporaire, pouvant etre recalculees
-				CleanTemporayDataItemsToComputeAndClean();
+				// On ne le fait pas s'il y a eu trop de passe de nettoyage, pour eviter
+				// de passer un temps potentiellement enorme
+				if (memoryGuard->GetMemoryCleaningNumber() < memoryGuard->GetMaxMemoryCleaningNumber())
+				{
+					// Nettoyage des donnees de travail temporaire, pouvant etre recalculees
+					CleanTemporayDataItemsToComputeAndClean();
 
-				// Actualisation de la detetcion de depassement memoire
-				memoryGuard->UpdateAfterMemoryCleaning();
+					// Actualisation de la detection de depassement memoire
+					memoryGuard->UpdateAfterMemoryCleaning();
+				}
 			}
 		}
 	}

--- a/src/Learning/KWData/KWObject.h
+++ b/src/Learning/KWData/KWObject.h
@@ -435,7 +435,7 @@ int KWObjectCompareCreationIndex(const void* elem1, const void* elem2);
 #include "KWClass.h"
 #include "KWAttributeBlock.h"
 #include "KWDerivationRule.h"
-#include "KWDataPath.h"
+#include "KWObjectDataPath.h"
 
 /////////////////////////////////////////////////////////////////
 // Methodes en inline

--- a/src/Learning/KWData/KWObject.h
+++ b/src/Learning/KWData/KWObject.h
@@ -1012,6 +1012,8 @@ inline void KWObject::SetObjectValueAt(KWLoadIndex liLoadIndex, KWObject* kwoVal
 inline ObjectArray* KWObject::ComputeObjectArrayValueAt(KWLoadIndex liLoadIndex) const
 {
 	ObjectArray* oaSubObjects;
+	KWDerivationRule* rule;
+	KWDatabaseMemoryGuard* memoryGuard;
 
 	debug(require(nObjectLoadedDataItemNumber == kwcClass->GetTotalInternallyLoadedDataItemNumber()));
 	debug(require(nFreshness == kwcClass->GetFreshness()));
@@ -1023,16 +1025,32 @@ inline ObjectArray* KWObject::ComputeObjectArrayValueAt(KWLoadIndex liLoadIndex)
 		if (GetAt(liLoadIndex.GetDenseIndex()).IsObjectArrayForbidenValue())
 		{
 			// Verification que l'attribut est derive
-			assert(kwcClass->GetAttributeAtLoadIndex(liLoadIndex)->GetDerivationRule() != NULL);
+			rule = kwcClass->GetAttributeAtLoadIndex(liLoadIndex)->GetDerivationRule();
+			assert(rule != NULL);
 
 			// Derivation
 			// Le tableau d'objet rendu par la regle est duplique, et appartient desormais a l'objet
-			oaSubObjects = kwcClass->GetAttributeAtLoadIndex(liLoadIndex)
-					   ->GetDerivationRule()
-					   ->ComputeObjectArrayResult(this, liLoadIndex);
+			oaSubObjects = rule->ComputeObjectArrayResult(this, liLoadIndex);
 			if (oaSubObjects != NULL)
 				oaSubObjects = oaSubObjects->Clone();
 			GetAt(liLoadIndex.GetDenseIndex()).SetObjectArray(oaSubObjects);
+
+			// Cas d'une regle de creation d'instances
+			// Il faut s'assurer qu'il n'y a pas d'objet a NULL dans le tableau, ce qui peut arriver
+			// en cas de depassement des limite memoire lors de la creation d'instance
+			// Les regles de creation d'instance s'assurent juste de ne pas appeler de methodes
+			// sur les instances NULL, mais elle peuvent en integrer dans leur tableau
+			// Ici, de facon centralisee, on nettoie les tableaux en cas de probleme memoire
+			if (not rule->GetReference())
+			{
+				// Acces au service de protection memoire
+				memoryGuard = GetObjectDataPath()->GetMemoryGuard();
+
+				// Nettoyage du tableau en cas de depassement memoire, pour eviter les instances NULL
+				if (memoryGuard->IsSingleInstanceMemoryLimitReached())
+					oaSubObjects->DeleteAll();
+			}
+			assert(oaSubObjects->NoNulls());
 
 			// Verification de la valeur de l'attribut derive
 			assert(not GetAt(liLoadIndex.GetDenseIndex()).IsObjectArrayForbidenValue());

--- a/src/Learning/KWData/KWObjectDataPath.cpp
+++ b/src/Learning/KWData/KWObjectDataPath.cpp
@@ -1,0 +1,288 @@
+// Copyright (c) 2023-2025 Orange. All rights reserved.
+// This software is distributed under the BSD 3-Clause-clear License, the text of which is available
+// at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
+
+#include "KWObjectDataPath.h"
+
+// Inclusion de ce header dans le source pour eviter une dependance cyclique
+#include "KWClass.h"
+
+////////////////////////////////////////////////////////////
+// Classe KWObjectDataPath
+
+KWObjectDataPath::KWObjectDataPath()
+{
+	bCreatedObjects = false;
+	lMainCreationIndex = 0;
+	lCreationNumber = 0;
+	dataPathManager = NULL;
+	nCompiledRandomSeed = 0;
+	nCompiledRandomLeap = 0;
+	nCompileHash = 0;
+}
+
+KWObjectDataPath::~KWObjectDataPath() {}
+
+boolean KWObjectDataPath::IsRuleCreationManaged() const
+{
+	return true;
+}
+
+void KWObjectDataPath::ResetCreationNumber(longint lNewMainCreationIndex) const
+{
+	int n;
+	KWObjectDataPath* componentDataPath;
+
+	require(IsCompiled());
+	require(lNewMainCreationIndex >= 0);
+
+	// Reinitialisation des index
+	lMainCreationIndex = lNewMainCreationIndex;
+	lCreationNumber = 0;
+
+	// Propagation aux sous data paths
+	for (n = 0; n < oaComponents.GetSize(); n++)
+	{
+		componentDataPath = cast(KWObjectDataPath*, oaComponents.GetAt(n));
+		componentDataPath->ResetCreationNumber(lMainCreationIndex);
+	}
+}
+
+void KWObjectDataPath::CopyFrom(const KWDataPath* aSource)
+{
+	const KWObjectDataPath* sourceObjectDataPath;
+
+	require(aSource != NULL);
+
+	// Methode ancetre
+	KWDataPath::CopyFrom(aSource);
+
+	// Specialisation
+	sourceObjectDataPath = cast(const KWObjectDataPath*, aSource);
+	bCreatedObjects = sourceObjectDataPath->bCreatedObjects;
+
+	// Nettoyage des attributs de composition ou de gestion
+	lCreationNumber = 0;
+	oaComponents.SetSize(0);
+	dataPathManager = NULL;
+	liCompiledTerminalAttributeLoadIndex.Reset();
+	nCompiledRandomSeed = 0;
+	nCompiledRandomLeap = 0;
+	oaCompiledComponentDataPathsByLoadIndex.SetSize(0);
+	nCompileHash = 0;
+}
+
+KWDataPath* KWObjectDataPath::Create() const
+{
+	return new KWObjectDataPath;
+}
+
+int KWObjectDataPath::Compare(const KWDataPath* aSource) const
+{
+	int nCompare;
+
+	require(aSource != NULL);
+
+	// Methode ancetre
+	nCompare = KWDataPath::Compare(aSource);
+
+	// Specialisation
+	if (nCompare == 0)
+		nCompare =
+		    CompareBoolean(GetCreatedObjects(), cast(const KWObjectDataPath*, aSource)->GetCreatedObjects());
+	return nCompare;
+}
+
+void KWObjectDataPath::Write(ostream& ost) const
+{
+	KWDataPath::Write(ost);
+	ost << "Created objects\t" << BooleanToString(GetCreatedObjects()) << "\n";
+}
+
+void KWObjectDataPath::WriteHeaderLineReport(ostream& ost) const
+{
+	KWDataPath::WriteHeaderLineReport(ost);
+	ost << "\tCreated";
+}
+
+void KWObjectDataPath::WriteLineReport(ostream& ost) const
+{
+	KWDataPath::WriteLineReport(ost);
+	ost << "\t";
+	if (GetCreatedObjects())
+		ost << "*";
+}
+
+longint KWObjectDataPath::GetUsedMemory() const
+{
+	longint lUsedMemory;
+
+	// Methode ancetre
+	lUsedMemory = KWDataPath::GetUsedMemory();
+	lUsedMemory += sizeof(KWObjectDataPath) - sizeof(KWDataPath);
+
+	// Specialisation
+	lUsedMemory += oaComponents.GetUsedMemory();
+	lUsedMemory += oaCompiledComponentDataPathsByLoadIndex.GetUsedMemory();
+	return lUsedMemory;
+}
+
+void KWObjectDataPath::Compile(const KWClass* mainClass)
+{
+	KWClass* kwcOriginClass;
+	KWClass* currentClass;
+	KWAttribute* currentAttribute;
+	int n;
+	KWObjectDataPath* componentDataPath;
+	ALString sSeedEncoding;
+	ALString sLeapEncoding;
+	ALString sTmp;
+
+	require(mainClass != NULL);
+	require(mainClass->IsCompiled());
+	require(Check());
+
+	// Arret si deja compile
+	if (IsCompiled())
+		return;
+
+	// Recherche de la classe origine
+	kwcOriginClass = mainClass->GetDomain()->LookupClass(sOriginClassName);
+	assert(kwcOriginClass != NULL);
+	assert(kwcOriginClass == mainClass or kwcOriginClass->GetName() != mainClass->GetName());
+
+	// Recherche de l'index de chargement du dernier attribut du data path et de sa class extremite
+	liCompiledTerminalAttributeLoadIndex.Reset();
+	currentClass = kwcOriginClass;
+	for (n = 0; n < GetDataPathAttributeNumber(); n++)
+	{
+		// Recherche de l'attribut
+		currentAttribute = currentClass->LookupAttribute(GetDataPathAttributeNameAt(n));
+		assert(currentAttribute != NULL);
+		assert(currentAttribute->GetLoaded());
+		assert(currentAttribute->GetLoadIndex().IsDense());
+		assert(KWType::IsRelation(currentAttribute->GetType()));
+		assert(currentAttribute->GetDerivationRule() == NULL or
+		       not currentAttribute->GetDerivationRule()->GetReference());
+
+		// Memorisation de son index de chargement
+		liCompiledTerminalAttributeLoadIndex.lFullIndex = currentAttribute->GetLoadIndex().lFullIndex;
+
+		// Changement de classe courante
+		currentClass = currentAttribute->GetClass();
+	}
+
+	// Compilation des sous data paths, por acceder a leurs services
+	for (n = 0; n < oaComponents.GetSize(); n++)
+	{
+		componentDataPath = cast(KWObjectDataPath*, oaComponents.GetAt(n));
+		componentDataPath->Compile(mainClass);
+	}
+
+	// Utilisation de la partie dense des index de chargement des attributs pour un acces direct aux sous data path
+	// Cet index ne peut depasser le nombre d'attributs charges en memoire de la classe terminale du data path
+	oaCompiledComponentDataPathsByLoadIndex.RemoveAll();
+	if (oaComponents.GetSize() > 0)
+	{
+		// Acces au dernier sous data path, pour avoir la valeur max d'index
+		componentDataPath = cast(KWObjectDataPath*, oaComponents.GetAt(oaComponents.GetSize() - 1));
+
+		// Retaillage du tableau compile
+		oaCompiledComponentDataPathsByLoadIndex.SetSize(
+		    componentDataPath->GetTerminalLoadIndex().GetDenseIndex() + 1);
+
+		// Memorisation de chaque sous data path selon son index dense
+		for (n = 0; n < oaComponents.GetSize(); n++)
+		{
+			componentDataPath = cast(KWObjectDataPath*, oaComponents.GetAt(n));
+			oaCompiledComponentDataPathsByLoadIndex.SetAt(
+			    componentDataPath->GetTerminalLoadIndex().GetDenseIndex(), componentDataPath);
+		}
+	}
+
+	// Initialisation des parametres de generateur aleatoire par hashage de chaines de caractere
+	// dependant du nom de la classe origine et du data path
+	sSeedEncoding = sTmp + "DataPathSeed" + kwcOriginClass->GetName() + "///" + GetDataPath() + "DataPathSeed";
+	sLeapEncoding = sTmp + "DataPathLeap" + kwcOriginClass->GetName() + "///" + GetDataPath() + "DataPathLeap";
+	sLeapEncoding.MakeReverse();
+	nCompiledRandomSeed = HashValue(sSeedEncoding);
+	nCompiledRandomLeap = HashValue(sLeapEncoding);
+
+	// On interdit un Leap de 0
+	n = 0;
+	while (nCompiledRandomLeap == 0)
+	{
+		sLeapEncoding += "_";
+		sLeapEncoding += IntToString(n);
+		nCompiledRandomLeap = HashValue(sLeapEncoding);
+		n++;
+	}
+
+	// Calcul de hash de compilation
+	nCompileHash = HashValue(GetDataPath());
+
+	ensure(IsCompiled());
+}
+
+boolean KWObjectDataPath::IsCompiled() const
+{
+	return nCompiledRandomLeap != 0 and nCompileHash == HashValue(GetDataPath());
+}
+
+////////////////////////////////////////////////////////////
+// Classe KWObjectDataPathManager
+
+KWObjectDataPathManager::KWObjectDataPathManager()
+{
+	// Specifialisation des objet data path crees par la classe
+	delete dataPathCreator;
+	dataPathCreator = new KWObjectDataPath;
+}
+
+KWObjectDataPathManager::~KWObjectDataPathManager() {}
+
+void KWObjectDataPathManager::ComputeAllDataPaths(const KWClass* mainClass)
+{
+	int i;
+	KWObjectDataPath* objectDataPath;
+
+	// Methode ancetre
+	KWDataPathManager::ComputeAllDataPaths(mainClass);
+
+	// Specialisation par optimisation des data paths
+	for (i = 0; i < oaDataPaths.GetSize(); i++)
+	{
+		objectDataPath = cast(KWObjectDataPath*, oaDataPaths.GetAt(i));
+
+		// Compilation
+		objectDataPath->Compile(mainClass);
+	}
+}
+
+void KWObjectDataPathManager::CopyFrom(const KWDataPathManager* aSource)
+{
+	int i;
+	KWObjectDataPath* objectDataPath;
+	KWClass* kwcMainClass;
+
+	// Methode ancetre
+	KWDataPathManager::CopyFrom(aSource);
+
+	// Specialisation par optimisation des data paths
+	kwcMainClass = KWClassDomain::GetCurrentDomain()->LookupClass(GetMainClassName());
+	if (kwcMainClass != NULL)
+	{
+		for (i = 0; i < oaDataPaths.GetSize(); i++)
+		{
+			objectDataPath = cast(KWObjectDataPath*, oaDataPaths.GetAt(i));
+
+			// Compilation
+			objectDataPath->Compile(kwcMainClass);
+		}
+	}
+}
+
+KWDataPathManager* KWObjectDataPathManager::Create() const
+{
+	return new KWObjectDataPathManager;
+}

--- a/src/Learning/KWData/KWObjectDataPath.cpp
+++ b/src/Learning/KWData/KWObjectDataPath.cpp
@@ -234,7 +234,9 @@ boolean KWObjectDataPath::IsCompiled() const
 
 KWObjectDataPathManager::KWObjectDataPathManager()
 {
-	// Specifialisation des objet data path crees par la classe
+	databaseMemoryGuard = NULL;
+
+	// Specifialisation des objets data path crees par la classe
 	delete dataPathCreator;
 	dataPathCreator = new KWObjectDataPath;
 }
@@ -280,6 +282,7 @@ void KWObjectDataPathManager::CopyFrom(const KWDataPathManager* aSource)
 			objectDataPath->Compile(kwcMainClass);
 		}
 	}
+	databaseMemoryGuard = cast(KWObjectDataPathManager*, aSource)->databaseMemoryGuard;
 }
 
 KWDataPathManager* KWObjectDataPathManager::Create() const

--- a/src/Learning/KWData/KWObjectDataPath.h
+++ b/src/Learning/KWData/KWObjectDataPath.h
@@ -65,7 +65,7 @@ public:
 	// Index de creation principal, servant de reference aux instances crees dans son contexte
 	longint GetMainCreationIndex() const;
 
-	// Obtention d'un nouvel index de creation, a memoirser our chaque nouvel objet cree
+	// Obtention d'un nouvel index de creation, a memoriser pour chaque nouvel objet cree
 	longint NewCreationIndex() const;
 
 	// Acces au nombre d'objet crees

--- a/src/Learning/KWData/KWObjectDataPath.h
+++ b/src/Learning/KWData/KWObjectDataPath.h
@@ -1,0 +1,269 @@
+// Copyright (c) 2023-2025 Orange. All rights reserved.
+// This software is distributed under the BSD 3-Clause-clear License, the text of which is available
+// at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
+
+#pragma once
+
+class KWObjectDataPath;
+class KWObjectDataPathManager;
+
+#include "KWDataPath.h"
+
+////////////////////////////////////////////////////////////
+// Classe KWObjectDataPath
+//
+// Specialisation de KWDataPath a destination des KWObject pour identifier de facon unique
+// chaque objet, qu'il soient stocke ou cree par une regle de derivation
+// Cet identifiant unique des KWObject exploite
+// - le data path de l'objet, qu'il soit lu ou cree par une regle
+// - le CreationIndex de l'object
+//   - s'il s'agit d'un objet lu: numero de ligne
+//   - s'il s'agit d'un objet cree par une regle
+//     - numero de creation local a son instance principale, plus CreationIndex de l'instance principal
+//     - dans le cas des table externe, le numero est local a l'ensemble de toutes les instances
+// Cette identication permet a la regle de derivation Random de generer des suites de valeurs aleatoires
+// de facon reproductible, et independantes entre elles si la regle Random est utilisee plusieurs fois.
+class KWObjectDataPath : public KWDataPath
+{
+public:
+	// Constructeur
+	KWObjectDataPath();
+	~KWObjectDataPath();
+
+	// Indique que la classe gere les data paths correspondant a des instances crees par des regle de creation d'instance
+	boolean IsRuleCreationManaged() const override;
+
+	// Indique si le data path correspond a des objets crees par des regles de creation d'instances
+	// (defaut: false, correspondant a des objet stockes dans des fichiers)
+	boolean GetCreatedObjects() const override;
+	void SetCreatedObjects(boolean bValue) override;
+
+	////////////////////////////////////////////////////////////////////////
+	// Service de navigation dans les data paths
+
+	// Acces au data path fils pour un index d'attribut relationnel du dictionnaire extremite
+	const KWObjectDataPath* GetComponentDataPath(const KWLoadIndex liAttributeLoadIndex) const;
+
+	////////////////////////////////////////////////////////////////////////
+	// Service d'identification des objets d'un schema multi-table
+	//
+	// Identifiant unique d'un objet dans une hierarchie de donnees multi-table,
+	//  que les donnees soit stockee et lue depuis des fichier ou crees en memoire
+	//  via des regles de derivation de creation d'instance
+	// Utilisation des CreationIndex: cf. KWObject::GetCreationIndex()
+	//   - objets stockes: CreationIndex unique et reproductible, base sur un numero de ligne dans un fichier
+	//   - objets crees: CreationIndex unique, base sur un compteur de creation d'instance local au data path
+	// Les objets crees peuvent alors etre identifie de facon unique par le CreationIndex de leur instance
+	// principale (main ou Root), et leur CreationIndex localement a cette instance stockee.
+
+	// Reinitialisation du compteur de creation d'instance, a appeler a chaque changement
+	// d'objet principal (racine de l'objet principal d'un schema multi-table), ou Root (racine dans le cas d'une table externe)
+	// Cette reinitialisation est propagee a tous
+	void ResetCreationNumber(longint lNewMainCreationIndex) const;
+
+	// Index de creation principal, servant de reference aux instances crees dans son contexte
+	longint GetMainCreationIndex() const;
+
+	// Obtention d'un nouvel index de creation, a memoirser our chaque nouvel objet cree
+	longint NewCreationIndex() const;
+
+	// Acces au nombre d'objet crees
+	longint GetCreationNumber() const;
+
+	////////////////////////////////////////////////////////////////////////
+	// Services de parametrage (Seed, Leap) de generateur pseudo-aleatoire par hashage du data path,
+	// pour le parametrage des generateur de nombre aleatoire, avec garantie de reproductibilite
+	// en calcul distribue, et d'independance entre les series aleatoire generes par differents
+	// appels a la regle de derivation Random
+
+	// Graine de generateur aleatoire
+	int GetRandomSeed() const;
+
+	// Saut de type leap frog d'un generateur aleatoire
+	int GetRandomLeap() const;
+
+	////////////////////////////////////////////////////////
+	// Divers
+
+	// Copie
+	void CopyFrom(const KWDataPath* aSource) override;
+
+	// Creation pour renvoyer une instance du meme type dynamique
+	KWDataPath* Create() const override;
+
+	// Comparaison
+	int Compare(const KWDataPath* aSource) const override;
+
+	// Ecriture
+	void Write(ostream& ost) const override;
+	void WriteHeaderLineReport(ostream& ost) const override;
+	void WriteLineReport(ostream& ost) const override;
+
+	// Memoire utilisee par le mapping
+	longint GetUsedMemory() const override;
+
+	////////////////////////////////////////////////////////
+	//// Implementation
+protected:
+	friend class KWObjectDataPathManager;
+
+	// Compilation pour avoir acces efficacement aux services avances
+	void Compile(const KWClass* mainClass);
+	boolean IsCompiled() const;
+
+	// Index de chargement de la derniere variable du data path, aboutissant a son extremite
+	const KWLoadIndex GetTerminalLoadIndex() const;
+
+	// Gestionnaire de ObjectDataPath
+	const KWObjectDataPathManager* GetObjectDataPathManager() const;
+
+	/////////////////////////////////////////////////////////////////////
+	// Attributs de base
+
+	// Indicateur de data path dedie a des objets crees par des regles de creation d'instances
+	boolean bCreatedObjects;
+
+	// Index de creation principal, servant de reference aux instances crees dans son contexte
+	mutable longint lMainCreationIndex;
+
+	// Nombre d'index de creation generes
+	mutable longint lCreationNumber;
+
+	/////////////////////////////////////////////////////////////////////
+	// Attributs de gestion de la compilation du data path
+
+	// Index de chargement de la derniere variable du data path, aboutissant a son extremite
+	KWLoadIndex liCompiledTerminalAttributeLoadIndex;
+
+	// Tableau des data path indexes par leur index de chargement
+	// On utilise la partie dense de l'index de chargement pour avoir un acces direct a un data path
+	ObjectArray oaCompiledComponentDataPathsByLoadIndex;
+
+	// Parametres pour le generateur de nombre aleatoire
+	int nCompiledRandomSeed;
+	int nCompiledRandomLeap;
+
+	// Valeur de hash du data path au moment de compilation, permettant de verifier sa validite
+	int nCompileHash;
+};
+
+////////////////////////////////////////////////////////////
+// Classe KWObjectDataPathManager
+// Specialisation dans le cas de KWObjectDataPath
+class KWObjectDataPathManager : public KWDataPathManager
+{
+public:
+	// Constructeur
+	KWObjectDataPathManager();
+	~KWObjectDataPathManager();
+
+	// Calcul de tous les data path a partir du dictionnaire principal
+	// d'une base multi-table
+	void ComputeAllDataPaths(const KWClass* mainClass) override;
+
+	// Acces aux data paths avec le type specialise
+	const KWObjectDataPath* GetObjectDataPathAt(int nIndex) const;
+	const KWObjectDataPath* GetExternalRootObjectDataPathAt(int nIndex) const;
+	const KWObjectDataPath* GetMainObjectDataPath() const;
+	const KWObjectDataPath* LookupObjectDataPath(const ALString& sDataPath) const;
+
+	////////////////////////////////////////////////////////
+	// Divers
+
+	// Copie
+	void CopyFrom(const KWDataPathManager* aSource) override;
+
+	// Creation pour renvoyer une instance du meme type dynamique
+	KWDataPathManager* Create() const override;
+};
+
+////////////////////////////////////////////////////////////
+// Implementations inline
+
+inline boolean KWObjectDataPath::GetCreatedObjects() const
+{
+	return bCreatedObjects;
+}
+
+inline void KWObjectDataPath::SetCreatedObjects(boolean bValue)
+{
+	bCreatedObjects = bValue;
+}
+
+inline const KWObjectDataPath* KWObjectDataPath::GetComponentDataPath(const KWLoadIndex liAttributeLoadIndex) const
+{
+	const KWObjectDataPath* foundComponentDataPath;
+
+	require(IsCompiled());
+	require(liAttributeLoadIndex.IsValid());
+	require(liAttributeLoadIndex.IsDense());
+	require(liAttributeLoadIndex.GetDenseIndex() < oaCompiledComponentDataPathsByLoadIndex.GetSize());
+
+	foundComponentDataPath =
+	    cast(const KWObjectDataPath*,
+		 oaCompiledComponentDataPathsByLoadIndex.GetAt(liAttributeLoadIndex.GetDenseIndex()));
+	ensure(foundComponentDataPath->GetTerminalLoadIndex().GetDenseIndex() == liAttributeLoadIndex.GetDenseIndex());
+	return foundComponentDataPath;
+}
+
+inline longint KWObjectDataPath::GetMainCreationIndex() const
+{
+	require(IsCompiled());
+	return lMainCreationIndex;
+}
+
+inline longint KWObjectDataPath::NewCreationIndex() const
+{
+	require(IsCompiled());
+	lCreationNumber++;
+	return lCreationNumber;
+}
+
+inline longint KWObjectDataPath::GetCreationNumber() const
+{
+	require(IsCompiled());
+	return lCreationNumber;
+}
+
+inline const KWLoadIndex KWObjectDataPath::GetTerminalLoadIndex() const
+{
+	require(IsCompiled());
+	return liCompiledTerminalAttributeLoadIndex;
+}
+
+inline int KWObjectDataPath::GetRandomSeed() const
+{
+	require(IsCompiled());
+	return nCompiledRandomSeed;
+}
+
+inline int KWObjectDataPath::GetRandomLeap() const
+{
+	require(IsCompiled());
+	return nCompiledRandomLeap;
+}
+
+inline const KWObjectDataPath* KWObjectDataPathManager::GetObjectDataPathAt(int nIndex) const
+{
+	return cast(const KWObjectDataPath*, GetDataPathAt(nIndex));
+}
+
+inline const KWObjectDataPath* KWObjectDataPathManager::GetMainObjectDataPath() const
+{
+	return cast(const KWObjectDataPath*, GetMainDataPath());
+}
+
+inline const KWObjectDataPath* KWObjectDataPathManager::GetExternalRootObjectDataPathAt(int nIndex) const
+{
+	return cast(const KWObjectDataPath*, GetExternalRootDataPathAt(nIndex));
+}
+
+inline const KWObjectDataPath* KWObjectDataPathManager::LookupObjectDataPath(const ALString& sDataPath) const
+{
+	return cast(const KWObjectDataPath*, LookupDataPath(sDataPath));
+}
+
+inline const KWObjectDataPathManager* KWObjectDataPath::GetObjectDataPathManager() const
+{
+	return cast(const KWObjectDataPathManager*, dataPathManager);
+}

--- a/src/Learning/KWData/KWObjectDataPath.h
+++ b/src/Learning/KWData/KWObjectDataPath.h
@@ -8,6 +8,7 @@ class KWObjectDataPath;
 class KWObjectDataPathManager;
 
 #include "KWDataPath.h"
+#include "KWDatabaseMemoryGuard.h"
 
 ////////////////////////////////////////////////////////////
 // Classe KWObjectDataPath
@@ -84,6 +85,10 @@ public:
 
 	////////////////////////////////////////////////////////
 	// Divers
+
+	// Service de protection memoire pour gerer les enregistrements trop volumineux,
+	// notamment la creation d'instances en grand nombre
+	KWDatabaseMemoryGuard* GetMemoryGuard() const;
 
 	// Copie
 	void CopyFrom(const KWDataPath* aSource) override;
@@ -167,6 +172,11 @@ public:
 	const KWObjectDataPath* GetMainObjectDataPath() const;
 	const KWObjectDataPath* LookupObjectDataPath(const ALString& sDataPath) const;
 
+	// Service de protection memoire pour gerer les enregistrements trop volumineux,
+	// notamment la creation d'instances en grand nombre
+	void SetMemoryGuard(KWDatabaseMemoryGuard* memoryGuard);
+	KWDatabaseMemoryGuard* GetMemoryGuard() const;
+
 	////////////////////////////////////////////////////////
 	// Divers
 
@@ -175,6 +185,11 @@ public:
 
 	// Creation pour renvoyer une instance du meme type dynamique
 	KWDataPathManager* Create() const override;
+
+	////////////////////////////////////////////////////////
+	//// Implementation
+protected:
+	KWDatabaseMemoryGuard* databaseMemoryGuard;
 };
 
 ////////////////////////////////////////////////////////////
@@ -243,6 +258,18 @@ inline int KWObjectDataPath::GetRandomLeap() const
 	return nCompiledRandomLeap;
 }
 
+inline KWDatabaseMemoryGuard* KWObjectDataPath::GetMemoryGuard() const
+{
+	require(GetObjectDataPathManager() != NULL);
+	require(GetObjectDataPathManager()->GetMemoryGuard() != NULL);
+	return GetObjectDataPathManager()->GetMemoryGuard();
+}
+
+inline const KWObjectDataPathManager* KWObjectDataPath::GetObjectDataPathManager() const
+{
+	return cast(const KWObjectDataPathManager*, dataPathManager);
+}
+
 inline const KWObjectDataPath* KWObjectDataPathManager::GetObjectDataPathAt(int nIndex) const
 {
 	return cast(const KWObjectDataPath*, GetDataPathAt(nIndex));
@@ -263,7 +290,12 @@ inline const KWObjectDataPath* KWObjectDataPathManager::LookupObjectDataPath(con
 	return cast(const KWObjectDataPath*, LookupDataPath(sDataPath));
 }
 
-inline const KWObjectDataPathManager* KWObjectDataPath::GetObjectDataPathManager() const
+inline void KWObjectDataPathManager::SetMemoryGuard(KWDatabaseMemoryGuard* memoryGuard)
 {
-	return cast(const KWObjectDataPathManager*, dataPathManager);
+	databaseMemoryGuard = memoryGuard;
+}
+
+inline KWDatabaseMemoryGuard* KWObjectDataPathManager::GetMemoryGuard() const
+{
+	return databaseMemoryGuard;
 }

--- a/src/Learning/KWData/KWSTDatabase.cpp
+++ b/src/Learning/KWData/KWSTDatabase.cpp
@@ -189,12 +189,12 @@ KWObject* KWSTDatabase::PhysicalRead()
 	// Parametrage du data path de l'objet
 	if (kwoObject != NULL)
 	{
-		kwoObject->SetObjectDataPath(objectDataPathManager->GetMainObjectDataPath());
+		kwoObject->SetObjectDataPath(objectDataPathManager.GetMainObjectDataPath());
 
 		// Reinitialisation des informations de gestion de creation d'instance pour tous les
 		// sous data path potentiels en cas de regles de derivation de creation d'instance
 		assert(kwoObject->GetClass() == kwcPhysicalClass);
-		objectDataPathManager->GetMainObjectDataPath()->ResetCreationNumber(kwoObject->GetCreationIndex());
+		objectDataPathManager.GetMainObjectDataPath()->ResetCreationNumber(kwoObject->GetCreationIndex());
 	}
 
 	// Positionnement du flag d'erreur

--- a/src/Learning/KWDataUtils/KWDatabaseTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTask.cpp
@@ -504,14 +504,8 @@ boolean KWDatabaseTask::MasterInitializeDatabase()
 			nSourceBufferSize = nForcedBufferSize;
 
 		// Parametrage du MemoryGuard dans le cas multi-tables
-		if (shared_sourceDatabase.GetDatabase()->IsMultiTableTechnology())
-		{
-			shared_sourceDatabase.GetMTDatabase()->SetMemoryGuardMaxSecondaryRecordNumber(
-			    shared_sourceDatabase.GetMTDatabase()->GetEstimatedMaxSecondaryRecordNumber());
-			shared_sourceDatabase.GetMTDatabase()->SetMemoryGuardSingleInstanceMemoryLimit(
-			    shared_sourceDatabase.GetMTDatabase()->ComputeEstimatedSingleInstanceMemoryLimit(
-				lSourceDatabaseGrantedMemory));
-		}
+		sourceDatabase->GetDatabase()->GetMemoryGuard()->SetSingleInstanceMemoryLimit(
+		    sourceDatabase->ComputeEstimatedSingleInstanceMemoryLimit(lSourceDatabaseGrantedMemory));
 	}
 
 	// Parametrage des tailles de buffer

--- a/src/Learning/KWDataUtils/PLDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLDatabaseTextFile.cpp
@@ -279,15 +279,6 @@ longint PLDatabaseTextFile::GetInMemoryEstimatedFileObjectNumber() const
 		return plstDatabaseTextFile->GetInMemoryEstimatedFileObjectNumber();
 }
 
-longint PLDatabaseTextFile::GetEstimatedUsedMemoryPerObject() const
-{
-	require(IsInitialized());
-	if (IsMultiTableTechnology())
-		return plmtDatabaseTextFile->GetEstimatedUsedMemoryPerObject()->GetAt(0);
-	else
-		return plstDatabaseTextFile->GetEstimatedUsedMemoryPerObject();
-}
-
 longint PLDatabaseTextFile::GetEmptyOpenNecessaryMemory() const
 {
 	require(IsInitialized());
@@ -358,6 +349,15 @@ int PLDatabaseTextFile::GetBufferSize() const
 		return plmtDatabaseTextFile->GetBufferSize();
 	else
 		return plstDatabaseTextFile->GetBufferSize();
+}
+
+longint PLDatabaseTextFile::ComputeEstimatedSingleInstanceMemoryLimit(longint lOpenGrantedMemory) const
+{
+	require(IsInitialized());
+	if (IsMultiTableTechnology())
+		return plmtDatabaseTextFile->ComputeEstimatedSingleInstanceMemoryLimit(lOpenGrantedMemory);
+	else
+		return plstDatabaseTextFile->ComputeEstimatedSingleInstanceMemoryLimit(lOpenGrantedMemory);
 }
 
 void PLDatabaseTextFile::PhysicalDeleteDatabase()

--- a/src/Learning/KWDataUtils/PLDatabaseTextFile.h
+++ b/src/Learning/KWDataUtils/PLDatabaseTextFile.h
@@ -93,9 +93,6 @@ public:
 	// Nombre d'objets dans le fichier, estime de facon heuristique
 	longint GetInMemoryEstimatedFileObjectNumber() const;
 
-	// Memoire utilisee par KWObject physique pour le fichier
-	longint GetEstimatedUsedMemoryPerObject() const;
-
 	// Memoire minimum necessaire pour ouvrir la base sans tenir compte des buffers
 	longint GetEmptyOpenNecessaryMemory() const;
 
@@ -115,6 +112,9 @@ public:
 	// Taille du buffer du driver : a manipuler avec precaution
 	void SetBufferSize(int nSize);
 	int GetBufferSize() const;
+
+	// Calcul de la memoire a reserver pour le DatabaseMemoryGuard
+	longint ComputeEstimatedSingleInstanceMemoryLimit(longint lOpenGrantedMemory) const;
 
 	// Affichage des messages de bilan d'un traitement de base
 	//   . le libelle de la base permet de qualifier le type d'utilisation de la base ("Input database", "Output

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
@@ -1076,11 +1076,11 @@ void PLMTDatabaseTextFile::ComputeMemoryGuardOpenInformation()
 				    longint(dAverageSecondaryRecordNumber *
 					    KWDatabaseMemoryGuard::GetDefautMaxSecondaryRecordNumberFactor());
 
-				// On prend egalement en compte des nombres absolus de records, repartis par table
-				// secondaire Pour le min, on prend le minimum, pour eviter de surestimer la memoire
-				// minimum necessaire En effet, on peut avoir une table principale petite, avec des
-				// tables secondaire comportement une majorite d'enregistrements orphelins, ce qui
-				// fausse les estimation et peut empecher a tort l'execution des taches
+				// On prend egalement en compte des nombres absolus de records, repartis par table secondaire.
+				// Pour le min, on prend le minimum, pour eviter de surestimer la memoire minimum necessaire.
+				// En effet, on peut avoir une table principale petite, avec des tables secondaires
+				// comportement une majorite d'enregistrements orphelins, ce qui fausse les estimations
+				// et peut empecher a tort l'execution des taches
 				dTableRatio = lSecondaryRecordNumber / (1.0 + lTotalSecondaryRecordNumber);
 				lMinSecondaryRecordNumber =
 				    min(lMinSecondaryRecordNumber,
@@ -1095,8 +1095,7 @@ void PLMTDatabaseTextFile::ComputeMemoryGuardOpenInformation()
 				lMinSecondaryRecordNumber = min(lMinSecondaryRecordNumber, lSecondaryRecordNumber);
 				lMaxSecondaryRecordNumber = min(lMaxSecondaryRecordNumber, lSecondaryRecordNumber);
 
-				// Dans le cas ou on sature sur le nombre total d'enregistrement, on differencie le min
-				// du max
+				// Dans le cas ou on sature sur le nombre total d'enregistrement, on differencie le min du max
 				if (lMinSecondaryRecordNumber == lMaxSecondaryRecordNumber)
 				{
 					// Correction pour avoir un ratio "standard" entre les nombre min et max
@@ -1377,8 +1376,10 @@ void PLShared_MTDatabaseTextFile::SerializeObject(PLSerializer* serializer, cons
 
 	// Ecriture des parametres du memory guard
 	serializer->PutLongint(database->GetMemoryGuardMaxSecondaryRecordNumber());
+	serializer->PutLongint(database->GetMemoryGuardMaxCreatedRecordNumber());
 	serializer->PutLongint(database->GetMemoryGuardSingleInstanceMemoryLimit());
 	serializer->PutLongint(KWDatabaseMemoryGuard::GetCrashTestMaxSecondaryRecordNumber());
+	serializer->PutLongint(KWDatabaseMemoryGuard::GetCrashTestMaxCreatedRecordNumber());
 	serializer->PutLongint(KWDatabaseMemoryGuard::GetCrashTestSingleInstanceMemoryLimit());
 }
 
@@ -1469,8 +1470,10 @@ void PLShared_MTDatabaseTextFile::DeserializeObject(PLSerializer* serializer, Ob
 
 	// Lecture des parametres du memory guard
 	database->SetMemoryGuardMaxSecondaryRecordNumber(serializer->GetLongint());
+	database->SetMemoryGuardMaxCreatedRecordNumber(serializer->GetLongint());
 	database->SetMemoryGuardSingleInstanceMemoryLimit(serializer->GetLongint());
 	KWDatabaseMemoryGuard::SetCrashTestMaxSecondaryRecordNumber(serializer->GetLongint());
+	KWDatabaseMemoryGuard::SetCrashTestMaxCreatedRecordNumber(serializer->GetLongint());
 	KWDatabaseMemoryGuard::SetCrashTestSingleInstanceMemoryLimit(serializer->GetLongint());
 }
 

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
@@ -1047,7 +1047,7 @@ void PLMTDatabaseTextFile::ComputeMemoryGuardOpenInformation()
 		mapping = GetUsedMappingAt(i);
 		assert(mapping == NULL or mapping == mappingManager.GetMappingAt(i));
 
-		// Prise en compte si si mapping utilise
+		// Prise en compte si mapping utilise
 		if (mapping != NULL)
 		{
 			// Stats sur les records de la table secondaires

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.cpp
@@ -14,9 +14,6 @@ PLMTDatabaseTextFile::PLMTDatabaseTextFile()
 	lEmptyOpenNecessaryMemory = 0;
 	lMinOpenNecessaryMemory = 0;
 	lMaxOpenNecessaryMemory = 0;
-	lEstimatedMaxSecondaryRecordNumber = 0;
-	lEstimatedMinSingleInstanceMemoryLimit = 0;
-	lEstimatedMaxSingleInstanceMemoryLimit = 0;
 	nReadSizeMin = 0;
 	nReadSizeMax = 0;
 	bOpenOnDemandMode = false;
@@ -45,7 +42,6 @@ void PLMTDatabaseTextFile::Reset()
 	lTotalFileSize = 0;
 	lTotalUsedFileSize = 0;
 	lvInMemoryEstimatedFileObjectNumbers.SetSize(0);
-	lvEstimatedUsedMemoryPerObject.SetSize(0);
 	nMainLocalTableNumber = 0;
 	CleanOpenInformation();
 }
@@ -54,7 +50,7 @@ boolean PLMTDatabaseTextFile::ComputeOpenInformation(boolean bRead, boolean bInc
 						     PLMTDatabaseTextFile* outputDatabaseTextFile)
 {
 	boolean bOk = true;
-	boolean bDisplay = GetPreparationTraceMode();
+	const boolean bTrace = GetPreparationTraceMode();
 	boolean bCurrentVerboseMode;
 	KWMTDatabaseMapping* mapping;
 	KWMTDatabaseMapping* outputMapping;
@@ -128,7 +124,6 @@ boolean PLMTDatabaseTextFile::ComputeOpenInformation(boolean bRead, boolean bInc
 	{
 		lvFileSizes.SetSize(GetMultiTableMappings()->GetSize());
 		lvInMemoryEstimatedFileObjectNumbers.SetSize(GetMultiTableMappings()->GetSize());
-		lvEstimatedUsedMemoryPerObject.SetSize(GetMultiTableMappings()->GetSize());
 		oaUsedMappingHeaderLineClasses.SetSize(GetMultiTableMappings()->GetSize());
 	}
 
@@ -167,11 +162,6 @@ boolean PLMTDatabaseTextFile::ComputeOpenInformation(boolean bRead, boolean bInc
 		if (lvInMemoryEstimatedFileObjectNumbers.GetAt(i) == 0 and driver != NULL)
 			lvInMemoryEstimatedFileObjectNumbers.SetAt(
 			    i, driver->GetInMemoryEstimatedObjectNumber(lvFileSizes.GetAt(i)));
-
-		// Memorisation de la memoire utilisee par KWObject
-		lvEstimatedUsedMemoryPerObject.SetAt(i, 0);
-		if (driver != NULL)
-			lvEstimatedUsedMemoryPerObject.SetAt(i, driver->GetEstimatedUsedMemoryPerObject());
 
 		// Si driver present, on calcule et memorise le vecteur d'index des champs de la table en entree
 		if (bRead and driver != NULL)
@@ -325,28 +315,27 @@ boolean PLMTDatabaseTextFile::ComputeOpenInformation(boolean bRead, boolean bInc
 	if (bOk and bRead)
 	{
 		ComputeMemoryGuardOpenInformation();
+		assert(GetMemoryGuard()->GetEstimatedMinSingleInstanceMemoryLimit() <=
+		       GetMemoryGuard()->GetEstimatedMaxSingleInstanceMemoryLimit());
 
 		// Mise a jour des min et max de memoire necessaire, en tenant compte du DatabaseMemoryGuard
-		lMinOpenNecessaryMemory += lEstimatedMinSingleInstanceMemoryLimit;
-		lMaxOpenNecessaryMemory += lEstimatedMaxSingleInstanceMemoryLimit;
+		lMinOpenNecessaryMemory += GetMemoryGuard()->GetEstimatedMinSingleInstanceMemoryLimit();
+		lMaxOpenNecessaryMemory += GetMemoryGuard()->GetEstimatedMaxSingleInstanceMemoryLimit();
 	}
 
 	// Affichage
-	if (bDisplay)
+	if (bTrace)
 	{
-		cout << "PLMTDatabaseTextFile::ComputeOpenInformation " << bRead << endl;
+		cout << "PLMTDatabaseTextFile::ComputeOpenInformation " << bRead << "\n";
 		cout << "\tDatabaseClassNecessaryMemory\t"
-		     << LongintToHumanReadableString(lDatabaseClassNecessaryMemory) << endl;
+		     << LongintToHumanReadableString(lDatabaseClassNecessaryMemory) << "\n";
 		cout << "\tEmptyOpenNecessaryMemory\t" << LongintToHumanReadableString(lEmptyOpenNecessaryMemory)
-		     << endl;
-		cout << "\tMinOpenBufferSize\t" << LongintToHumanReadableString(nReadSizeMin) << endl;
-		cout << "\tMinOpenNecessaryMemory\t" << LongintToHumanReadableString(lMinOpenNecessaryMemory) << endl;
-		cout << "\tMaxOpenBufferSize\t" << LongintToHumanReadableString(nReadSizeMax) << endl;
-		cout << "\tMaxOpenNecessaryMemory\t" << LongintToHumanReadableString(lMaxOpenNecessaryMemory) << endl;
-		cout << "\tEstimatedMinSingleInstanceMemoryLimit\t"
-		     << LongintToHumanReadableString(lEstimatedMinSingleInstanceMemoryLimit) << endl;
-		cout << "\tEstimatedMaxSingleInstanceMemoryLimit\t"
-		     << LongintToHumanReadableString(lEstimatedMaxSingleInstanceMemoryLimit) << endl;
+		     << "\n";
+		cout << "\tMinOpenBufferSize\t" << LongintToHumanReadableString(nReadSizeMin) << "\n";
+		cout << "\tMinOpenNecessaryMemory\t" << LongintToHumanReadableString(lMinOpenNecessaryMemory) << "\n";
+		cout << "\tMaxOpenBufferSize\t" << LongintToHumanReadableString(nReadSizeMax) << "\n";
+		cout << "\tMaxOpenNecessaryMemory\t" << LongintToHumanReadableString(lMaxOpenNecessaryMemory) << "\n";
+		GetMemoryGuard()->WriteParameters(cout);
 	}
 
 	// Nettoyage
@@ -379,8 +368,7 @@ void PLMTDatabaseTextFile::CleanOpenInformation()
 	nReadSizeMax = 0;
 	oaIndexedMappingsDataItemLoadIndexes.DeleteAll();
 	oaIndexedMappingsMainKeyIndexes.DeleteAll();
-	lEstimatedMinSingleInstanceMemoryLimit = 0;
-	lEstimatedMaxSingleInstanceMemoryLimit = 0;
+	GetMemoryGuard()->Reset();
 }
 
 KWMTDatabaseMapping* PLMTDatabaseTextFile::GetUsedMappingAt(int nTableIndex) const
@@ -448,12 +436,6 @@ const LongintVector* PLMTDatabaseTextFile::GetInMemoryEstimatedFileObjectNumbers
 	return &lvInMemoryEstimatedFileObjectNumbers;
 }
 
-const LongintVector* PLMTDatabaseTextFile::GetEstimatedUsedMemoryPerObject() const
-{
-	require(IsOpenInformationComputed());
-	return &lvEstimatedUsedMemoryPerObject;
-}
-
 int PLMTDatabaseTextFile::GetMainLocalTableNumber() const
 {
 	return nMainLocalTableNumber;
@@ -481,24 +463,6 @@ longint PLMTDatabaseTextFile::GetOutputNecessaryDiskSpace() const
 {
 	require(IsOpenInformationComputed());
 	return lOutputNecessaryDiskSpace;
-}
-
-longint PLMTDatabaseTextFile::GetEstimatedMaxSecondaryRecordNumber() const
-{
-	require(IsOpenInformationComputed());
-	return lEstimatedMaxSecondaryRecordNumber;
-}
-
-longint PLMTDatabaseTextFile::GetEstimatedMinSingleInstanceMemoryLimit() const
-{
-	require(IsOpenInformationComputed());
-	return lEstimatedMinSingleInstanceMemoryLimit;
-}
-
-longint PLMTDatabaseTextFile::GetEstimatedMaxSingleInstanceMemoryLimit() const
-{
-	require(IsOpenInformationComputed());
-	return lEstimatedMaxSingleInstanceMemoryLimit;
 }
 
 int PLMTDatabaseTextFile::GetMaxSlaveProcessNumber() const
@@ -533,6 +497,7 @@ int PLMTDatabaseTextFile::ComputeOpenBufferSize(boolean bRead, longint lOpenGran
 		// Calcul de la partie de la memoire pour les buffers
 		lOpenGrantedMemoryForBuffers =
 		    lOpenGrantedMemory - ComputeEstimatedSingleInstanceMemoryLimit(lOpenGrantedMemory);
+		assert(nReadSizeMin <= lOpenGrantedMemoryForBuffers and lOpenGrantedMemoryForBuffers <= nReadSizeMax);
 
 		// On recherche par dichotomie la taille de buffer permettant d'utiliser au mieux la memoire alouee
 		nLowerBufferSize = nReadSizeMin;
@@ -589,22 +554,24 @@ longint PLMTDatabaseTextFile::ComputeEstimatedSingleInstanceMemoryLimit(longint 
 
 	// Cas ou on a alloue le min
 	if (lOpenGrantedMemory == lMinOpenNecessaryMemory)
-		lEstimatedSingleInstanceMemoryLimit = lEstimatedMinSingleInstanceMemoryLimit;
+		lEstimatedSingleInstanceMemoryLimit = GetConstMemoryGuard()->GetEstimatedMinSingleInstanceMemoryLimit();
 	// Cas ou on a alloue le min
 	else if (lOpenGrantedMemory == lMaxOpenNecessaryMemory)
-		lEstimatedSingleInstanceMemoryLimit = lEstimatedMaxSingleInstanceMemoryLimit;
+		lEstimatedSingleInstanceMemoryLimit = GetConstMemoryGuard()->GetEstimatedMaxSingleInstanceMemoryLimit();
 	// Cas intermediaire
 	else
 	{
 		// Calcul selon une regle de 3
 		dPercentage = (lOpenGrantedMemory - lMinOpenNecessaryMemory) * 1.0 /
 			      (lMaxOpenNecessaryMemory - lMinOpenNecessaryMemory);
-		lEstimatedSingleInstanceMemoryLimit = lEstimatedMinSingleInstanceMemoryLimit +
-						      longint(dPercentage * (lEstimatedMaxSingleInstanceMemoryLimit -
-									     lEstimatedMinSingleInstanceMemoryLimit));
+		lEstimatedSingleInstanceMemoryLimit =
+		    GetConstMemoryGuard()->GetEstimatedMinSingleInstanceMemoryLimit() +
+		    longint(dPercentage * (GetConstMemoryGuard()->GetEstimatedMaxSingleInstanceMemoryLimit() -
+					   GetConstMemoryGuard()->GetEstimatedMinSingleInstanceMemoryLimit()));
 	}
-	ensure(lEstimatedMinSingleInstanceMemoryLimit <= lEstimatedSingleInstanceMemoryLimit and
-	       lEstimatedSingleInstanceMemoryLimit <= lEstimatedMaxSingleInstanceMemoryLimit);
+	ensure(
+	    GetConstMemoryGuard()->GetEstimatedMinSingleInstanceMemoryLimit() <= lEstimatedSingleInstanceMemoryLimit and
+	    lEstimatedSingleInstanceMemoryLimit <= GetConstMemoryGuard()->GetEstimatedMaxSingleInstanceMemoryLimit());
 	ensure(lEstimatedSingleInstanceMemoryLimit <= lOpenGrantedMemory);
 	return lEstimatedSingleInstanceMemoryLimit;
 }
@@ -1004,28 +971,45 @@ void PLMTDatabaseTextFile::PhysicalDeleteDatabase()
 
 void PLMTDatabaseTextFile::ComputeMemoryGuardOpenInformation()
 {
-	boolean bDisplay = false;
+	const boolean bTrace = false;
 	int i;
 	KWMTDatabaseMapping* mapping;
+	PLDataTableDriverTextFile* driver;
 	longint lMainObjectNumber;
 	longint lSecondaryRecordNumber;
 	longint lUsedMemoryPerObject;
-	double dAverageSecondaryRecordNumber;
+	longint lEstimatedMemoryForSingleObjectCreation;
+	longint lEstimatedMemoryForMultipleObjectCreation;
+	longint lEstimatedTotalCreatedSingleObjectNumber;
+	longint lEstimatedTotalCreatedMultipleObjectNumber;
+	longint lAverageSecondaryRecordNumber;
 	longint lMinSecondaryRecordNumber;
 	longint lMaxSecondaryRecordNumber;
 	longint lTotalSecondaryRecordNumber;
+	longint lTotalMaxSecondaryRecordNumber;
+	longint lTotalMaxCreatedRecordNumber;
+	longint lEstimatedMinSingleInstanceMemoryLimit;
+	longint lEstimatedMaxSingleInstanceMemoryLimit;
 	double dTableRatio;
 	longint lUsedMemoryForTableSelection;
+	const KWDataPath* dataPath;
 
-	// Le dimensionnement des buffer doit etre effectue
+	// Le dimensionnement des buffers doit etre effectue
 	require(lMinOpenNecessaryMemory > 0);
 
 	// Initialisation des resultats
-	lEstimatedMaxSecondaryRecordNumber = 0;
+	GetMemoryGuard()->Reset();
+	lTotalMaxSecondaryRecordNumber = 0;
+	lTotalMaxCreatedRecordNumber = 0;
 	lEstimatedMinSingleInstanceMemoryLimit = 0;
 	lEstimatedMaxSingleInstanceMemoryLimit = 0;
-	if (bDisplay)
+	if (bTrace)
 		cout << "ComputeMemoryGuardOpenInformation\n";
+
+	// Initialisation de tous les data paths a destination des objets lus ou cree
+	// pour le dimensionnement des objets cree
+	assert(objectDataPathManager.GetDataPathNumber() == 0);
+	objectDataPathManager.ComputeAllDataPaths(kwcPhysicalClass);
 
 	// Nombre de records de la table principale
 	assert(GetUsedMappingAt(0) != NULL);
@@ -1050,13 +1034,17 @@ void PLMTDatabaseTextFile::ComputeMemoryGuardOpenInformation()
 		// Prise en compte si mapping utilise
 		if (mapping != NULL)
 		{
+			driver = cast(PLDataTableDriverTextFile*, mapping->GetDataTableDriver());
+			assert(driver != NULL);
+
 			// Stats sur les records de la table secondaires
 			lSecondaryRecordNumber = GetInMemoryEstimatedFileObjectNumbers()->GetAt(i);
-			lUsedMemoryPerObject = GetEstimatedUsedMemoryPerObject()->GetAt(i);
+			lUsedMemoryPerObject = driver->GetClass()->GetEstimatedUsedMemoryPerObject();
 
 			// Cas de la table principale
 			if (i == 0)
 			{
+				lAverageSecondaryRecordNumber = 1;
 				lEstimatedMinSingleInstanceMemoryLimit = lUsedMemoryPerObject;
 				lEstimatedMaxSingleInstanceMemoryLimit = lUsedMemoryPerObject;
 				lMinSecondaryRecordNumber = 0;
@@ -1065,16 +1053,16 @@ void PLMTDatabaseTextFile::ComputeMemoryGuardOpenInformation()
 			// Prise en compte des records des tables secondaires
 			else
 			{
-				dAverageSecondaryRecordNumber = 1 + lSecondaryRecordNumber / (1.0 + lMainObjectNumber);
+				lAverageSecondaryRecordNumber = 1 + lSecondaryRecordNumber / (1 + lMainObjectNumber);
 
 				// Estimation du nombre min de records a traiter, selon un facteur par rapport au nombre
 				// moyen de record par instance principale
 				lMinSecondaryRecordNumber =
-				    longint(dAverageSecondaryRecordNumber *
-					    KWDatabaseMemoryGuard::GetDefautMinSecondaryRecordNumberFactor());
+				    lAverageSecondaryRecordNumber *
+				    KWDatabaseMemoryGuard::GetDefautMinSecondaryRecordNumberFactor();
 				lMaxSecondaryRecordNumber =
-				    longint(dAverageSecondaryRecordNumber *
-					    KWDatabaseMemoryGuard::GetDefautMaxSecondaryRecordNumberFactor());
+				    lAverageSecondaryRecordNumber *
+				    KWDatabaseMemoryGuard::GetDefautMaxSecondaryRecordNumberFactor();
 
 				// On prend egalement en compte des nombres absolus de records, repartis par table secondaire.
 				// Pour le min, on prend le minimum, pour eviter de surestimer la memoire minimum necessaire.
@@ -1095,7 +1083,7 @@ void PLMTDatabaseTextFile::ComputeMemoryGuardOpenInformation()
 				lMinSecondaryRecordNumber = min(lMinSecondaryRecordNumber, lSecondaryRecordNumber);
 				lMaxSecondaryRecordNumber = min(lMaxSecondaryRecordNumber, lSecondaryRecordNumber);
 
-				// Dans le cas ou on sature sur le nombre total d'enregistrement, on differencie le min du max
+				// Dans le cas ou on sature sur le nombre total d'enregistrements, on differencie le min du max
 				if (lMinSecondaryRecordNumber == lMaxSecondaryRecordNumber)
 				{
 					// Correction pour avoir un ratio "standard" entre les nombre min et max
@@ -1109,60 +1097,91 @@ void PLMTDatabaseTextFile::ComputeMemoryGuardOpenInformation()
 					    lMinSecondaryRecordNumber,
 					    longint(
 						sqrt(KWDatabaseMemoryGuard::GetDefautMinSecondaryRecordNumberFactor()) *
-						dAverageSecondaryRecordNumber));
+						lAverageSecondaryRecordNumber));
 					lMinSecondaryRecordNumber =
 					    min(lMinSecondaryRecordNumber, lMaxSecondaryRecordNumber);
 				}
 
-				// Prise en compte pour le dimensionnement, en prenant un peu de marge pour les variable
+				// Prise en compte pour le dimensionnement, en prenant un peu de marge pour les variables
 				// secondaires memorisant des selections
 				lUsedMemoryForTableSelection = sizeof(KWObject*) + sizeof(KWValueIndexPair) +
 							       sizeof(ObjectArray*) + sizeof(ObjectArray);
-				lEstimatedMaxSecondaryRecordNumber += lMinSecondaryRecordNumber;
+				lTotalMaxSecondaryRecordNumber += lMaxSecondaryRecordNumber;
 				lEstimatedMinSingleInstanceMemoryLimit +=
 				    lMinSecondaryRecordNumber * (lUsedMemoryPerObject + lUsedMemoryForTableSelection);
 				lEstimatedMaxSingleInstanceMemoryLimit +=
 				    lMaxSecondaryRecordNumber * (lUsedMemoryPerObject + lUsedMemoryForTableSelection);
 			}
 
+			// Estimation des stats sur les objets crees dans la hierarchie
+			dataPath = objectDataPathManager.LookupDataPath(mapping->GetDataPath());
+			dataPath->ComputeEstimatedMemoryForObjectCreation(
+			    driver->GetClass()->GetDomain(), lEstimatedMemoryForSingleObjectCreation,
+			    lEstimatedMemoryForMultipleObjectCreation, lEstimatedTotalCreatedSingleObjectNumber,
+			    lEstimatedTotalCreatedMultipleObjectNumber);
+
+			// Prise en compte de la memoire pour les objets crees
+			lTotalMaxCreatedRecordNumber +=
+			    lEstimatedTotalCreatedSingleObjectNumber +
+			    lEstimatedTotalCreatedMultipleObjectNumber *
+				KWDatabaseMemoryGuard::GetDefautMaxSecondaryRecordNumberFactor();
+			lEstimatedMinSingleInstanceMemoryLimit +=
+			    lEstimatedMemoryForSingleObjectCreation +
+			    lAverageSecondaryRecordNumber * lEstimatedMemoryForMultipleObjectCreation *
+				KWDatabaseMemoryGuard::GetDefautMinSecondaryRecordNumberFactor();
+			lEstimatedMaxSingleInstanceMemoryLimit +=
+			    lEstimatedMemoryForSingleObjectCreation +
+			    lAverageSecondaryRecordNumber * lEstimatedMemoryForMultipleObjectCreation *
+				KWDatabaseMemoryGuard::GetDefautMaxSecondaryRecordNumberFactor();
+
 			// Affichage des details
-			if (bDisplay)
+			if (bTrace)
 			{
 				if (i == 0)
-					cout << "\t\tTable\tDataPath\tRecords\tRAM per record\tlEst. max records\tMin "
-						"record\tMax record\tMin RAM\tMax RAM\n";
-				cout << "\t\tTable" << i << "\t" << mapping->GetDataPath() << "\t"
-				     << lSecondaryRecordNumber << "\t" << lUsedMemoryPerObject << "\t";
-				cout << lEstimatedMaxSecondaryRecordNumber << "\t";
-				cout << lMinSecondaryRecordNumber << "\t" << lMaxSecondaryRecordNumber << "\t";
+					cout << "\t\tTable\tDataPath\tRecords\tRAM per record\tRAM for single "
+						"creation\tRAM for multiple creation\tlTotal "
+						"max records\tTotal max created\tMin "
+						"records\tMean records\tMax records\tMin RAM\tMax RAM\n";
+				cout << "\t\tTable" << i << "\t";
+				cout << mapping->GetDataPath() << "\t";
+				cout << lSecondaryRecordNumber << "\t";
+				cout << lUsedMemoryPerObject << "\t";
+				cout << lEstimatedMemoryForSingleObjectCreation << "\t";
+				cout << lEstimatedMemoryForMultipleObjectCreation << "\t";
+				cout << lTotalMaxSecondaryRecordNumber << "\t";
+				cout << lTotalMaxCreatedRecordNumber << "\t";
+				cout << lMinSecondaryRecordNumber << "\t";
+				cout << lAverageSecondaryRecordNumber << "\t";
+				cout << lMaxSecondaryRecordNumber << "\t";
 				cout << lEstimatedMinSingleInstanceMemoryLimit << "\t"
 				     << lEstimatedMaxSingleInstanceMemoryLimit << "\n";
 			}
 		}
 	}
 
-	// On utilise une limite minimale au nombre max de records secondaires, pour de pas declencher de warning
-	// utilisateurs excessifs
-	lEstimatedMaxSecondaryRecordNumber = max(lEstimatedMaxSecondaryRecordNumber,
-						 KWDatabaseMemoryGuard::GetDefautMinSecondaryRecordNumberLowerBound());
+	// On utilise une limite minimale au nombre max de records secondaires ou crees,
+	// pour de pas declencher de warning utilisateurs excessifs
+	lTotalMaxSecondaryRecordNumber =
+	    max(lTotalMaxSecondaryRecordNumber, KWDatabaseMemoryGuard::GetDefautMinSecondaryRecordNumberLowerBound());
+	lTotalMaxCreatedRecordNumber =
+	    max(lTotalMaxCreatedRecordNumber, KWDatabaseMemoryGuard::GetDefautMinSecondaryRecordNumberLowerBound());
 
 	// On utilise une limite minimale a la memoire RAM, pour de pas declencher de warning utilisateurs excessifs
-	lEstimatedMinSingleInstanceMemoryLimit += 2 * BufferedFile::nDefaultBufferSize;
+	lEstimatedMinSingleInstanceMemoryLimit += BufferedFile::nDefaultBufferSize / 8;
 	lEstimatedMaxSingleInstanceMemoryLimit += 2 * BufferedFile::nDefaultBufferSize;
 
-	// Passage de la memoire logique a la memoire physique en RAM
-	lEstimatedMinSingleInstanceMemoryLimit =
-	    longint(lEstimatedMinSingleInstanceMemoryLimit * (1 + MemGetAllocatorOverhead()));
-	lEstimatedMaxSingleInstanceMemoryLimit =
-	    longint(lEstimatedMaxSingleInstanceMemoryLimit * (1 + MemGetAllocatorOverhead()));
+	// Destruction des data paths de gestion des objets
+	objectDataPathManager.Reset();
+
+	// Memorisation dans le memory guard
+	GetMemoryGuard()->SetMaxSecondaryRecordNumber(lTotalMaxSecondaryRecordNumber);
+	GetMemoryGuard()->SetMaxCreatedRecordNumber(lTotalMaxCreatedRecordNumber);
+	GetMemoryGuard()->SetEstimatedMinSingleInstanceMemoryLimit(lEstimatedMinSingleInstanceMemoryLimit);
+	GetMemoryGuard()->SetEstimatedMaxSingleInstanceMemoryLimit(lEstimatedMaxSingleInstanceMemoryLimit);
 
 	// Affichage
-	if (bDisplay)
-	{
-		cout << "\tMaxSecondaryRecordNumber\t" << lEstimatedMaxSecondaryRecordNumber << endl;
-		cout << "\tMinSingleInstanceMemoryLimit\t" << lEstimatedMinSingleInstanceMemoryLimit << endl;
-		cout << "\tMaxSingleInstanceMemoryLimit\t" << lEstimatedMaxSingleInstanceMemoryLimit << endl;
-	}
+	if (bTrace)
+		GetMemoryGuard()->WriteParameters(cout);
 }
 
 longint PLMTDatabaseTextFile::ComputeBufferNecessaryMemory(boolean bRead, int nBufferSize) const
@@ -1350,15 +1369,11 @@ void PLShared_MTDatabaseTextFile::SerializeObject(PLSerializer* serializer, cons
 	serializer->PutLongint(database->lTotalUsedFileSize);
 	serializer->PutInt(database->nDatabasePreferredBufferSize);
 	serializer->PutLongintVector(&database->lvInMemoryEstimatedFileObjectNumbers);
-	serializer->PutLongintVector(&database->lvEstimatedUsedMemoryPerObject);
 	serializer->PutInt(database->nMainLocalTableNumber);
 	serializer->PutLongint(database->lOutputNecessaryDiskSpace);
 	serializer->PutLongint(database->lEmptyOpenNecessaryMemory);
 	serializer->PutLongint(database->lMinOpenNecessaryMemory);
 	serializer->PutLongint(database->lMaxOpenNecessaryMemory);
-	serializer->PutLongint(database->lEstimatedMaxSecondaryRecordNumber);
-	serializer->PutLongint(database->lEstimatedMinSingleInstanceMemoryLimit);
-	serializer->PutLongint(database->lEstimatedMaxSingleInstanceMemoryLimit);
 	serializer->PutInt(database->nReadSizeMin);
 	serializer->PutInt(database->nReadSizeMax);
 
@@ -1375,9 +1390,11 @@ void PLShared_MTDatabaseTextFile::SerializeObject(PLSerializer* serializer, cons
 	shared_oaIndexedMappingsMainKeyIndexes.SerializeObject(serializer, &database->oaIndexedMappingsMainKeyIndexes);
 
 	// Ecriture des parametres du memory guard
-	serializer->PutLongint(database->GetMemoryGuardMaxSecondaryRecordNumber());
-	serializer->PutLongint(database->GetMemoryGuardMaxCreatedRecordNumber());
-	serializer->PutLongint(database->GetMemoryGuardSingleInstanceMemoryLimit());
+	serializer->PutLongint(database->GetConstMemoryGuard()->GetMaxSecondaryRecordNumber());
+	serializer->PutLongint(database->GetConstMemoryGuard()->GetMaxCreatedRecordNumber());
+	serializer->PutLongint(database->GetConstMemoryGuard()->GetEstimatedMinSingleInstanceMemoryLimit());
+	serializer->PutLongint(database->GetConstMemoryGuard()->GetEstimatedMaxSingleInstanceMemoryLimit());
+	serializer->PutLongint(database->GetConstMemoryGuard()->GetSingleInstanceMemoryLimit());
 	serializer->PutLongint(KWDatabaseMemoryGuard::GetCrashTestMaxSecondaryRecordNumber());
 	serializer->PutLongint(KWDatabaseMemoryGuard::GetCrashTestMaxCreatedRecordNumber());
 	serializer->PutLongint(KWDatabaseMemoryGuard::GetCrashTestSingleInstanceMemoryLimit());
@@ -1448,15 +1465,11 @@ void PLShared_MTDatabaseTextFile::DeserializeObject(PLSerializer* serializer, Ob
 	database->lTotalUsedFileSize = serializer->GetLongint();
 	database->nDatabasePreferredBufferSize = serializer->GetInt();
 	serializer->GetLongintVector(&database->lvInMemoryEstimatedFileObjectNumbers);
-	serializer->GetLongintVector(&database->lvEstimatedUsedMemoryPerObject);
 	database->nMainLocalTableNumber = serializer->GetInt();
 	database->lOutputNecessaryDiskSpace = serializer->GetLongint();
 	database->lEmptyOpenNecessaryMemory = serializer->GetLongint();
 	database->lMinOpenNecessaryMemory = serializer->GetLongint();
 	database->lMaxOpenNecessaryMemory = serializer->GetLongint();
-	database->lEstimatedMaxSecondaryRecordNumber = serializer->GetLongint();
-	database->lEstimatedMinSingleInstanceMemoryLimit = serializer->GetLongint();
-	database->lEstimatedMaxSingleInstanceMemoryLimit = serializer->GetLongint();
 	database->nReadSizeMin = serializer->GetInt();
 	database->nReadSizeMax = serializer->GetInt();
 
@@ -1469,9 +1482,11 @@ void PLShared_MTDatabaseTextFile::DeserializeObject(PLSerializer* serializer, Ob
 								 &database->oaIndexedMappingsMainKeyIndexes);
 
 	// Lecture des parametres du memory guard
-	database->SetMemoryGuardMaxSecondaryRecordNumber(serializer->GetLongint());
-	database->SetMemoryGuardMaxCreatedRecordNumber(serializer->GetLongint());
-	database->SetMemoryGuardSingleInstanceMemoryLimit(serializer->GetLongint());
+	database->GetMemoryGuard()->SetMaxSecondaryRecordNumber(serializer->GetLongint());
+	database->GetMemoryGuard()->SetMaxCreatedRecordNumber(serializer->GetLongint());
+	database->GetMemoryGuard()->SetEstimatedMinSingleInstanceMemoryLimit(serializer->GetLongint());
+	database->GetMemoryGuard()->SetEstimatedMaxSingleInstanceMemoryLimit(serializer->GetLongint());
+	database->GetMemoryGuard()->SetSingleInstanceMemoryLimit(serializer->GetLongint());
 	KWDatabaseMemoryGuard::SetCrashTestMaxSecondaryRecordNumber(serializer->GetLongint());
 	KWDatabaseMemoryGuard::SetCrashTestMaxCreatedRecordNumber(serializer->GetLongint());
 	KWDatabaseMemoryGuard::SetCrashTestSingleInstanceMemoryLimit(serializer->GetLongint());

--- a/src/Learning/KWDataUtils/PLMTDatabaseTextFile.h
+++ b/src/Learning/KWDataUtils/PLMTDatabaseTextFile.h
@@ -79,10 +79,6 @@ public:
 	// Renvoie 0 pour les fichiers des tables non encore utilisees
 	const LongintVector* GetInMemoryEstimatedFileObjectNumbers() const;
 
-	// Memoire utilisee par KWObject physique pour chaque fichier
-	// Renvoie 0 pour les fichiers des tables non concernees
-	const LongintVector* GetEstimatedUsedMemoryPerObject() const;
-
 	// Nombre de tables principales, hors tables externes, avec des fichiers locaux (sans URI)
 	int GetMainLocalTableNumber() const;
 
@@ -96,15 +92,6 @@ public:
 
 	// Memoire necessaire pour stocker le fichier d'une base en sortie a partir d'une base en lecture (0 sinon)
 	longint GetOutputNecessaryDiskSpace() const;
-
-	// Nombre max de records secondaires pour la parametrage du DatabaseMemoryGuard
-	// On renvoie 0 s'il n'est pas necessaire d'activer le DatabaseMemoryGuard, meme si
-	// on reserve de la memoire pour sa gestion
-	longint GetEstimatedMaxSecondaryRecordNumber() const;
-
-	// Memoire minimum et maximum necessaire pour le parametrage du DatabaseMemoryGuard
-	longint GetEstimatedMinSingleInstanceMemoryLimit() const;
-	longint GetEstimatedMaxSingleInstanceMemoryLimit() const;
 
 	// Nombre maximum de taches elementaires qui devront etre traitees par les esclaves
 	int GetMaxSlaveProcessNumber() const;
@@ -197,15 +184,11 @@ protected:
 	longint lTotalUsedFileSize;
 	int nDatabasePreferredBufferSize;
 	LongintVector lvInMemoryEstimatedFileObjectNumbers;
-	LongintVector lvEstimatedUsedMemoryPerObject;
 	int nMainLocalTableNumber;
 	longint lOutputNecessaryDiskSpace;
 	longint lEmptyOpenNecessaryMemory;
 	longint lMinOpenNecessaryMemory;
 	longint lMaxOpenNecessaryMemory;
-	longint lEstimatedMaxSecondaryRecordNumber;
-	longint lEstimatedMinSingleInstanceMemoryLimit;
-	longint lEstimatedMaxSingleInstanceMemoryLimit;
 
 	// Definition des exigences pour la taille du buffer
 	// La taille de buffer est porte par le driver

--- a/src/Learning/KWDataUtils/PLSTDatabaseTextFile.cpp
+++ b/src/Learning/KWDataUtils/PLSTDatabaseTextFile.cpp
@@ -462,8 +462,10 @@ void PLShared_STDatabaseTextFile::SerializeObject(PLSerializer* serializer, cons
 
 	// Ecriture des parametres du memory guard
 	serializer->PutLongint(database->GetMemoryGuardMaxSecondaryRecordNumber());
+	serializer->PutLongint(database->GetMemoryGuardMaxCreatedRecordNumber());
 	serializer->PutLongint(database->GetMemoryGuardSingleInstanceMemoryLimit());
 	serializer->PutLongint(KWDatabaseMemoryGuard::GetCrashTestMaxSecondaryRecordNumber());
+	serializer->PutLongint(KWDatabaseMemoryGuard::GetCrashTestMaxCreatedRecordNumber());
 	serializer->PutLongint(KWDatabaseMemoryGuard::GetCrashTestSingleInstanceMemoryLimit());
 }
 
@@ -509,8 +511,10 @@ void PLShared_STDatabaseTextFile::DeserializeObject(PLSerializer* serializer, Ob
 
 	// Lecture des parametres du memory guard
 	database->SetMemoryGuardMaxSecondaryRecordNumber(serializer->GetLongint());
+	database->SetMemoryGuardMaxCreatedRecordNumber(serializer->GetLongint());
 	database->SetMemoryGuardSingleInstanceMemoryLimit(serializer->GetLongint());
 	KWDatabaseMemoryGuard::SetCrashTestMaxSecondaryRecordNumber(serializer->GetLongint());
+	KWDatabaseMemoryGuard::SetCrashTestMaxCreatedRecordNumber(serializer->GetLongint());
 	KWDatabaseMemoryGuard::SetCrashTestSingleInstanceMemoryLimit(serializer->GetLongint());
 }
 

--- a/src/Learning/KWDataUtils/PLSTDatabaseTextFile.h
+++ b/src/Learning/KWDataUtils/PLSTDatabaseTextFile.h
@@ -64,9 +64,6 @@ public:
 	// Nombre d'objets dans le fichier, estime de facon heuristique
 	longint GetInMemoryEstimatedFileObjectNumber() const;
 
-	// Memoire utilisee par KWObject physique pour le fichier
-	longint GetEstimatedUsedMemoryPerObject() const;
-
 	// Memoire minimum necessaire pour ouvrir la base sans tenir compte des buffers
 	longint GetEmptyOpenNecessaryMemory() const;
 
@@ -82,6 +79,9 @@ public:
 
 	// Calcul de la memoire par buffer pour une memoire allouee pour l'ouverture et un nombre de process
 	int ComputeOpenBufferSize(boolean bRead, longint lOpenGrantedMemory, int nProcessNumber) const;
+
+	// Calcul de la memoire a reserver pour le DatabaseMemoryGuard
+	longint ComputeEstimatedSingleInstanceMemoryLimit(longint lOpenGrantedMemory) const;
 
 	//////////////////////////////////////////////////////////////////////////////////////
 	// Parametrage des buffers
@@ -111,12 +111,14 @@ public:
 protected:
 	friend class PLShared_STDatabaseTextFile;
 
+	// Calcul des informations necessaires pour la DatabaseMemoryGuard lors de l'ouverture de la base en lecture
+	void ComputeMemoryGuardOpenInformation();
+
 	// Resultat de l'appel de la methode ComputeOpenInformation
 	KWClass kwcHeaderLineClass;
 	longint lTotalFileSize;
 	int nDatabasePreferredBufferSize;
 	longint lInMemoryEstimatedFileObjectNumber;
-	longint lEstimatedUsedMemoryPerObject;
 	longint lOutputNecessaryDiskSpace;
 	longint lEmptyOpenNecessaryMemory;
 	longint lMinOpenNecessaryMemory;

--- a/src/Learning/KWLearningProblem/KWCrashTestParametersView.cpp
+++ b/src/Learning/KWLearningProblem/KWCrashTestParametersView.cpp
@@ -16,6 +16,8 @@ KWCrashTestParametersView::KWCrashTestParametersView()
 	AddIntField("CrashTestMaxSecondaryRecordNumber",
 		    "Crash test - max secondary record number per multi-table instance",
 		    int(KWDatabaseMemoryGuard::GetCrashTestMaxSecondaryRecordNumber()));
+	AddIntField("CrashTestMaxCreatedRecordNumber", "Crash test - max created record number per instance",
+		    int(KWDatabaseMemoryGuard::GetCrashTestMaxCreatedRecordNumber()));
 	AddIntField("CrashTestSingleInstanceMemoryLimit", "Crash test - memory limit per multi-table instance in MB",
 		    int(KWDatabaseMemoryGuard::GetCrashTestSingleInstanceMemoryLimit()));
 
@@ -29,6 +31,7 @@ KWCrashTestParametersView::KWCrashTestParametersView()
 	cast(UIIntElement*, GetFieldAt("CrashTestMaxLineLength"))
 	    ->SetDefaultValue(InputBufferedFile::GetMaxLineLength());
 	cast(UIIntElement*, GetFieldAt("CrashTestMaxSecondaryRecordNumber"))->SetMinValue(0);
+	cast(UIIntElement*, GetFieldAt("CrashTestMaxCreatedRecordNumber"))->SetMinValue(0);
 	cast(UIIntElement*, GetFieldAt("CrashTestSingleInstanceMemoryLimit"))->SetMinValue(0);
 
 	// Initialisation des valeurs des parametres de crash concernant les taches
@@ -46,6 +49,10 @@ KWCrashTestParametersView::KWCrashTestParametersView()
 	GetFieldAt("CrashTestMaxLineLength")->SetHelpText("Max line length in input data files (expert).");
 	GetFieldAt("CrashTestMaxSecondaryRecordNumber")
 	    ->SetHelpText("Max record number per multi-table instance."
+			  "\n By default, this parameter is set to 0, meaning that the limit is not active."
+			  "\n If the limit is exceeded, a warning is issued.");
+	GetFieldAt("CrashTestMaxCreatedRecordNumber")
+	    ->SetHelpText("Max created record number per instance."
 			  "\n By default, this parameter is set to 0, meaning that the limit is not active."
 			  "\n If the limit is exceeded, a warning is issued.");
 	GetFieldAt("CrashTestSingleInstanceMemoryLimit")
@@ -66,6 +73,7 @@ void KWCrashTestParametersView::EventUpdate(Object* object)
 	PLParallelTask::nCrashTestCallIndex = GetIntValueAt("CrashTestCallIndex");
 	InputBufferedFile::SetMaxLineLength(GetIntValueAt("CrashTestMaxLineLength"));
 	KWDatabaseMemoryGuard::SetCrashTestMaxSecondaryRecordNumber(GetIntValueAt("CrashTestMaxSecondaryRecordNumber"));
+	KWDatabaseMemoryGuard::SetCrashTestMaxCreatedRecordNumber(GetIntValueAt("CrashTestMaxCreatedRecordNumber"));
 	KWDatabaseMemoryGuard::SetCrashTestSingleInstanceMemoryLimit(
 	    GetIntValueAt("CrashTestSingleInstanceMemoryLimit") * lMB);
 }
@@ -79,6 +87,8 @@ void KWCrashTestParametersView::EventRefresh(Object* object)
 	SetIntValueAt("CrashTestMaxLineLength", InputBufferedFile::GetMaxLineLength());
 	SetIntValueAt("CrashTestMaxSecondaryRecordNumber",
 		      int(KWDatabaseMemoryGuard::GetCrashTestMaxSecondaryRecordNumber()));
+	SetIntValueAt("CrashTestMaxCreatedRecordNumber",
+		      int(KWDatabaseMemoryGuard::GetCrashTestMaxCreatedRecordNumber()));
 	SetIntValueAt("CrashTestSingleInstanceMemoryLimit",
 		      int(KWDatabaseMemoryGuard::GetCrashTestSingleInstanceMemoryLimit() / lMB));
 }
@@ -91,6 +101,7 @@ void KWCrashTestParametersView::ResetParameters()
 	PLParallelTask::nCrashTestCallIndex = 1;
 	InputBufferedFile::SetMaxLineLength(8 * lMB);
 	KWDatabaseMemoryGuard::SetCrashTestMaxSecondaryRecordNumber(0);
+	KWDatabaseMemoryGuard::SetCrashTestMaxCreatedRecordNumber(0);
 	KWDatabaseMemoryGuard::SetCrashTestSingleInstanceMemoryLimit(0);
 }
 

--- a/src/Learning/KWModeling/KWBenchmarkClassSpec.cpp
+++ b/src/Learning/KWModeling/KWBenchmarkClassSpec.cpp
@@ -66,6 +66,10 @@ void KWBenchmarkClassSpec::ReadClasses()
 			temporaryClassDomain->ReadFile(GetClassFileName());
 		}
 	}
+
+	// Compilation
+	if (temporaryClassDomain->Check())
+		temporaryClassDomain->Compile();
 	Global::SetSilentMode(false);
 	sLastReadClassFileName = GetClassFileName();
 }

--- a/src/Learning/KWUserInterface/KDTextFeatureSpecView.cpp
+++ b/src/Learning/KWUserInterface/KDTextFeatureSpecView.cpp
@@ -28,12 +28,12 @@ KDTextFeatureSpecView::KDTextFeatureSpecView()
 		"\n - tokens : text tokens whose interpretability and interest depend on the quality of the input text "
 		"preprocessing."
 		"\n"
-		"\n The \"words\" automatic tokenization process uses separator or control characters as delimiters."
+		"\n The \"words\" automatic tokenization process uses space or control characters as delimiters."
 		"\n The obtained words are either sequences of punctuation characters or sequences of any other "
 		"character."
 		"\n"
 		"\n The \"tokens\" tokenization process simply uses the blank character as delimiter."
-		"\n This method assumes  that the text has been already preprocessed (eg. lemmatization).");
+		"\n This method assumes that the text has been already preprocessed (eg. lemmatization).");
 
 	// ##
 }

--- a/src/Learning/MHHistograms/MHDiscretizerTruncationMODLHistogram.cpp
+++ b/src/Learning/MHHistograms/MHDiscretizerTruncationMODLHistogram.cpp
@@ -123,7 +123,7 @@ void MHDiscretizerTruncationMODLHistogram::TruncationDiscretizeBins(const Contin
 		else if (optimizedHistogram->GetDistinctValueNumber() == 3 and
 			 optimizedHistogram->GetIntervalNumber() > 1)
 		{
-			// Recherche de la troiseme valeur diferrente du min et du max
+			// Recherche de la troisieme valeur differente du min et du max
 			cMeadianValue = optimizedHistogram->GetMinValue();
 			for (n = cvSourceBinUpperValues->GetSize() - 2; n > 0; n--)
 			{
@@ -149,7 +149,7 @@ void MHDiscretizerTruncationMODLHistogram::TruncationDiscretizeBins(const Contin
 			// Recherche de l'epsilon de troncature sur la base des variations de valeurs
 			if (bIsTruncationNecessary)
 			{
-				// Calcul de l'histogrammes des variations de valeurs
+				// Calcul de l'histogramme des variations de valeurs
 				DiscretizeDeltaValues(cvSourceBinLowerValues, cvSourceBinUpperValues,
 						      ivSourceBinFrequencies, cvSourceDeltaBinLowerValues,
 						      cvSourceDeltaBinUpperValues, ivSourceDeltaBinFrequencies,

--- a/src/Norm/base/Ermgt.cpp
+++ b/src/Norm/base/Ermgt.cpp
@@ -95,6 +95,7 @@ void Global::AddErrorObjectValued(int nGravityValue, const ALString& sCategoryVa
 				  const ALString& sLabelValue)
 {
 	Error e;
+	boolean bIgnoreErrorFlowForDisplay;
 	longint lErrorFlowNumber;
 	ALString sAdditionalInfo;
 
@@ -110,6 +111,9 @@ void Global::AddErrorObjectValued(int nGravityValue, const ALString& sCategoryVa
 	// Cas des autres types de message
 	else
 	{
+		// Test s'il faut ignorer le controle de flux des erreurs
+		bIgnoreErrorFlowForDisplay = IgnoreErrorFlowForDisplay(&e);
+
 		// Nombre de messages selon le type
 		lErrorFlowNumber = 0;
 		if (nGravityValue == Error::GravityMessage)
@@ -130,14 +134,14 @@ void Global::AddErrorObjectValued(int nGravityValue, const ALString& sCategoryVa
 
 		// Affichage si autorise
 		if (nErrorFlowControlLevel == 0 or lErrorFlowNumber <= nMaxErrorFlowNumber or
-		    IgnoreErrorFlowForDisplay(&e))
+		    bIgnoreErrorFlowForDisplay)
 			ShowError(&e);
 
 		// Affichage special si depassement du nombre max autorise
 		if (nErrorFlowControlLevel > 0 and lErrorFlowNumber > nMaxErrorFlowNumber)
 		{
 			// Cas ou on vient juste de depasser le nombre de messages
-			if (lErrorFlowNumber == nMaxErrorFlowNumber + 1)
+			if (lErrorFlowNumber == (longint)nMaxErrorFlowNumber + 1)
 			{
 				e.Initialize(nGravityValue, sCategoryValue, "", "...");
 				ShowError(&e);

--- a/test/LearningTestTool/py/_kht_check_results.py
+++ b/test/LearningTestTool/py/_kht_check_results.py
@@ -1441,6 +1441,14 @@ RESILIENCE_USER_MESSAGE_PATTERNS = [
         " after reading ",
         " secondary records ",
     ],
+    [
+        "warning : Database ",
+        ": Record ",
+        " : Single instance ",
+        "uses too much memory (more than ",
+        " after creating ",
+        " records ",
+    ],
     ["error : ", " : Not enough memory "],
 ]
 

--- a/test/LearningTestTool/py/_kht_check_results.py
+++ b/test/LearningTestTool/py/_kht_check_results.py
@@ -1449,6 +1449,22 @@ RESILIENCE_USER_MESSAGE_PATTERNS = [
         " after creating ",
         " records ",
     ],
+    [
+        "warning : Database ",
+        ": Record ",
+        " : Record not selected due to selection variable with possible incorrect value. Single instance ",
+        "uses too much memory (more than ",
+        " after reading ",
+        " secondary records ",
+    ],
+    [
+        "warning : Database ",
+        ": Record ",
+        " : Record not selected due to selection variable with possible incorrect value. Single instance ",
+        "uses too much memory (more than ",
+        " after creating ",
+        " records ",
+    ],
     ["error : ", " : Not enough memory "],
 ]
 


### PR DESCRIPTION
Il s'agit essentiellement de la gestion des instances "éléphant", dont le volume est tel que la mémoire disponible n'est pas suffisante pour la lecture des records du flocons de données et le calcul des attributs dérivés.
Ce problème est déjà gérè dans le cas des schémas multi-table en flocons.

Avec les règles de création d'instances, ce problème peut arriver en mono-table comme en multi-table, si des des règles de création d'instances créent trop d'instances.
Il faut donc dimensionner la mémoire pour pouvoir gérer des instances éléphants de taille raisonnable, la contrôler au fur et a mesure de l’exécution des règles en cas de dépassement mémoire, et émettre des messages utilisateur les plus intelligible possible en cas de problèmes.