### PR TITLE
782 check memory limit management for external tables within kni

### DIFF
--- a/src/Learning/KDDomainKnowledge/KDSelectionOperandDataSampler.cpp
+++ b/src/Learning/KDDomainKnowledge/KDSelectionOperandDataSampler.cpp
@@ -691,7 +691,6 @@ boolean KDSelectionOperandDataSampler::ExtractSelectionOneObject(const KWObject*
 	require(lMainObjectIndex >= 0);
 	require(lSubObjectIndex >= 0);
 	require(nkdAllSubObjects != NULL);
-	require(nkdAllSubObjects->Lookup(kwoObject) == NULL);
 	require(classSelectionData == NULL or
 		classSelectionData == odClassSelectionData.Lookup(kwoObject->GetClass()->GetName()));
 

--- a/src/Learning/KWData/KWDatabase.cpp
+++ b/src/Learning/KWData/KWDatabase.cpp
@@ -527,7 +527,7 @@ boolean KWDatabase::OpenForRead()
 	assert(not bOpenedForRead);
 	bOpenedForRead = PhysicalOpenForRead();
 
-	// Installation du handler specifique pour ignorer le flow des erreur dans le cas du memory guard
+	// Installation du handler specifique pour ignorer le flow des erreurs dans le cas du memory guard
 	KWDatabaseMemoryGuard::InstallMemoryGuardErrorFlowIgnoreFunction();
 
 	// Fermeture si echec

--- a/src/Learning/KWData/KWDatabase.h
+++ b/src/Learning/KWData/KWDatabase.h
@@ -823,8 +823,6 @@ inline KWDatabaseMemoryGuard* KWDatabase::GetMemoryGuard()
 
 inline const KWDatabaseMemoryGuard* KWDatabase::GetConstMemoryGuard() const
 {
-	require(not IsOpenedForRead());
-	require(not IsOpenedForWrite());
 	return &memoryGuard;
 }
 

--- a/src/Learning/KWData/KWDatabaseMemoryGuard.cpp
+++ b/src/Learning/KWData/KWDatabaseMemoryGuard.cpp
@@ -136,6 +136,8 @@ void KWDatabaseMemoryGuard::Init()
 
 	// Initialisation de la limite memoire dure
 	lMaxHeapMemory = lInitialHeapMemory + lActualPhysicalMemoryLimit;
+	ensure(lActualPhysicalMemoryLimit == longint(lActualMemoryLimit * (1 + MemGetAllocatorOverhead())) or
+	       lActualPhysicalMemoryLimit == lCrashTestMemoryLimit);
 }
 
 void KWDatabaseMemoryGuard::SetMainObjectKey(const ALString& sValue)
@@ -320,7 +322,8 @@ const ALString KWDatabaseMemoryGuard::GetSingleInstanceMemoryLimitLabel() const
 
 	require(IsMemoryLimitReached());
 	require(GetTotalReadExternalRecordNumber() == 0);
-	assert(lActualPhysicalMemoryLimit == longint(lActualMemoryLimit * (1 + MemGetAllocatorOverhead())));
+	assert(lActualPhysicalMemoryLimit == longint(lActualMemoryLimit * (1 + MemGetAllocatorOverhead())) or
+	       lActualPhysicalMemoryLimit == lCrashTestMemoryLimit);
 
 	// Entete du message
 	sLabel = sLabelPrefixSingleInstance;

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -781,6 +781,7 @@ boolean KWMTDatabase::PhysicalOpenForRead()
 	longint lRemainingMemory;
 	longint lExternalTableUsedMemory;
 	longint lTotalExternalObjectNumber;
+	boolean bMemoryLimitReached;
 
 	require(Check());
 	require(CheckObjectConsistency());
@@ -808,7 +809,7 @@ boolean KWMTDatabase::PhysicalOpenForRead()
 
 			// La lecture peut echouer pour des raisons de dimensionnement ou autres
 			bOk = PhysicalReadAllReferenceObjects(lRemainingMemory, lExternalTableUsedMemory,
-							      lTotalExternalObjectNumber);
+							      lTotalExternalObjectNumber, bMemoryLimitReached);
 		}
 	}
 	return bOk;
