### PR TITLE
Set TaskProgression to interruptible in MPI slaves

### DIFF
--- a/src/Parallel/PLMPI/PLMPIMaster.cpp
+++ b/src/Parallel/PLMPI/PLMPIMaster.cpp
@@ -271,6 +271,9 @@ boolean PLMPIMaster::Run()
 	// ...  des resources allouees
 	shared_rg.SerializeObject(&serializer, RMParallelResourceDriver::grantedResources);
 
+	// ... de la presence d'une IHM
+	serializer.PutBoolean(UIObject::GetUIMode() == UIObject::Graphic);
+
 	// .. et de la liste des serveurs de fichier
 	PLShared_ObjectDictionary shared_odFileServer(new PLShared_IntObject);
 	shared_odFileServer.SerializeObject(&serializer, &PLMPITaskDriver::GetDriver()->odFileServers);

--- a/src/Parallel/PLMPI/PLMPISlave.cpp
+++ b/src/Parallel/PLMPI/PLMPISlave.cpp
@@ -16,6 +16,7 @@ PLMPISlave::PLMPISlave(PLParallelTask* t)
 	PLShared_TaskResourceGrant shared_rg;
 	PLMPIMsgContext context;
 	PLSerializer serializer;
+	boolean bIsGUI;
 
 	bBoostedMode = false;
 	bIsWorking = false;
@@ -43,11 +44,18 @@ PLMPISlave::PLMPISlave(PLParallelTask* t)
 	RMParallelResourceDriver::grantedResources = new RMTaskResourceGrant;
 	shared_rg.DeserializeObject(&serializer, RMParallelResourceDriver::grantedResources);
 
+	// ... et de la presence d'une IHM
+	bIsGUI = serializer.GetBoolean();
+
 	// .. et de la liste des serveurs de fichier
 	PLShared_ObjectDictionary shared_odFileServer(new PLShared_IntObject);
 	shared_odFileServer.DeserializeObject(&serializer,
 					      &cast(PLMPITaskDriver*, PLParallelTask::GetDriver())->odFileServers);
 	serializer.Close();
+
+	// Quand on utilise une IHM, les esclaves peuvent recevoir une notification d'interruption.
+	// L'instance de TaskProgression chez les esclaves est textual, donc par defaut non-interruptible
+	TaskProgression::SetInterruptible(bIsGUI);
 
 	POSITION position = cast(PLMPITaskDriver*, PLParallelTask::GetDriver())->odFileServers.GetStartPosition();
 	ALString sKey;


### PR DESCRIPTION
Taking into account the evolution of the TaskProgression class (introduced in commit 0779790): in slaves, TaskProgression must be interruptible even if there is no GUI.