@@ -1223,7 +1224,7 @@ boolean KWMTDatabase::IsPhysicalObjectSelected(KWObject* kwoPhysicalObject)
 }
 
 boolean KWMTDatabase::PhysicalReadAllReferenceObjects(longint lMaxAvailableMemory, longint& lNecessaryMemory,
-						      longint& lTotalExternalObjectNumber)
+						      longint& lTotalExternalObjectNumber, boolean& bMemoryLimitReached)
 {
 	const boolean bTrace = false;
 	boolean bOk = true;
@@ -1577,6 +1578,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(longint lMaxAvailableMemor
 	lNecessaryMemory = longint(lNecessaryMemory / (1 + MemGetAllocatorOverhead()));
 
 	// Erreur utilisateur en cas de depassement memoire
+	bMemoryLimitReached = memoryGuard.IsMemoryLimitReached();
 	if (memoryGuard.IsMemoryLimitReached())
 	{
 		bOk = false;
@@ -1625,6 +1627,7 @@ boolean KWMTDatabase::ComputeExactNecessaryMemoryForReferenceObjects(longint& lN
 	longint lDeleteBasedNecessaryMemory;
 	longint lEstimatedNecessaryMemory;
 	longint lRemainingMemory;
+	boolean bMemoryLimitReached;
 	boolean bCurrentVerboseMode;
 
 	require(Check());
@@ -1667,7 +1670,7 @@ boolean KWMTDatabase::ComputeExactNecessaryMemoryForReferenceObjects(longint& lN
 		bCurrentVerboseMode = GetVerboseMode();
 		SetVerboseMode(false);
 		bOk = PhysicalReadAllReferenceObjects(lRemainingMemory, lReadBasedNecessaryMemory,
-						      lTotalExternalObjectNumber);
+						      lTotalExternalObjectNumber, bMemoryLimitReached);
 		SetVerboseMode(bCurrentVerboseMode);
 		if (bTrace)
 		{

--- a/src/Learning/KWData/KWMTDatabase.cpp
+++ b/src/Learning/KWData/KWMTDatabase.cpp
@@ -1253,7 +1253,8 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(longint lMaxAvailableMemor
 	if (bTrace)
 	{
 		cout << "\t  PhysicalReadAllReferenceObjects\t" << LongintToHumanReadableString(lMaxAvailableMemory)
-		     << endl;
+		     << "\n";
+		cout << "\t\tInitial heap memory\t" << LongintToHumanReadableString(MemGetHeapMemory()) << "\n";
 		timer.Start();
 	}
 
@@ -1448,6 +1449,13 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(longint lMaxAvailableMemor
 			break;
 	}
 
+	// Trace intermediaire apres la phase de lecture
+	if (bTrace)
+	{
+		cout << "\t\tNecessary time for read\t" << timer.GetElapsedTime() << "\n";
+		cout << "\t\tHeap memory after read\t" << LongintToHumanReadableString(MemGetHeapMemory()) << "\n";
+	}
+
 	// Reinitialisation des index de creation d'instances pour les objets des tables externes
 	//
 	//
@@ -1584,6 +1592,7 @@ boolean KWMTDatabase::PhysicalReadAllReferenceObjects(longint lMaxAvailableMemor
 	if (bTrace)
 	{
 		timer.Stop();
+		cout << "\t\tFinal heap memory\t" << LongintToHumanReadableString(MemGetHeapMemory()) << "\n";
 		cout << "\t\tRoot record number\t" << memoryGuard.GetTotalReadExternalRecordNumber() << "\n";
 		cout << "\t\tSecondary record number\t" << memoryGuard.GetTotalReadSecondaryRecordNumber() << "\n";
 		cout << "\t\tCreated record number\t" << memoryGuard.GetTotalCreatedRecordNumber() << "\n";

--- a/src/Learning/KWData/KWMTDatabase.h
+++ b/src/Learning/KWData/KWMTDatabase.h
@@ -181,8 +181,9 @@ protected:
 	// On renvoie egalement en sortie le nombre total d'objets lus ou crees dans l'ensemble des tables externes.
 	// Attention, en entree comme en sortie, il s'agit de la memoire logique, et non physique (cf. RMResourceManager)
 	// On renvoie false avec un message d'erreur en cas de depassement memoire ou de tout autre erreur
-	boolean PhysicalReadAllReferenceObjects(longint lMaxAvailableMemory, longint& lNecessaryMemory,
-						longint& lTotalExternalObjectNumber);
+	virtual boolean PhysicalReadAllReferenceObjects(longint lMaxAvailableMemory, longint& lNecessaryMemory,
+							longint& lTotalExternalObjectNumber,
+							boolean& bMemoryLimitReached);
 
 	// Destruction des objets references
 	void PhysicalDeleteAllReferenceObjects();

--- a/src/Learning/KWData/KWObject.h
+++ b/src/Learning/KWData/KWObject.h
@@ -1041,7 +1041,7 @@ inline ObjectArray* KWObject::ComputeObjectArrayValueAt(KWLoadIndex liLoadIndex)
 			// Les regles de creation d'instance s'assurent juste de ne pas appeler de methodes
 			// sur les instances NULL, mais elle peuvent en integrer dans leur tableau
 			// Ici, de facon centralisee, on nettoie les tableaux en cas de probleme memoire
-			if (not rule->GetReference())
+			if (oaSubObjects != NULL and not rule->GetReference())
 			{
 				// Acces au service de protection memoire
 				memoryGuard = GetObjectDataPath()->GetMemoryGuard();
@@ -1050,7 +1050,7 @@ inline ObjectArray* KWObject::ComputeObjectArrayValueAt(KWLoadIndex liLoadIndex)
 				if (memoryGuard->IsMemoryLimitReached())
 					oaSubObjects->DeleteAll();
 			}
-			assert(oaSubObjects->NoNulls());
+			assert(oaSubObjects == NULL or oaSubObjects->NoNulls());
 
 			// Verification de la valeur de l'attribut derive
 			assert(not GetAt(liLoadIndex.GetDenseIndex()).IsObjectArrayForbidenValue());

--- a/src/Learning/KhiopsNativeInterface/KWDataTableDriverStream.h
+++ b/src/Learning/KhiopsNativeInterface/KWDataTableDriverStream.h
@@ -48,7 +48,7 @@ public:
 	void ResetInputBuffer();
 
 	// Remplissage du buffer avec un enregistrement ajoute en fin de position courante du buffer
-	// Retaillage potentiel du buffer su le BufferSize a ete agrandi
+	// Retaillage potentiel du buffer si le BufferSize a ete agrandi
 	// Si depassement du buffer, renvoie false sans remplir le buffer
 	boolean FillBufferWithRecord(const char* sInputRecord);
 
@@ -59,6 +59,10 @@ public:
 	// Remplissage d'un enregistrement avec le buffer (sans retour a la ligne)
 	// Renvoie false en cas de depassement de capacite (avec un '\0' en fin), true sinon
 	boolean FillRecordWithBuffer(char* sOutputRecord, int nOutputMaxLength);
+
+	// Nettoyage de la memoire du buffer de entree
+	// Usage avance en cas de probleme memoire avec une instance ayant sature les buffers
+	void FreeInputBuffer();
 
 	///////////////////////////////////////////////////////////
 	// Reimplementation de methodes virtuelles de KWDataTableDriver
@@ -103,6 +107,10 @@ public:
 	// Reinitialisation du buffer
 	void ResetBuffer();
 
+	// Liberation de la memoire du buffer
+	// Usage avance
+	void FreeBuffer();
+
 	// Reimplementation de methodes virtuelles
 	longint GetFileSize() const;
 	boolean Open();
@@ -127,7 +135,12 @@ public:
 	void ResetBuffer();
 
 	// Reimplementation de methodes virtuelles
-	boolean Open();
-	boolean IsOpened() const;
-	boolean Close();
+	boolean Open() override;
+	boolean IsOpened() const override;
+	boolean Close() override;
+
+	////////////////////////////////////////////////////////
+	//// Implementation
+protected:
+	boolean FlushCache() override;
 };

--- a/src/Norm/base/InputBufferedFile.h
+++ b/src/Norm/base/InputBufferedFile.h
@@ -290,7 +290,7 @@ public:
 	// Si une ligne ne tient pas dans le buffer, la taille du buffer sera automatiquement
 	// et temporairement etendue jusqu'a cette taille pour recevoir la ligne en entier.
 	// N'est pris en compte que si la taille du buffer est plus petite que la taille max des lignes
-	// Les lignes depassant la taille max sont ignoree lors de la lecture (avec warning)
+	// Les lignes depassant la taille max sont ignorees lors de la lecture (avec warning)
 	static int GetMaxLineLength();
 	static void SetMaxLineLength(int nValue);
 

--- a/src/Norm/base/MemoryBufferedFile.cpp
+++ b/src/Norm/base/MemoryBufferedFile.cpp
@@ -238,3 +238,10 @@ boolean MemoryOutputBufferedFile::Close()
 	bIsOpened = false;
 	return true;
 }
+
+boolean MemoryOutputBufferedFile::FlushCache()
+{
+	require(IsOpened());
+	bIsError = true;
+	return false;
+}

--- a/src/Norm/base/MemoryBufferedFile.h
+++ b/src/Norm/base/MemoryBufferedFile.h
@@ -58,4 +58,9 @@ public:
 	boolean Open() override;
 	boolean IsOpened() const override;
 	boolean Close() override;
+
+	////////////////////////////////////////////////////////
+	//// Implementation
+protected:
+	boolean FlushCache() override;
 };

--- a/src/Norm/base/OutputBufferedFile.h
+++ b/src/Norm/base/OutputBufferedFile.h
@@ -80,7 +80,7 @@ protected:
 	// Ecriture du contenu du buffer dans le fichier
 	// Peut provoquer une erreur
 	// Lorsque la taille du cache est plus grande que GetPreferredBufferSize,
-	// seule un multiple de GetPreferredBufferSize est ecrit, le reste a ecrire est recopier
+	// seule un multiple de GetPreferredBufferSize est ecrit, le reste a ecrire est recopie
 	// au debut du cache
 	virtual boolean FlushCache();
 

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -489,13 +489,19 @@ def evaluate_tool_on_test_dir(
             )  # Suppression eventuelle des lignes de copyright
             lines = utils.filter_empty_lines(lines)  # Suppression des lignes vides
 
-            # Pour les test KNI, le stdout contient une ligne avec le nombre de records
+            # Pour les tests KNI, le stdout contient une ligne avec le nombre de records ou une erreur d'ouverture ou de recoddage
             if is_kni:
                 lines = utils.filter_lines_with_pattern(
                     lines, ["Recoded record number:"]
                 )
                 lines = utils.filter_lines_with_pattern(
                     lines, ["Error : Finish opening stream error:"]
+                )
+                lines = utils.filter_lines_with_pattern(
+                    lines, ["Error : Open stream error:"]
+                )
+                lines = utils.filter_lines_with_pattern(
+                    lines, ["Error : Recode failure ", " in record "]
                 )
             # Cas particulier du coclustering en mode debug
             if is_coclustering:


### PR DESCRIPTION
L'objectif est de gerer proprement les limites de la memoire utilisable par stream
- phase d'ouverture du stream
  - la memoire necessaire provient de:
    - memorisation des specifications du stream
    - chargement, puis compilation du dictionnaire
    - chargement des eventuelles tables externes, jusqu'à la limite memoire
    - ouverture effective du stream, avec creation potentielle d'un dictionnaire "physique" intermediaire
      et allocation des buffers de base (taille: une ligne de taille max) en lecture et ecriture
  - a chaque etape, la memoire utilisee dans la heap est controlee effectivement, et on on emet un message
    d'erreur le plus intelligible possible, avec des indications sur l'etape d'ouverture du stream
  - fonctions impactees, avec code retour KNI_ErrorMemoryOverflow si le stream n'a pas pu etre ouvert pour des raisons de memoire
    - KNIOpenStream
    - KNIFinishOpeningStream (multi-table)
- phase d'exploitation du stream, pour le recodage
  - la memoire necessaire provient de:
    - stockage des records dans des buffers
    - lecture de l'objet a partir des buffers, et calcul des attributs derives, potentiellement gourmants en memoire,
      notament dans le cas de regles de creation d'instances
  - methodes impactees
    - KNISetSecondaryInputRecord
      - si plus de memoire dans le buffer, on tente de l'agrandir dynamiquement dans la limite de la memoire max de stream
      - code retour de type KNI_ErrorMemoryOverflow si pas assez de memoire
    - KNIRecodeStreamRecord  
      - code retour de type KNI_ErrorMemoryOverflow si buffers satures ou si objet non calculable avec ce qui reste de memoire
      - si les buffers sont satures: erreur synthetique additionnelle dans le log, puis reinitialisations des buffer pour liberer
        de la memoire en preparation pour le prochain record a recoder
