### PR TITLE
787 merge class kwdrdynamicsymbolvector with kwdrvector

### DIFF
--- a/src/Learning/KDDomainKnowledge/KDSelectionOperandDataSampler.cpp
+++ b/src/Learning/KDDomainKnowledge/KDSelectionOperandDataSampler.cpp
@@ -93,7 +93,7 @@ int KDSelectionOperandDataSampler::ComputeMaxSampleSize()
 		    max(nMaxSelectionOperandGranularity, classSelectionData->GetMaxOperandGranularity());
 	}
 
-	// Nombre minimum d'objets a garder dans les echantillons pour avoir une estimation suffisament fine des
+	// Nombre minimum d'objets a garder dans les echantillons pour avoir une estimation suffisamment fine des
 	// partiles
 	nSampleSize = nMaxSelectionOperandGranularity * nMinObjectNumberPerPartile;
 	nSampleSize = min(nSampleSize, nMaxSize);

--- a/src/Learning/KIInterpretation/KIInterpretationClassBuilder.cpp
+++ b/src/Learning/KIInterpretation/KIInterpretationClassBuilder.cpp
@@ -952,21 +952,21 @@ KIInterpretationClassBuilder::CreateReinforcerAttribute(KWClass* kwcReinforcemen
 	require(svReinforcementAttributes != NULL);
 	require(svReinforcementAttributes->GetSize() > 0);
 
-	// Creation d'une regle de derivation pour les noms des attributs de renforcement
-	reinforcementAttributesRule = new KWDRSymbolVector;
-	reinforcementAttributesRule->SetValueNumber(svReinforcementAttributes->GetSize());
-	for (nAttribute = 0; nAttribute < svReinforcementAttributes->GetSize(); nAttribute++)
-		reinforcementAttributesRule->SetValueAt(nAttribute,
-							(Symbol)svReinforcementAttributes->GetAt(nAttribute));
-
 	// Creation de la regle de derivation
 	reinforcerRule = new KIDRClassifierReinforcer;
 	reinforcerRule->SetClassName(kwcReinforcementClass->GetName());
 	reinforcerRule->GetFirstOperand()->SetOrigin(KWDerivationRuleOperand::OriginAttribute);
 	reinforcerRule->GetFirstOperand()->SetAttributeName(predictorRuleAttribute->GetName());
 	reinforcerRule->GetSecondOperand()->SetOrigin(KWDerivationRuleOperand::OriginRule);
-	reinforcerRule->GetSecondOperand()->SetDerivationRule(reinforcementAttributesRule);
 	assert(reinforcerRule->Check());
+
+	// Parametrage de la regle de derivation pour les noms des attributs de renforcement, deja disponible
+	reinforcementAttributesRule = cast(KWDRSymbolVector*, reinforcerRule->GetSecondOperand()->GetDerivationRule());
+	assert(reinforcementAttributesRule != NULL);
+	reinforcementAttributesRule->SetValueNumber(svReinforcementAttributes->GetSize());
+	for (nAttribute = 0; nAttribute < svReinforcementAttributes->GetSize(); nAttribute++)
+		reinforcementAttributesRule->SetValueAt(nAttribute,
+							(Symbol)svReinforcementAttributes->GetAt(nAttribute));
 
 	// Ajout d'operandes pour chaque attribut genere par paire utilise par le predicteur
 	reinforcerRule->DeleteAllVariableOperands();

--- a/src/Learning/KWDRRuleLibrary/KWDRHashMap.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRHashMap.cpp
@@ -95,49 +95,65 @@ boolean KWDRSymbolHashMap::CheckCompleteness(const KWClass* kwcOwnerClass) const
 		keyVector = cast(KWDRSymbolVector*, GetFirstOperand()->GetDerivationRule());
 		valueVector = cast(KWDRSymbolVector*, GetSecondOperand()->GetDerivationRule());
 
-		// Transfert des cles vers la representation structuree
-		check(keyVector);
-		if (keyVector->GetStructureInterface())
-			checkedKeyVector = cast(KWDRSymbolVector*, GetFirstOperand()->GetDerivationRule());
-		else
-		{
-			tmpKeyVector.BuildStructureFromBase(keyVector);
-			checkedKeyVector = &tmpKeyVector;
-		}
-
-		// Transfert des valeurs vers la representation structuree
-		check(valueVector);
-		if (valueVector->GetStructureInterface())
-			checkedValueVector = cast(KWDRSymbolVector*, GetSecondOperand()->GetDerivationRule());
-		else
-		{
-			tmpValueVector.BuildStructureFromBase(valueVector);
-			checkedValueVector = &tmpValueVector;
-		}
-
-		// Verification de la taille des vecteurs
-		if (checkedKeyVector->GetValueNumber() != checkedValueVector->GetValueNumber())
+		// Les vecteurs de parametres doivent etre constant
+		if (not keyVector->CheckConstantOperands(true))
 		{
 			bOk = false;
-			AddError(sTmp + "Number of keys (" + IntToString(checkedKeyVector->GetValueNumber()) +
-				 ") should be the same as the number of values (" +
-				 IntToString(checkedValueVector->GetValueNumber()) + ")");
+			AddError(sTmp + "Keys in operand 1 should be constants");
+		}
+		if (not valueVector->CheckConstantOperands(true))
+		{
+			bOk = false;
+			AddError(sTmp + "Values in operand 2 should be constants");
 		}
 
-		// Verification de l'unicite des cle
-		for (nKey = 0; nKey < checkedKeyVector->GetValueNumber(); nKey++)
+		// Verification des valeurs
+		if (bOk)
 		{
-			sKey = checkedKeyVector->GetValueAt(nKey);
+			// Transfert des cles vers la representation structuree
+			check(keyVector);
+			if (keyVector->GetStructureInterface())
+				checkedKeyVector = keyVector;
+			else
+			{
+				tmpKeyVector.BuildStructureFromBase(keyVector);
+				checkedKeyVector = &tmpKeyVector;
+			}
 
-			// Test si la cle a deja ete vue
-			if (nkdKeys.Lookup(sKey.GetNumericKey()) != NULL)
+			// Transfert des valeurs vers la representation structuree
+			check(valueVector);
+			if (valueVector->GetStructureInterface())
+				checkedValueVector = valueVector;
+			else
+			{
+				tmpValueVector.BuildStructureFromBase(valueVector);
+				checkedValueVector = &tmpValueVector;
+			}
+
+			// Verification de la taille des vecteurs
+			if (checkedKeyVector->GetValueNumber() != checkedValueVector->GetValueNumber())
 			{
 				bOk = false;
-				AddError(sTmp + "Key " + sKey + " is used several times");
-				break;
+				AddError(sTmp + "Number of keys (" + IntToString(checkedKeyVector->GetValueNumber()) +
+					 ") should be the same as the number of values (" +
+					 IntToString(checkedValueVector->GetValueNumber()) + ")");
 			}
-			else
-				nkdKeys.SetAt(sKey.GetNumericKey(), &nkdKeys);
+
+			// Verification de l'unicite des cle
+			for (nKey = 0; nKey < checkedKeyVector->GetValueNumber(); nKey++)
+			{
+				sKey = checkedKeyVector->GetValueAt(nKey);
+
+				// Test si la cle a deja ete vue
+				if (nkdKeys.Lookup(sKey.GetNumericKey()) != NULL)
+				{
+					bOk = false;
+					AddError(sTmp + "Key " + sKey + " is used several times");
+					break;
+				}
+				else
+					nkdKeys.SetAt(sKey.GetNumericKey(), &nkdKeys);
+			}
 		}
 	}
 	return bOk;
@@ -271,49 +287,61 @@ boolean KWDRContinuousHashMap::CheckCompleteness(const KWClass* kwcOwnerClass) c
 		keyVector = cast(KWDRSymbolVector*, GetFirstOperand()->GetDerivationRule());
 		valueVector = cast(KWDRContinuousVector*, GetSecondOperand()->GetDerivationRule());
 
-		// Transfert des cles vers la representation structuree
-		check(keyVector);
-		if (keyVector->GetStructureInterface())
-			checkedKeyVector = keyVector;
-		else
-		{
-			tmpKeyVector.BuildStructureFromBase(keyVector);
-			checkedKeyVector = &tmpKeyVector;
-		}
-
-		// Transfert des valeurs vers la representation structuree
-		check(valueVector);
-		if (valueVector->GetStructureInterface())
-			checkedValueVector = valueVector;
-		else
-		{
-			tmpValueVector.BuildStructureFromBase(valueVector);
-			checkedValueVector = &tmpValueVector;
-		}
-
-		// Verification de la taille des vecteurs
-		if (checkedKeyVector->GetValueNumber() != checkedValueVector->GetValueNumber())
+		// Les vecteurs de parametres doivent etre constant
+		if (not keyVector->CheckConstantOperands(true))
 		{
 			bOk = false;
-			AddError(sTmp + "Number of keys (" + IntToString(checkedKeyVector->GetValueNumber()) +
-				 ") should be the same as the number of values (" +
-				 IntToString(checkedValueVector->GetValueNumber()) + ")");
+			AddError(sTmp + "Keys in operand 1 should be constants");
 		}
+		assert(valueVector->AreConstantOperandsMandatory());
 
-		// Verification de l'unicite des cle
-		for (nKey = 0; nKey < checkedKeyVector->GetValueNumber(); nKey++)
+		// Verification des valeurs
+		if (bOk)
 		{
-			sKey = checkedKeyVector->GetValueAt(nKey);
+			// Transfert des cles vers la representation structuree
+			check(keyVector);
+			if (keyVector->GetStructureInterface())
+				checkedKeyVector = keyVector;
+			else
+			{
+				tmpKeyVector.BuildStructureFromBase(keyVector);
+				checkedKeyVector = &tmpKeyVector;
+			}
 
-			// Test si la cle a deja ete vue
-			if (nkdKeys.Lookup(sKey.GetNumericKey()) != NULL)
+			// Transfert des valeurs vers la representation structuree
+			check(valueVector);
+			if (valueVector->GetStructureInterface())
+				checkedValueVector = valueVector;
+			else
+			{
+				tmpValueVector.BuildStructureFromBase(valueVector);
+				checkedValueVector = &tmpValueVector;
+			}
+
+			// Verification de la taille des vecteurs
+			if (checkedKeyVector->GetValueNumber() != checkedValueVector->GetValueNumber())
 			{
 				bOk = false;
-				AddError(sTmp + "Key " + sKey + " is used several times");
-				break;
+				AddError(sTmp + "Number of keys (" + IntToString(checkedKeyVector->GetValueNumber()) +
+					 ") should be the same as the number of values (" +
+					 IntToString(checkedValueVector->GetValueNumber()) + ")");
 			}
-			else
-				nkdKeys.SetAt(sKey.GetNumericKey(), &nkdKeys);
+
+			// Verification de l'unicite des cle
+			for (nKey = 0; nKey < checkedKeyVector->GetValueNumber(); nKey++)
+			{
+				sKey = checkedKeyVector->GetValueAt(nKey);
+
+				// Test si la cle a deja ete vue
+				if (nkdKeys.Lookup(sKey.GetNumericKey()) != NULL)
+				{
+					bOk = false;
+					AddError(sTmp + "Key " + sKey + " is used several times");
+					break;
+				}
+				else
+					nkdKeys.SetAt(sKey.GetNumericKey(), &nkdKeys);
+			}
 		}
 	}
 	return bOk;

--- a/src/Learning/KWDRRuleLibrary/KWDRHashMap.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRHashMap.cpp
@@ -293,7 +293,11 @@ boolean KWDRContinuousHashMap::CheckCompleteness(const KWClass* kwcOwnerClass) c
 			bOk = false;
 			AddError(sTmp + "Keys in operand 1 should be constants");
 		}
-		assert(valueVector->AreConstantOperandsMandatory());
+		if (not valueVector->CheckConstantOperands(true))
+		{
+			bOk = false;
+			AddError(sTmp + "Values in operand 2 should be constants");
+		}
 
 		// Verification des valeurs
 		if (bOk)

--- a/src/Learning/KWDRRuleLibrary/KWDRString.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRString.cpp
@@ -714,21 +714,40 @@ boolean KWDRTranslate::CheckCompleteness(const KWClass* kwcOwnerClass) const
 {
 	boolean bOk;
 	ALString sTmp;
+	KWDRSymbolVector* searchValues;
+	KWDRSymbolVector* replaceValues;
 	int nSearchValueNumber;
 	int nReplaceValueNumber;
 
 	// Methode ancetre
 	bOk = KWDerivationRule::CheckCompleteness(kwcOwnerClass);
 
-	// Verification de la longueur des listes
+	// Verification des operandes de search et replace
 	if (bOk)
 	{
-		nSearchValueNumber = cast(KWDRSymbolVector*, GetOperandAt(1)->GetDerivationRule())->GetValueNumber();
-		nReplaceValueNumber = cast(KWDRSymbolVector*, GetOperandAt(2)->GetDerivationRule())->GetValueNumber();
-		if (nSearchValueNumber != nReplaceValueNumber)
+		// Acces aux vecteurs de search et replace
+		searchValues = cast(KWDRSymbolVector*, GetOperandAt(1)->GetDerivationRule());
+		replaceValues = cast(KWDRSymbolVector*, GetOperandAt(2)->GetDerivationRule());
+
+		// Les vecteurs de parametres doivent etre constant
+		if (not searchValues->CheckConstantOperands(true))
 		{
 			bOk = false;
-			AddError(sTmp + " number of search values (" + IntToString(nSearchValueNumber) +
+			AddError(sTmp + "Search values in operand 2 should be constants");
+		}
+		if (not replaceValues->CheckConstantOperands(true))
+		{
+			bOk = false;
+			AddError(sTmp + "Replace values in operand 3 should be constants");
+		}
+
+		// Les vecteur doivent etre de meme taille
+		nSearchValueNumber = searchValues->GetValueNumber();
+		nReplaceValueNumber = replaceValues->GetValueNumber();
+		if (bOk and nSearchValueNumber != nReplaceValueNumber)
+		{
+			bOk = false;
+			AddError(sTmp + "Number of search values (" + IntToString(nSearchValueNumber) +
 				 ") should be equal to number of replace values (" + IntToString(nReplaceValueNumber) +
 				 ")");
 		}

--- a/src/Learning/KWDRRuleLibrary/KWDRVector.h
+++ b/src/Learning/KWDRRuleLibrary/KWDRVector.h
@@ -97,14 +97,19 @@ protected:
 
 ///////////////////////////////////////////////////////////////
 // Classe KWDRContinuousVector
-// Regle de derivation de type Structure(DoubleVector), memorisant les valeurs
+// Regle de derivation de type Structure(Vector), memorisant les valeurs
 // d'un vecteur de continuous
+// Cette classe est adaptee pour pouvoir traiter soit des valeurs constantes de maniere optimisee
+// soit des valeurs non constantes
 class KWDRContinuousVector : public KWDRStructureRule
 {
 public:
 	// Constructeur
 	KWDRContinuousVector();
 	~KWDRContinuousVector();
+
+	// Redefinition a false, pour permettre qu'un vecteur contienne des valeurs non constantes
+	boolean AreConstantOperandsMandatory() const override;
 
 	//////////////////////////////////////////////////////////////
 	// La specification de la regle se fait en specifiant les
@@ -135,6 +140,9 @@ public:
 	//////////////////////////////////////////////////////
 	// Redefinition des methodes de structure
 
+	// Calcul de l'objet Structure, reimplemente pour le cas non constant
+	Object* ComputeStructureResult(const KWObject* kwoObject) const override;
+
 	// Recopie de la partie structure de la regle
 	void CopyStructureFrom(const KWDerivationRule* kwdrSource) override;
 
@@ -155,7 +163,7 @@ public:
 	///// Implementation
 protected:
 	// Valeurs
-	ContinuousVector cvValues;
+	mutable ContinuousVector cvValues;
 };
 
 ///////////////////////////////////////////////////////////////

--- a/src/Learning/KWData/KWCYac.cpp
+++ b/src/Learning/KWData/KWCYac.cpp
@@ -568,8 +568,8 @@ static const yytype_int16 yyrline[] = {
     205,  209,  215,  233,  234,  235,  240,  260,  265,  307,  391,  412,  422,  466,  514,  656,  659,
     666,  676,  690,  693,  713,  735,  753,  774,  923,  926,  941,  944,  951,  954,  971,  974,  984,
     1001, 1004, 1012, 1015, 1023, 1027, 1031, 1035, 1039, 1043, 1047, 1051, 1055, 1059, 1063, 1071, 1074,
-    1082, 1085, 1089, 1093, 1098, 1110, 1116, 1135, 1150, 1258, 1262, 1305, 1312, 1323, 1336, 1350, 1361,
-    1375, 1386, 1397, 1409, 1421, 1432, 1444, 1451, 1454, 1455, 1459, 1466, 1472, 1473, 1477, 1485, 1491};
+    1082, 1085, 1089, 1093, 1098, 1110, 1116, 1135, 1150, 1261, 1265, 1308, 1315, 1326, 1339, 1353, 1364,
+    1378, 1389, 1400, 1412, 1424, 1435, 1447, 1454, 1457, 1458, 1462, 1469, 1475, 1476, 1480, 1488, 1494};
 #endif
 
 /** Accessing symbol of state STATE.  */
@@ -2809,12 +2809,15 @@ yyreduce:
 				// Acces a la regle de structure, transformation au format structure et nettoyage memoire
 				// Cette optimisation memoire des regles structure est critique dans le cas de dictionnaires
 				// de tres grande taille. Sinon, des millions d'operandes de regles sont potentiellement crees,
-				// puis lors de la compilation des dictionnaire, l'essentiel de la memoire liberee laisse des trous
+				// puis lors de la compilation des dictionnaires, l'essentiel de la memoire liberee laisse des trous
 				// dans les segments de la heap, qui ne peuvent etre rendus au systeme
 				assert(rule->CheckDefinition());
 				structureRule = cast(KWDRStructureRule*, rule);
-				structureRule->BuildStructureFromBase(rule);
-				structureRule->CleanCompiledBaseInterface();
+				if (structureRule->CheckConstantOperands(false))
+				{
+					structureRule->BuildStructureFromBase(rule);
+					structureRule->CleanCompiledBaseInterface();
+				}
 			}
 		}
 
@@ -2822,19 +2825,19 @@ yyreduce:
 		delete ruleBody;
 		(yyval.kwdrValue) = rule;
 	}
-#line 2804 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2807 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 77: /* derivationRuleBody: derivationRuleBegin  */
-#line 1259 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1262 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2812 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2815 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 78: /* derivationRuleBody: derivationRuleBegin ':' operandList  */
-#line 1263 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1266 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* ruleBody = (yyvsp[-2].kwdrValue);
 		ObjectArray* oaOutputOperands = (yyvsp[0].oaOperands);
@@ -2877,19 +2880,19 @@ yyreduce:
 
 		(yyval.kwdrValue) = ruleRelationCreationBody;
 	}
-#line 2859 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2862 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 79: /* derivationRuleBody: derivationRuleHeader  */
-#line 1306 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1309 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.kwdrValue) = (yyvsp[0].kwdrValue);
 	}
-#line 2867 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2870 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 80: /* operandList: operandList ',' derivationRuleOperand  */
-#line 1313 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1316 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ObjectArray* oaOperandList = (yyvsp[-2].oaOperands);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2900,11 +2903,11 @@ yyreduce:
 		oaOperandList->Add(operand);
 		(yyval.oaOperands) = oaOperandList;
 	}
-#line 2882 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2885 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 81: /* operandList: derivationRuleOperand  */
-#line 1324 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1327 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
 		ObjectArray* oaOperandList;
@@ -2915,11 +2918,11 @@ yyreduce:
 		oaOperandList->Add(operand);
 		(yyval.oaOperands) = oaOperandList;
 	}
-#line 2897 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2900 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 82: /* derivationRuleHeader: IDENTIFIER openparenthesis  */
-#line 1337 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1340 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ALString* sIdentifier = (yyvsp[-1].sValue);
 		KWDerivationRule* rule;
@@ -2930,11 +2933,11 @@ yyreduce:
 		delete sIdentifier;
 		(yyval.kwdrValue) = rule;
 	}
-#line 2912 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2915 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 83: /* derivationRuleBegin: derivationRuleHeader derivationRuleOperand  */
-#line 1351 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1354 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-1].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2945,11 +2948,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2927 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2930 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 84: /* derivationRuleBegin: derivationRuleBegin ',' derivationRuleOperand  */
-#line 1362 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1365 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[-2].kwdrValue);
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
@@ -2960,11 +2963,11 @@ yyreduce:
 		rule->AddOperand(operand);
 		(yyval.kwdrValue) = rule;
 	}
-#line 2942 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2945 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 85: /* derivationRuleOperand: IDENTIFIER  */
-#line 1376 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1379 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ALString* sIdentifier = (yyvsp[0].sValue);
 		KWDerivationRuleOperand* operand;
@@ -2975,11 +2978,11 @@ yyreduce:
 		delete sIdentifier;
 		(yyval.kwdroValue) = operand;
 	}
-#line 2957 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2960 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 86: /* derivationRuleOperand: CONTINUOUSLITTERAL  */
-#line 1387 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1390 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		Continuous cValue = (yyvsp[0].cValue);
 		KWDerivationRuleOperand* operand;
@@ -2990,11 +2993,11 @@ yyreduce:
 		operand->SetContinuousConstant(cValue);
 		(yyval.kwdroValue) = operand;
 	}
-#line 2972 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2975 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 87: /* derivationRuleOperand: bigstring  */
-#line 1398 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1401 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ALString* sValue = (yyvsp[0].sValue);
 		KWDerivationRuleOperand* operand;
@@ -3006,11 +3009,11 @@ yyreduce:
 		delete sValue;
 		(yyval.kwdroValue) = operand;
 	}
-#line 2988 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 2991 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 88: /* derivationRuleOperand: derivationRule  */
-#line 1410 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1413 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRule* rule = (yyvsp[0].kwdrValue);
 		KWDerivationRuleOperand* operand;
@@ -3022,22 +3025,22 @@ yyreduce:
 			operand->SetType(operand->GetDerivationRule()->GetType());
 		(yyval.kwdroValue) = operand;
 	}
-#line 3004 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3007 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 89: /* derivationRuleOperand: '.' derivationRuleOperand  */
-#line 1422 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1425 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		KWDerivationRuleOperand* operand = (yyvsp[0].kwdroValue);
 
 		operand->SetScopeLevel(operand->GetScopeLevel() + 1);
 		(yyval.kwdroValue) = operand;
 	}
-#line 3015 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3018 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 90: /* bigstring: bigstring '+' STRINGLITTERAL  */
-#line 1433 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1436 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		ALString* sValue1 = (yyvsp[-2].sValue);
 		ALString* sValue2 = (yyvsp[0].sValue);
@@ -3049,80 +3052,80 @@ yyreduce:
 		delete sValue1;
 		delete sValue2;
 	}
-#line 3031 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3034 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 91: /* bigstring: STRINGLITTERAL  */
-#line 1445 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1448 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		(yyval.sValue) = (yyvsp[0].sValue);
 	}
-#line 3039 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3042 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 92: /* semicolon: %empty  */
-#line 1451 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1454 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Missing ';'");
 	}
-#line 3047 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3050 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 94: /* semicolon: ';' ';'  */
-#line 1456 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1459 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous ';'");
 	}
-#line 3055 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3058 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 95: /* semicolon: ';' ';' ';'  */
-#line 1460 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1463 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many ';'");
 	}
-#line 3063 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3066 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 96: /* openparenthesis: %empty  */
-#line 1466 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1469 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		// Cette instruction est la pour aider au diagnostic des erreurs
 		// de parenthesage: elle est utile dans ce cas, mais genere (avec
 		// sa consoeur de nombreux shift/reduce et reduce conflicts
 		yyerror("Missing '('");
 	}
-#line 3074 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3077 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 98: /* openparenthesis: '(' '('  */
-#line 1474 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1477 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("There is one superfluous '('");
 	}
-#line 3082 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3085 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 99: /* openparenthesis: '(' '(' '('  */
-#line 1478 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1481 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		yyerror("Too many '('");
 	}
-#line 3090 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3093 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
 	case 100: /* closeparenthesis: %empty  */
-#line 1485 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1488 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 	{
 		// Cette instruction est la pour aider au diagnostic des erreurs
 		// de parenthesage: elle est utile dans ce cas, mais genere (avec
 		// sa consoeur de nombreux shift/reduce et reduce conflicts
 		yyerror("Missing ')'");
 	}
-#line 3101 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3104 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 	break;
 
-#line 3105 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
+#line 3108 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.cpp"
 
 	default:
 		break;
@@ -3301,7 +3304,7 @@ yyreturnlab:
 	return yyresult;
 }
 
-#line 1495 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
+#line 1498 "C:/Applications/boullema/DevGit/khiops/src/Learning/KWData/KWCYac.yac"
 
 #include "KWCLex.inc"
 

--- a/src/Learning/KWData/KWCYac.yac
+++ b/src/Learning/KWData/KWCYac.yac
@@ -1239,12 +1239,15 @@ derivationRule: derivationRuleBody closeparenthesis
 					// Acces a la regle de structure, transformation au format structure et nettoyage memoire
 					// Cette optimisation memoire des regles structure est critique dans le cas de dictionnaires
 					// de tres grande taille. Sinon, des millions d'operandes de regles sont potentiellement crees,
-					// puis lors de la compilation des dictionnaire, l'essentiel de la memoire liberee laisse des trous
+					// puis lors de la compilation des dictionnaires, l'essentiel de la memoire liberee laisse des trous
 					// dans les segments de la heap, qui ne peuvent etre rendus au systeme
 					assert(rule->CheckDefinition());
 					structureRule = cast(KWDRStructureRule*, rule);
-					structureRule->BuildStructureFromBase(rule);
-					structureRule->CleanCompiledBaseInterface();
+					if (structureRule->CheckConstantOperands(false))
+					{
+						structureRule->BuildStructureFromBase(rule);
+						structureRule->CleanCompiledBaseInterface();
+					}
 				}
 			}
 

--- a/src/Learning/KWData/KWDerivationRule.cpp
+++ b/src/Learning/KWData/KWDerivationRule.cpp
@@ -117,7 +117,7 @@ void KWDerivationRule::DeleteAllVariableOperands()
 	// Recherche de la regle de derivation de reference
 	kwdrReference = KWDerivationRule::LookupDerivationRule(GetName());
 
-	// Supression des derniers operandes si la regle est a nombre variables d'operandes
+	// Supression des derniers operandes si la regle est a nombre variable d'operandes
 	if (kwdrReference->GetVariableOperandNumber())
 	{
 		// Supression des derniers operandes
@@ -293,7 +293,7 @@ KWDerivationRuleOperand* KWDerivationRule::GetOutputOperandAt(int nIndex) const
 
 boolean KWDerivationRule::CheckDefinition() const
 {
-	// On test d'abord les operandes, qui peuvent etre a l'origine d'erreur sur la regle elle-meme
+	// On teste d'abord les operandes, qui peuvent etre a l'origine d'erreurs sur la regle elle-meme
 	return CheckOperandsDefinition() and CheckRuleDefinition();
 }
 
@@ -405,7 +405,7 @@ boolean KWDerivationRule::CheckOperandsDefinition() const
 		}
 	}
 
-	// Cas des regle avec scope multiple
+	// Cas des regles avec scope multiple
 	if (bResult and GetMultipleScope())
 	{
 		// Il doit y avoir au moins un operande
@@ -424,7 +424,7 @@ boolean KWDerivationRule::CheckOperandsDefinition() const
 
 boolean KWDerivationRule::CheckFamily(const KWDerivationRule* ruleFamily) const
 {
-	// On test d'abord les operandes, qui peuvent etre a l'origine d'erreur sur la regle elle-meme
+	// On teste d'abord les operandes, qui peuvent etre a l'origine d'erreurs sur la regle elle-meme
 	return CheckOperandsFamily(ruleFamily) and CheckRuleFamily(ruleFamily);
 }
 
@@ -544,7 +544,7 @@ boolean KWDerivationRule::CheckOperandsFamily(const KWDerivationRule* ruleFamily
 
 boolean KWDerivationRule::CheckCompleteness(const KWClass* kwcOwnerClass) const
 {
-	// On test d'abord les operandes, qui peuvent etre a l'origine d'erreur sur la regle elle-meme
+	// On teste d'abord les operandes, qui peuvent etre a l'origine d'erreurs sur la regle elle-meme
 	return CheckOperandsCompleteness(kwcOwnerClass) and CheckRuleCompletness(kwcOwnerClass);
 }
 
@@ -592,10 +592,10 @@ boolean KWDerivationRule::CheckRuleCompletness(const KWClass* kwcOwnerClass) con
 		bResult = false;
 	}
 
-	/// Verification des cle pour les blocs de variables
-	// Verification technique, utile pour la mise au pouint des regles de type bloc
+	// Verification des cle pour les blocs de variables
+	// Verification technique, utile pour la mise au point des regles de type bloc
 	// Cette verification n'est effectuee qu'a la fin pour ne pas perturber si possible les
-	// message d'erreur utilisateur
+	// messages d'erreur utilisateur
 	if (bResult)
 	{
 		// Type de cle pour les variables
@@ -744,7 +744,7 @@ boolean KWDerivationRule::CheckBlockAttributes(const KWClass* kwcOwnerClass,
 			{
 				secondaryScopeClass = LookupSecondaryScopeClass(kwcOwnerClass);
 
-				// Arret si on a pas trouve la classe secondaire
+				// Arret si on n'a pas trouve la classe secondaire
 				if (secondaryScopeClass == NULL)
 					break;
 			}
@@ -986,7 +986,7 @@ boolean KWDerivationRule::ContainsCycle(NumericKeyDictionary* nkdGreyAttributes,
 						    nkdGreyAttributes, nkdBlackAttributes);
 				}
 			}
-			// Cas d'un bloc d'attribut
+			// Cas d'un bloc d'attributs
 			else
 			{
 				calledAttributeBlock = operand->GetOriginAttributeBlock();
@@ -1067,7 +1067,7 @@ void KWDerivationRule::InternalCompleteTypeInfo(const KWClass* kwcOwnerClass,
 			{
 				secondaryScopeClass = LookupSecondaryScopeClass(kwcOwnerClass);
 
-				// Arret si on a pas trouve la classe secondaire
+				// Arret si on n'a pas trouve la classe secondaire
 				if (secondaryScopeClass == NULL)
 					break;
 			}
@@ -1113,7 +1113,7 @@ void KWDerivationRule::Compile(KWClass* kwcOwnerClass)
 		kwcClass = kwcOwnerClass;
 		nClassFreshness = kwcClass->GetFreshness();
 
-		// Nettoyage prealable des operandes secondaires ayant acces aux scope principale de la regle
+		// Nettoyage prealable des operandes secondaires ayant acces au scope principal de la regle
 		if (oaMainScopeSecondaryOperands != NULL)
 			oaMainScopeSecondaryOperands->SetSize(0);
 		else
@@ -1147,7 +1147,7 @@ void KWDerivationRule::Compile(KWClass* kwcOwnerClass)
 				{
 					secondaryScopeClass = LookupSecondaryScopeClass(kwcOwnerClass);
 
-					// Arret si on a pas trouve la classe secondaire
+					// Arret si on n'a pas trouve la classe secondaire
 					if (secondaryScopeClass == NULL)
 						break;
 				}
@@ -1171,7 +1171,7 @@ void KWDerivationRule::Compile(KWClass* kwcOwnerClass)
 			}
 		}
 
-		// Destruction du tableau operandes secondaires ayant acces aux scope principale de la regle
+		// Destruction du tableau d'operandes secondaires ayant acces au scope principal de la regle
 		// dans le cas ou le tableau est vide
 		assert(oaMainScopeSecondaryOperands != NULL);
 		if (oaMainScopeSecondaryOperands->GetSize() == 0)
@@ -1444,7 +1444,7 @@ int KWDerivationRule::FullCompare(const KWDerivationRule* rule) const
 					nDiff = operand1->GetStructureName().Compare(operand2->GetStructureName());
 			}
 
-			// Comparaison sur l'origine des operande si necessaire
+			// Comparaison sur l'origine des operandes si necessaire
 			if (nDiff == 0)
 			{
 				// Comparaison sur l'origine de l'operande dans le cas d'une constante dans les deux cas
@@ -1494,7 +1494,7 @@ int KWDerivationRule::FullCompare(const KWDerivationRule* rule) const
 					{
 						assert(attribute1 != NULL and attribute2 != NULL);
 
-						// Acces aux bloc des attributs
+						// Acces aux blocs des attributs
 						attributeBlock1 = attribute1->GetAttributeBlock();
 						attributeBlock2 = attribute2->GetAttributeBlock();
 
@@ -1502,7 +1502,7 @@ int KWDerivationRule::FullCompare(const KWDerivationRule* rule) const
 						if (attributeBlock1 == NULL and attributeBlock2 == NULL)
 							// On compare sur le nom des attributs
 							nDiff = attribute1->GetName().Compare(attribute2->GetName());
-						// Cas ou un des attribut est dans un bloc
+						// Cas ou un des attributs est dans un bloc
 						else if (attributeBlock1 == NULL)
 							nDiff = -1;
 						else if (attributeBlock2 == NULL)
@@ -1532,7 +1532,7 @@ int KWDerivationRule::FullCompare(const KWDerivationRule* rule) const
 											attribute2));
 							}
 
-							// Comparaison supplementaire si necessaires, selon que les bloc
+							// Comparaison supplementaire si necessaire, selon que les blocs
 							// soient calcules ou non
 							if (nDiff == 0)
 							{
@@ -1542,12 +1542,12 @@ int KWDerivationRule::FullCompare(const KWDerivationRule* rule) const
 									// On compare sur le nom des blocs
 									nDiff = attributeBlock1->GetName().Compare(
 									    attributeBlock2->GetName());
-								// Cas ou un des bloc est calcule
+								// Cas ou un des blocs est calcule
 								else if (attributeBlock1->GetDerivationRule() == NULL)
 									nDiff = -1;
 								else if (attributeBlock2->GetDerivationRule() == NULL)
 									nDiff = 1;
-								// Cas ou les deux bloc sont calcules
+								// Cas ou les deux blocs sont calcules
 								else
 									nDiff = attributeBlock1->GetDerivationRule()
 										    ->FullCompare(
@@ -1561,7 +1561,7 @@ int KWDerivationRule::FullCompare(const KWDerivationRule* rule) const
 						nDiff = -1;
 					else if (operandRule2 == NULL)
 						nDiff = 1;
-					// Si les deux regles sont non nulle, on propage la comparaison
+					// Si les deux regles sont non nulles, on propage la comparaison
 					else
 						nDiff = operandRule1->FullCompare(operandRule2);
 				}
@@ -1605,7 +1605,7 @@ int KWDerivationRule::FullCompare(const KWDerivationRule* rule) const
 						nDiff = 1;
 					// Si les deux regles sont non nulles, on propage la comparaison
 					// On ne compare que la regle produisant les blocs, pas les attributs de chaque
-					// blocs (pourtant disponibles dans le cas d'un bloc d'origine Attribute, avec
+					// bloc (pourtant disponibles dans le cas d'un bloc d'origine Attribute, avec
 					// une regle)
 					else
 						nDiff = operandRule1->FullCompare(operandRule2);
@@ -1620,7 +1620,7 @@ int KWDerivationRule::FullCompare(const KWDerivationRule* rule) const
 				{
 					secondaryScopeClass = LookupSecondaryScopeClass(kwcClass);
 
-					// Arret si on a pas trouve la classe secondaire
+					// Arret si on n'a pas trouve la classe secondaire
 					if (secondaryScopeClass == NULL)
 						break;
 				}
@@ -1655,7 +1655,7 @@ longint KWDerivationRule::GetUsedMemory() const
 	KWDerivationRuleOperand* operand;
 
 	// Prise en compte de la regle elle-meme
-	// On ne prend pas en compte la memoire des UniqueString, car il elle est deja comptee par ailleurs
+	// On ne prend pas en compte la memoire des UniqueString, car elle est deja comptee par ailleurs
 	lUsedMemory = sizeof(KWDerivationRule);
 
 	// Prise en compte des operandes
@@ -1907,7 +1907,7 @@ void KWDerivationRule::WriteUsedObjectArray(const ObjectArray* oaSubObjectArray,
 	int i;
 	KWObjectKey key;
 
-	// Affichage des sous-objets du containers
+	// Affichage des sous-objets du container
 	ost << "\tTable\t" << oaSubObjectArray << endl;
 	if (oaSubObjectArray != NULL)
 	{

--- a/src/Learning/KWData/KWDerivationRule.h
+++ b/src/Learning/KWData/KWDerivationRule.h
@@ -83,11 +83,11 @@ class KWDatabase;
 
 /////////////////////////////////////////////////////////////////////////////////
 // Classe KWDerivationRule
-// Un regle de derivation sert a modeliser la facon dont une valeur peut
+// Une regle de derivation sert a modeliser la facon dont une valeur peut
 // etre calculee a partir d'autres valeurs provenant de constantes, d'attributs
 // de classe, ou d'autres regles.
 //
-// La specification d'un regles de derivation fait appel a la classe
+// La specification d'une regle de derivation fait appel a la classe
 // KWDerivationRuleOperand.
 //
 // Les attributs suivants permettent de definir une regle de derivation:
@@ -170,7 +170,7 @@ public:
 	// Nombre d'operandes
 	int GetOperandNumber() const;
 
-	// Initialisation/modification du nombre d'operande
+	// Initialisation/modification du nombre d'operandes
 	// Les operandes en trop sont supprimes, ceux en plus sont ajoutes
 	void SetOperandNumber(int nValue);
 
@@ -248,7 +248,7 @@ public:
 	//     TableSelection(Logs, G(DiffTime(LogTime, .UserTime), 0));
 	//        (UserTime est de scope principal)
 	// Le ScopeLevel (par defaut 0) permet de remonter le scope de un
-	// a plusieurs niveau
+	// a plusieurs niveaux
 	//   1 pour remonter un niveau (".")
 	//   2 pour remonter un niveau ("..")
 
@@ -264,7 +264,7 @@ public:
 	// Cela ne concerne que les regles de creation de Table ou Entity,
 	// c'est a dire avec une methode GetReference() renvoyant false
 	// Toute la gestion de ce type de regle est sous-traitee a la classe dediee KWRelationCreationRule
-	// pour des raison de modularite de l'implementation
+	// pour des raisons de modularite de l'implementation
 	// On ne definit ci-dessous en virtuel que les methodes de consultation des specifications
 	// pour simplifier l'implementation dans la classe KWRelationCreationRule et dans le parseur de dictionnaire
 
@@ -282,13 +282,13 @@ public:
 	// Ces methodes se decomposent en deux parties, sur la regle et sur ses operandes
 	// ce qui facilite la reimplementation partielle ou totale
 
-	// Verification qu'une regle est suffisament definie pour etre generalisee
+	// Verification qu'une regle est suffisamment definie pour etre generalisee
 	virtual boolean CheckDefinition() const;
 	virtual boolean CheckRuleDefinition() const;
 	virtual boolean CheckOperandsDefinition() const;
 
 	// Verification qu'une regle est une specialisation d'une regle plus generale
-	// suffisament definie
+	// suffisamment definie
 	virtual boolean CheckFamily(const KWDerivationRule* ruleFamily) const;
 	virtual boolean CheckRuleFamily(const KWDerivationRule* ruleFamily) const;
 	virtual boolean CheckOperandsFamily(const KWDerivationRule* ruleFamily) const;
@@ -300,7 +300,7 @@ public:
 
 	// Verification que les attributs d'un bloc sont tous presents via leur VarKey
 	// dans les blocs en operandes de la regle
-	// Les messages sont emis pour le bloc d'attribut en parametre, associe a la regle a verifier
+	// Les messages sont emis pour le bloc d'attributs en parametre, associe a la regle a verifier
 	virtual boolean CheckBlockAttributes(const KWClass* kwcOwnerClass,
 					     const KWAttributeBlock* attributeBlock) const;
 	virtual boolean CheckBlockAttributesAt(const KWClass* kwcOwnerClass, const KWAttributeBlock* attributeBlock,
@@ -317,7 +317,7 @@ public:
 	// On passe en parametre une liste d'attributs colore en Grey ou en Black
 	// (cf. algo decrit dans l'implementation de KWClassDomain::Compile())
 	// Prerequis: la classe doit etre compilee
-	// Retourne true si pas de cycle, sinon false en emmetant des messages d'erreur
+	// Retourne true si pas de cycle, sinon false en emettant des messages d'erreur
 	virtual boolean ContainsCycle(NumericKeyDictionary* nkdGreyAttributes,
 				      NumericKeyDictionary* nkdBlackAttributes) const;
 
@@ -349,9 +349,9 @@ public:
 	//  - type Text: ce sont egalement des valeurs (comme les Symbol), et cela ne pose pas de probleme
 	//  - type TextList: vecteur de valeurs, detruit avec les KWObjet le contenant
 	//    Une regle de calcul produisant un result TextList doit en garder la copie.
-	//    Le KWObjet memorisant un TextLits fera une copie des TextList renvoyes par les regles
+	//    Le KWObjet memorisant un TextList fera une copie des TextList renvoyes par les regles
 	//  - type object (Object et ObjectArray): selon qu'il soient internes ou references, ils appartiennent
-	//    a leur KWObject englobant et seront detruits par celui ci, ou sont simplement reference et sont
+	//    a leur KWObject englobant et seront detruits par celui ci, ou sont simplement references et sont
 	//    censes appartenir a un autre objet ou etre extrait d'un autre attribut
 	//    Une regle de calcul produisant des objets internes est responsable de leur destruction
 	//    Une regle de calcul produisant un ObjectArray doit en garder la copie et est responsable
@@ -362,7 +362,7 @@ public:
 	//    d'acces a l'objet dans le cas de regles de creation d'instances.
 	//  - type structure: le type Structure est cense appartenir a la KWClass, pas au KWObject
 	//    Il est donc detruit uniquement avec la KWClass, jamais par le KWObject
-	//    En pratique, une facon simple de respecter cette contrainte est de faire en sorte de la methode
+	//    En pratique, une facon simple de respecter cette contrainte est de faire en sorte que la methode
 	//    ComputeStructureResult renvoie directement un pointeur sur la KWDerivationRule.
 	//    Dans le cas de regles de classe (par exemple: specification d'une discretisation), l'objet est
 	//    cree et initialise une seule fois.
@@ -374,7 +374,7 @@ public:
 	//    l'attribut detruira les blocs lors de sa destruction. Si le bloc est utilise en operande de regle de
 	//    derivation, la regle de derivation n'aura pas a detruire le bloc car un bloc est necessairement de type
 	//    OriginAttribute (OriginRule est interdit, car on n'aurait pas acces aux VarKeys). Un bloc de cle indexes
-	//    est egalement passe en parametre, pour specifie les cles d'attributs a calculer et les memoriser selon
+	//    est egalement passe en parametre, pour specifier les cles d'attributs a calculer et les memoriser selon
 	//    leur index dans le bloc de valeurs.
 	virtual Continuous ComputeContinuousResult(const KWObject* kwoObject) const;
 	virtual Symbol ComputeSymbolResult(const KWObject* kwoObject) const;
@@ -425,7 +425,7 @@ public:
 
 	// Methode de comparaison entre deux regles, en remplacant les attributs
 	// references par leur eventuelle formule
-	// Prerequis: les regles doivent etre compilee ou avec des informations de type completes
+	// Prerequis: les regles doivent etre compilees ou avec des informations de type completes
 	virtual int FullCompare(const KWDerivationRule* rule) const;
 
 	// Acces a la fraicheur d'edition de la regle (sans tenir compte de ses operandes)
@@ -492,7 +492,7 @@ public:
 	// Indique si une regle est de type KWStructureRule (pour l'optimisation du parser)
 	virtual boolean IsStructureRule() const;
 
-	// Nom de la regle utilisee pour geree les references a des objets
+	// Nom de la regle utilisee pour gerer les references a des objets
 	static const ALString GetReferenceRuleName();
 
 	// Completion eventuelle de la regle avec les informations de type
@@ -532,19 +532,19 @@ protected:
 
 	// Verification du type du premier operande d'une regle a scope multiple
 	// La redefinition de cette methode permet de specifier des regles
-	// a scope multiple dont lme premier operande n'est pas de type Relation
-	// (par exemple une regle Structure ayant acces acces a un type de table)
+	// a scope multiple dont le premier operande n'est pas de type Relation
+	// (par exemple une regle Structure ayant acces a un type de table)
 	virtual boolean CheckFirstMultiScopeOperand() const;
 
 	// Recherche de la classe de scope secondaire en cas de scope multiple
 	// Cela correspond a la classe du premier operande de la regle
 	// Peut etre redefinie comme pour la methode precedente
 	// Renvoie NULL si la regle n'est pas de scope multiple ou si
-	// l'on a pas trouve cette classe
+	// l'on n'a pas trouve cette classe
 	virtual KWClass* LookupSecondaryScopeClass(const KWClass* kwcOwnerClass) const;
 
 	// Une fois compilee, une regle a scope multiple memorise dans un tableau
-	// tous les operandes secondaire ou des sous-regles a evaluer au niveau
+	// tous les operandes secondaires ou des sous-regles a evaluer au niveau
 	// du scope principal (en raison de leur ScopeLevel positif).
 	// Lors du calcul du resultat de la regle de derivation, ces operandes
 	// doivent etre evalues prealablement a l'evaluation de la regle elle-meme.
@@ -660,7 +660,7 @@ public:
 	// qui doit etre de type Relation).
 	// On peut alors remonter d'un niveau (ScopeLevel=1) pour acceder a la classe
 	// de regle, et generaliser a plusieurs niveaux (ScopeLevel > 1) si necessaire
-	// En externe, dans les dictionnaire, les niveaux de scope au dela du scope courant
+	// En externe, dans les dictionnaires, les niveaux de scope au dela du scope courant
 	// se traduisent par le prefixage des operandes par '.' (ScopeLevel=1),
 	// '..' (ScopeLevel=2), ...
 	// Seuls les oprandes non constants peuvent avoir un niveau de scope au dela du niveau courant
@@ -681,7 +681,7 @@ public:
 	enum
 	{
 		OriginConstant,  // Valeur constante, uniquement pour les type simples
-		OriginAttribute, // Valeur d'un attribut ou d'un bloc d'attribut
+		OriginAttribute, // Valeur d'un attribut ou d'un bloc d'attributs
 		OriginRule,      // Valeur retour d'une regle de derivation
 		OriginAny        // Provenance quelconque
 	};
@@ -689,7 +689,7 @@ public:
 	int GetOrigin() const;
 
 	// Libelle lie a l'origine, avec utilisation potentielle du type
-	// pour distinguer entre attribut et bloc d'attribut
+	// pour distinguer entre attribut et bloc d'attributs
 	static ALString OriginToString(int nOrigin, int nType);
 
 	// Valeur constante
@@ -700,7 +700,7 @@ public:
 	void SetSymbolConstant(const Symbol& sValue);
 	Symbol& GetSymbolConstant() const;
 
-	// Valeur specifiee de facon generique sous forme chaine de caractere dans le cas des types simples
+	// Valeur specifiee de facon generique sous forme chaine de caracteres dans le cas des types simples
 	// Le type pris en compte est celui de l'operande
 	void SetStringConstant(const ALString& sValue);
 	const ALString GetStringConstant() const;
@@ -713,11 +713,11 @@ public:
 	void SetAttributeName(const ALString& sName);
 	const ALString& GetAttributeName() const;
 
-	// Nom du bloc d'attribut, dans le cas d'une origine attribut et d'un type IsValueBlock
+	// Nom du bloc d'attributs, dans le cas d'une origine attribut et d'un type IsValueBlock
 	void SetAttributeBlockName(const ALString& sName);
 	const ALString& GetAttributeBlockName() const;
 
-	// Nom generique d'un attribut ou bloc d'attribut dans le cas d'une origine attribut
+	// Nom generique d'un attribut ou bloc d'attributs dans le cas d'une origine attribut
 	// Il y a ici moins de controle d'assertion
 	void SetDataItemName(const ALString& sName);
 	const ALString& GetDataItemName() const;
@@ -733,11 +733,11 @@ public:
 	//////////////////////////////////////////////////////////////////////////
 	// Methodes de verification
 
-	// Verification qu'une regle est suffisament definie pour etre generalisee
+	// Verification qu'une regle est suffisamment definie pour etre generalisee
 	boolean CheckDefinition() const;
 
 	// Verification qu'une regle est une specialisation d'une regle plus generale
-	// suffisament definie
+	// suffisamment definie
 	boolean CheckFamily(const KWDerivationRuleOperand* operandFamily) const;
 
 	// Verification qu'une regle est completement renseignee et compilable
@@ -818,8 +818,8 @@ public:
 	// Calcul de la valeur d'un operande accedant a un scope de niveau superieur et memorisation dans la valeur
 	// constant En effet, seuls les operandes d'origine Attribute ou Rule peuvent etre de scope superieur; on peut
 	// alors utiliser la valeur pour memoriser le resultat du calcul au debut de la regle de derivation au bon
-	// niveau de scope. Ce calcul est alors effectue uen fois pour toute au debut du calcul de valeur de la regle,
-	// puis ces valeurs sont accedees par leur valeur constante par les regle de scope secondaire Les methodes
+	// niveau de scope. Ce calcul est alors effectue une fois pour toute au debut du calcul de valeur de la regle,
+	// puis ces valeurs sont accedees par leur valeur constante par les regles de scope secondaire Les methodes
 	// suivantes precalculent les operandes de scope superieur (attribut ou regle) et les stockent sous forme de
 	// constante
 	//  void KWDerivationRule::EvaluateMainScopeSecondaryOperands(const KWObject* kwoObject);

--- a/src/Learning/KWData/KWStructureRule.h
+++ b/src/Learning/KWData/KWStructureRule.h
@@ -53,6 +53,18 @@ public:
 	// A reimplementer: nettoyage des attributs de structure
 	~KWDRStructureRule();
 
+	// Indique que les operandes de la regles doivent etre constant (defaut: true)
+	// Cela permet une optimisation avancee de ces regles, et est souvent obligatoire
+	// pour pouvoir effectuer des controles avances sur les valeurs des la compilation
+	// Peut-etre redefini, pour des regles acceptant une version constante ou non des operandes
+	// Dans ce cas:
+	// - les operandes ne doivent pas etre definis a OriginConstant dans le constructeur
+	// - la methode ComputeStructureResult doit etre reimplementee pour calculer le resultat
+	//   individuellement par KWObject dans le cas non constant
+	// - les autre regles utilisant ce type de regle, mais exigeant une vesion constantes,
+	//   doivent le controler dans leur methode CheckOperandsCompleteness
+	virtual boolean AreConstantOperandsMandatory() const;
+
 	// Flag d'utilisation de l'interface de Structure
 	// Par defaut: des que l'on a effectuer des mises a jour en
 	// interface de structure, ou apres la compilation
@@ -77,14 +89,20 @@ public:
 	KWDerivationRule* Create() const override;
 
 	// Calcul de l'objet Structure (renvoie la regle elle meme (this))
-	// Reimplementation facultative (l'interface de structure peut etre
-	// suffisante, sauf si elle depend de kwoObject)
+	// Reimplementation facultative dans les cas d'operande constants, car la compilation
+	// de la regle a transforme les operande en interface de type structure
+	//
+	// Dans le cas de sous classe acceptant les operandes non constants
+	// (AreConstantOperandsMandatory=false), cette methode doit etre
+	// remplementee dans le cas ou AreConstantOperands()=false, pour
+	// evaluer les operandes individuellement pour chaque objet et
+	// reconstruire l'interface de type structure
 	Object* ComputeStructureResult(const KWObject* kwoObject) const override;
 
 	//////////////////////////////////////////////////////
 	// Methode specifique a l'interface de structure a reimplementer
 
-	// Verification de la partie structure de la regle
+	// Verification de la partie structure de la regle, uniquement en cas d'operandes constantes
 	virtual boolean CheckStructureDefinition() const;
 
 	// Compilation de l'interface de structure de la regle de derivation
@@ -107,16 +125,17 @@ public:
 
 	// Affichage, ecriture dans un fichier
 	// Ecriture de la regle avec l'interface de structure,
-	// en respectant les regles de parenthesage de l'interface
-	// de base.
+	// en respectant les regles de parenthesage de l'interface de base.
 	// Permet de supprimer l'interface de base lors de la compilation,
 	// de facon a optimiser l'occupation memoire
 	// Par defaut: WriteUsedRule(ost)
 	virtual void WriteStructureUsedRule(ostream& ost) const;
 
+	// Methode de comparaison entre deux regles avec l'interface de structure
+	virtual int FullCompareStructure(const KWDerivationRule* rule) const;
+
 	//////////////////////////////////////////////////////
-	// Redefinition des methodes standard, reimplementees
-	// une fois pour toutes
+	// Redefinition des methodes standard
 
 	// Compilation de la regle de derivation
 	// Transfert si necessaire de l'interface de base vers
@@ -135,8 +154,15 @@ public:
 	// methode dediees structure selon le flag bStructureSpec
 	boolean CheckDefinition() const override;
 
+	// Redefinition de la regle pour tester si les operandes sont constantes
+	boolean CheckOperandsFamily(const KWDerivationRule* ruleFamily) const override;
+
+	// Test si les operandes sont constantes, avec emission de messages d'erreur en mode verbeux
+	boolean CheckConstantOperands(boolean bVerbose) const;
+
 	// Methode de comparaison entre deux regles
-	// A reimplementer dans le cas ou l'interface de structure est utilisee
+	// Re-aiguillage vers les methodes standard ou vers les
+	// methode dediees structure
 	int FullCompare(const KWDerivationRule* rule) const override;
 
 	// Memoire utilisee
@@ -156,5 +182,5 @@ public:
 
 protected:
 	// Flag d'utilisation de l'interface de Structure
-	boolean bStructureInterface;
+	mutable boolean bStructureInterface;
 };

--- a/src/Learning/KWDataPreparation/KWDRDataGrid.cpp
+++ b/src/Learning/KWDataPreparation/KWDRDataGrid.cpp
@@ -155,9 +155,6 @@ void KWDRDataGrid::ImportDataGridStats(const KWDataGridStats* dataGridStats, boo
 	operand->SetDerivationRule(frequenciesRule);
 	operand->SetStructureName(frequenciesRule->GetStructureName());
 
-	// Nettoyage prealable des operandes existants
-	frequenciesRule->DeleteAllOperands();
-
 	// Initialisation des effectifs par cellule
 	nCellNumber = dataGridStats->ComputeTotalGridSize();
 	ivPartIndexes.SetSize(dataGridStats->GetAttributeNumber());
@@ -192,7 +189,6 @@ void KWDRDataGrid::ImportDataGridStats(const KWDataGridStats* dataGridStats, boo
 		AddOperand(operand);
 
 		// Initialisation des effectifs initiaux par attributs
-		frequenciesRule->DeleteAllOperands();
 		frequenciesRule->SetFrequencyNumber(dataGridStats->GetAttributeNumber());
 		for (nAttribute = 0; nAttribute < dataGridStats->GetAttributeNumber(); nAttribute++)
 		{
@@ -210,7 +206,6 @@ void KWDRDataGrid::ImportDataGridStats(const KWDataGridStats* dataGridStats, boo
 		AddOperand(operand);
 
 		// Initialisation des effectifs granularises par attributs
-		frequenciesRule->DeleteAllOperands();
 		frequenciesRule->SetFrequencyNumber(dataGridStats->GetAttributeNumber());
 		for (nAttribute = 0; nAttribute < dataGridStats->GetAttributeNumber(); nAttribute++)
 		{
@@ -868,6 +863,7 @@ void KWDRFrequencies::SetFrequencyNumber(int nFrequency)
 {
 	require(nFrequency >= 0);
 
+	DeleteAllOperands();
 	ivFrequencies.SetSize(nFrequency);
 	bStructureInterface = true;
 	nFreshness++;
@@ -1027,7 +1023,7 @@ void KWDRFrequencies::WriteStructureUsedRule(ostream& ost) const
 	ost << ")";
 }
 
-int KWDRFrequencies::FullCompare(const KWDerivationRule* rule) const
+int KWDRFrequencies::FullCompareStructure(const KWDerivationRule* rule) const
 {
 	int nDiff;
 	KWDRFrequencies* ruleFrequencies;

--- a/src/Learning/KWDataPreparation/KWDRDataGrid.h
+++ b/src/Learning/KWDataPreparation/KWDRDataGrid.h
@@ -186,7 +186,7 @@ public:
 	// valeurs dans le vecteur prevu a cet effet
 
 	// Nombre de d'effectifs (de cellules)
-	// Le setter fait basculer en interface de structure,
+	// Le setter fait basculer en interface de structure, avec destruction des operandes,
 	// et le getter est accessible en interface de structure et de base
 	void SetFrequencyNumber(int nFrequency);
 	int GetFrequencyNumber() const;
@@ -226,7 +226,7 @@ public:
 	void WriteStructureUsedRule(ostream& ost) const override;
 
 	// Methode de comparaison entre deux regles
-	int FullCompare(const KWDerivationRule* rule) const override;
+	int FullCompareStructure(const KWDerivationRule* rule) const override;
 
 	// Memoire utilisee
 	longint GetUsedMemory() const override;

--- a/src/Learning/KWDataPreparation/KWDRPreprocessing.cpp
+++ b/src/Learning/KWDataPreparation/KWDRPreprocessing.cpp
@@ -66,6 +66,7 @@ void KWDRIntervalBounds::SetIntervalBoundNumber(int nValue)
 {
 	require(nValue >= 0);
 
+	DeleteAllOperands();
 	cvIntervalBounds.SetSize(nValue);
 	bStructureInterface = true;
 	nFreshness++;
@@ -218,9 +219,6 @@ void KWDRIntervalBounds::ImportAttributeDiscretization(const KWDGSAttributeDiscr
 
 	require(attributeDiscretization != NULL);
 
-	// Reinitialisation
-	DeleteAllOperands();
-
 	// Parametrage des intervalles
 	nBoundNumber = attributeDiscretization->GetIntervalBoundNumber();
 	SetIntervalBoundNumber(nBoundNumber);
@@ -314,7 +312,7 @@ void KWDRIntervalBounds::WriteStructureUsedRule(ostream& ost) const
 	ost << ")";
 }
 
-int KWDRIntervalBounds::FullCompare(const KWDerivationRule* rule) const
+int KWDRIntervalBounds::FullCompareStructure(const KWDerivationRule* rule) const
 {
 	int nDiff;
 	KWDRIntervalBounds* ruleIntervalBounds;
@@ -384,6 +382,7 @@ void KWDRContinuousValueSet::SetValueNumber(int nValue)
 {
 	require(nValue >= 0);
 
+	DeleteAllOperands();
 	cvContinuousValueSet.SetSize(nValue);
 	bStructureInterface = true;
 	nFreshness++;
@@ -526,9 +525,6 @@ void KWDRContinuousValueSet::ImportAttributeContinuousValues(
 
 	require(attributeContinuousValues != NULL);
 
-	// Reinitialisation
-	DeleteAllOperands();
-
 	// Parametrage des valeurs
 	SetValueNumber(attributeContinuousValues->GetValueNumber());
 	for (nValue = 0; nValue < GetValueNumber(); nValue++)
@@ -635,7 +631,7 @@ void KWDRContinuousValueSet::WriteStructureUsedRule(ostream& ost) const
 	ost << ")";
 }
 
-int KWDRContinuousValueSet::FullCompare(const KWDerivationRule* rule) const
+int KWDRContinuousValueSet::FullCompareStructure(const KWDerivationRule* rule) const
 {
 	int nDiff;
 	KWDRContinuousValueSet* ruleContinuousValueSet;
@@ -694,13 +690,28 @@ KWDRValueGroup::KWDRValueGroup()
 	SetLabel("Value group");
 	SetStructureName("ValueGroup");
 	GetFirstOperand()->SetSymbolConstant(Symbol::GetStarValue());
+	GetFirstOperand()->SetOrigin(KWDerivationRuleOperand::OriginConstant);
 }
 
 KWDRValueGroup::~KWDRValueGroup() {}
 
+boolean KWDRValueGroup::AreConstantOperandsMandatory() const
+{
+	return true;
+}
+
 KWDerivationRule* KWDRValueGroup::Create() const
 {
 	return new KWDRValueGroup;
+}
+
+Object* KWDRValueGroup::ComputeStructureResult(const KWObject* kwoObject) const
+{
+	require(Check());
+	require(IsCompiled());
+	require(AreConstantOperandsMandatory());
+
+	return (Object*)this;
 }
 
 void KWDRValueGroup::BuildStructureFromBase(const KWDerivationRule* kwdrSource)
@@ -1023,7 +1034,6 @@ void KWDRValueGroups::ImportAttributeGrouping(const KWDGSAttributeGrouping* attr
 		valueGroupOperand->SetStructureName(valueGroupRule->GetStructureName());
 
 		// Ajout des valeurs du groupe
-		valueGroupRule->DeleteAllOperands();
 		valueGroupRule->SetValueNumber(attributeGrouping->GetGroupValueNumberAt(nGroup));
 		for (nValue = 0; nValue < attributeGrouping->GetGroupValueNumberAt(nGroup); nValue++)
 		{
@@ -1165,7 +1175,7 @@ boolean KWDRValueGroups::CheckDefinition() const
 	return bOk;
 }
 
-int KWDRValueGroups::FullCompare(const KWDerivationRule* rule) const
+int KWDRValueGroups::FullCompareStructure(const KWDerivationRule* rule) const
 {
 	int nDiff;
 
@@ -1290,6 +1300,7 @@ void KWDRSymbolValueSet::SetValueNumber(int nValue)
 {
 	require(nValue >= 0);
 
+	DeleteAllOperands();
 	svSymbolValueSet.SetSize(nValue);
 	bStructureInterface = true;
 	nFreshness++;
@@ -1429,9 +1440,6 @@ void KWDRSymbolValueSet::ImportAttributeSymbolValues(const KWDGSAttributeSymbolV
 
 	require(attributeSymbolValues != NULL);
 
-	// Reinitialisation
-	DeleteAllOperands();
-
 	// Parametrage des valeurs
 	SetValueNumber(attributeSymbolValues->GetValueNumber());
 	for (nValue = 0; nValue < GetValueNumber(); nValue++)
@@ -1558,7 +1566,7 @@ void KWDRSymbolValueSet::WriteStructureUsedRule(ostream& ost) const
 	ost << ")";
 }
 
-int KWDRSymbolValueSet::FullCompare(const KWDerivationRule* rule) const
+int KWDRSymbolValueSet::FullCompareStructure(const KWDerivationRule* rule) const
 {
 	int nDiff;
 	KWDRSymbolValueSet* ruleSymbolValueSet;

--- a/src/Learning/KWDataPreparation/KWDRPreprocessing.h
+++ b/src/Learning/KWDataPreparation/KWDRPreprocessing.h
@@ -94,7 +94,7 @@ public:
 	// bornes des intervalles dans le vecteur prevu a cet effet
 
 	// Nombre d'intervalles
-	// Le setter fait basculer en interface de structure,
+	// Le setter fait basculer en interface de structure, avec destruction des operandes,
 	// et le getter est accessible en interface de structure et de base
 	// La methode peut etre appelee plusieurs fois pour retailler le vecteur
 	void SetIntervalBoundNumber(int nValue);
@@ -158,7 +158,7 @@ public:
 	void WriteStructureUsedRule(ostream& ost) const override;
 
 	// Methode de comparaison entre deux regles
-	int FullCompare(const KWDerivationRule* rule) const override;
+	int FullCompareStructure(const KWDerivationRule* rule) const override;
 
 	// Memoire utilisee
 	longint GetUsedMemory() const override;
@@ -191,7 +191,7 @@ public:
 	// valeurs (ordonnees) dans le vecteur prevu a cet effet
 
 	// Nombre de valeurs
-	// Le setter fait basculer en interface de structure,
+	// Le setter fait basculer en interface de structure, avec destruction des operandes,
 	// et le getter est accessible en interface de structure et de base
 	// La methode peut etre appelee plusieurs fois pour retailler le vecteur
 	void SetValueNumber(int nValue);
@@ -256,7 +256,7 @@ public:
 	void WriteStructureUsedRule(ostream& ost) const override;
 
 	// Methode de comparaison entre deux regles
-	int FullCompare(const KWDerivationRule* rule) const override;
+	int FullCompareStructure(const KWDerivationRule* rule) const override;
 
 	// Memoire utilisee
 	longint GetUsedMemory() const override;
@@ -279,11 +279,18 @@ public:
 	KWDRValueGroup();
 	~KWDRValueGroup();
 
+	// Redefinition a true
+	// Car on est dans une sous-classe de KWDRSymbolVector qui accepte es operandes non constants
+	boolean AreConstantOperandsMandatory() const override;
+
 	//////////////////////////////////////////////////////
 	// Redefinition des methodes standard
 
 	// Creation
 	KWDerivationRule* Create() const override;
+
+	// Calcul de l'objet Structure, ici constant systematiquement
+	Object* ComputeStructureResult(const KWObject* kwoObject) const override;
 
 	//////////////////////////////////////////////////////
 	// Redefinition des methodes de structure
@@ -384,7 +391,7 @@ public:
 
 	// Methode de comparaison entre deux regles
 	// A redefinir pour utiliser la methode standard
-	int FullCompare(const KWDerivationRule* rule) const override;
+	int FullCompareStructure(const KWDerivationRule* rule) const override;
 
 	// Memoire utilisee
 	longint GetUsedMemory() const override;
@@ -430,7 +437,7 @@ public:
 	// valeurs (ordonnees) dans le vecteur prevu a cet effet
 
 	// Nombre de valeurs
-	// Le setter fait basculer en interface de structure,
+	// Le setter fait basculer en interface de structure, avec destruction des operandes,
 	// et le getter est accessible en interface de structure et de base
 	// La methode peut etre appelee plusieurs fois pour retailler le vecteur
 	void SetValueNumber(int nValue);
@@ -496,7 +503,7 @@ public:
 	void WriteStructureUsedRule(ostream& ost) const override;
 
 	// Methode de comparaison entre deux regles
-	int FullCompare(const KWDerivationRule* rule) const override;
+	int FullCompareStructure(const KWDerivationRule* rule) const override;
 
 	// Memoire utilisee
 	longint GetUsedMemory() const override;

--- a/src/Learning/KWDataPreparation/KWDataGridOptimizer.cpp
+++ b/src/Learning/KWDataPreparation/KWDataGridOptimizer.cpp
@@ -174,7 +174,7 @@ double KWDataGridOptimizer::OptimizeDataGrid(const KWDataGrid* initialDataGrid, 
 
 			//////////////////////////////////////////////////////////////////////////////////////////////
 			// On determine si la granularite courante doit etre traitee
-			// - bIsGranularitySelected: parce qu'elle differe suffisament de la granularite precedente
+			// - bIsGranularitySelected: parce qu'elle differe suffisamment de la granularite precedente
 			//   et de la granularite max
 			// - bIsLastGranularity: par ce que c'est la derniere
 
@@ -221,7 +221,7 @@ double KWDataGridOptimizer::OptimizeDataGrid(const KWDataGrid* initialDataGrid, 
 				// Pour un nombre d'observations egal au nombre de variables pour toutes les instances,
 				// il faut atteindre G tel que G > Gmax - log(K) / log(2)
 				//
-				// On ne traite cette granularite que si elle est differe suffisament de la precedente et de la
+				// On ne traite cette granularite que si elle est differe suffisamment de la precedente et de la
 				for (nAttribute = 0; nAttribute < granularizedDataGrid.GetAttributeNumber();
 				     nAttribute++)
 				{

--- a/src/Learning/KWDataPreparation/KWDiscretizerMODLOptimization.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizerMODLOptimization.cpp
@@ -1009,7 +1009,7 @@ boolean KWDiscretizerMODL::UpdateOptimalDiscretizations(const KWFrequencyTable* 
 	interval = headInterval;
 	while (interval != NULL)
 	{
-		// Arret de la recherche s'il ne reste pas suffisament d'intervalles potentiels
+		// Arret de la recherche s'il ne reste pas suffisamment d'intervalles potentiels
 		if (interval->GetIntervalNumber() == interval->GetMaxIntervalNumber() or
 		    interval->GetIntervalNumber() < nInitialIntervalNumber)
 			break;

--- a/src/Learning/KWModeling/KWDRNBPredictor.cpp
+++ b/src/Learning/KWModeling/KWDRNBPredictor.cpp
@@ -1341,6 +1341,8 @@ KWDRSNBClassifier::KWDRSNBClassifier()
 	// Le premier operande est un vecteurs de poids
 	GetFirstOperand()->SetType(KWType::Structure);
 	GetFirstOperand()->SetStructureName("Vector");
+	GetFirstOperand()->SetOrigin(KWDerivationRuleOperand::OriginRule);
+	GetFirstOperand()->SetDerivationRule(new KWDRContinuousVector);
 
 	// Les operandes principaux contiennent des regles de type Structure
 	nFirstDataGridOperand = 1;
@@ -2138,6 +2140,8 @@ KWDRSNBRankRegressor::KWDRSNBRankRegressor()
 	// Le premier operande est un vecteurs de poids
 	GetFirstOperand()->SetType(KWType::Structure);
 	GetFirstOperand()->SetStructureName("Vector");
+	GetFirstOperand()->SetOrigin(KWDerivationRuleOperand::OriginRule);
+	GetFirstOperand()->SetDerivationRule(new KWDRContinuousVector);
 
 	// Les operandes principaux contiennent des regles de type Structure
 	nFirstDataGridOperand = 1;

--- a/src/Learning/KWModeling/KWDRNBPredictor.cpp
+++ b/src/Learning/KWModeling/KWDRNBPredictor.cpp
@@ -1364,6 +1364,7 @@ boolean KWDRSNBClassifier::CheckOperandsCompleteness(const KWClass* kwcOwnerClas
 	KWDerivationRule* dataGridStatsOrBlockRule;
 	KWDRDataGridStatsBlock* dataGridStatsBlockRule;
 	KWDRDataGridBlock* dataGridBlockRule;
+	KWDRContinuousVector* weightVector;
 	int nTotalDataGridNumber;
 	KWDRContinuousVector* weightsContinuousVectorRule;
 	ALString sTmp;
@@ -1397,11 +1398,23 @@ boolean KWDRSNBClassifier::CheckOperandsCompleteness(const KWClass* kwcOwnerClas
 				nTotalDataGridNumber += dataGridBlockRule->GetUncheckedDataGridNumber();
 			}
 		}
+	}
 
-		// Verfication que le nombre total de grilles est coherent avec le vecteur de poids
+	// Verification du vecteur de poids
+	if (bOk)
+	{
 		weightsContinuousVectorRule =
 		    cast(KWDRContinuousVector*, GetFirstOperand()->GetReferencedDerivationRule(kwcOwnerClass));
-		if (nTotalDataGridNumber != weightsContinuousVectorRule->GetValueNumber())
+
+		// Le vecteur de poids doit etre constant
+		if (not weightsContinuousVectorRule->CheckConstantOperands(true))
+		{
+			bOk = false;
+			AddError(sTmp + "Weights in operand 1 should be constants");
+		}
+
+		// Verification que le nombre total de grilles est coherent avec le vecteur de poids
+		if (bOk and nTotalDataGridNumber != weightsContinuousVectorRule->GetValueNumber())
 		{
 			AddError(sTmp + "Total number of data grids (" + IntToString(nTotalDataGridNumber) + ") " +
 				 "incoherent with the number of weights (" +
@@ -2196,11 +2209,23 @@ boolean KWDRSNBRankRegressor::CheckOperandsCompleteness(const KWClass* kwcOwnerC
 				nTotalDataGridNumber += dataGridBlockRule->GetUncheckedDataGridNumber();
 			}
 		}
+	}
 
-		// Verfication que le nombre total de grilles est coherent avec le vecteur de poids
+	// Verification du vecteur de poids
+	if (bOk)
+	{
 		weightsContinuousVectorRule =
 		    cast(KWDRContinuousVector*, GetFirstOperand()->GetReferencedDerivationRule(kwcOwnerClass));
-		if (nTotalDataGridNumber != weightsContinuousVectorRule->GetValueNumber())
+
+		// Le vecteur de poids doit etre constant
+		if (not weightsContinuousVectorRule->CheckConstantOperands(true))
+		{
+			bOk = false;
+			AddError(sTmp + "Weights in operand 1 should be constants");
+		}
+
+		// Verification que le nombre total de grilles est coherent avec le vecteur de poids
+		if (bOk and nTotalDataGridNumber != weightsContinuousVectorRule->GetValueNumber())
 		{
 			AddError(sTmp + "Total number of data grids (" + IntToString(nTotalDataGridNumber) + ") " +
 				 "incoherent with the number of weights (" +
@@ -2210,6 +2235,7 @@ boolean KWDRSNBRankRegressor::CheckOperandsCompleteness(const KWClass* kwcOwnerC
 	}
 	return bOk;
 }
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 // Classe KWDRNBRegressor
 

--- a/src/Learning/KWModeling/KWDRPredictor.cpp
+++ b/src/Learning/KWModeling/KWDRPredictor.cpp
@@ -183,6 +183,30 @@ Symbol KWDRBiasedTargetValue::ComputeSymbolResult(const KWObject* kwoObject) con
 	return classifier->ComputeBiasedTargetValue(cvOffsets->GetValues());
 }
 
+boolean KWDRBiasedTargetValue::CheckOperandsCompleteness(const KWClass* kwcOwnerClass) const
+{
+	boolean bOk;
+	KWDRContinuousVector* biasContinuousVectorRule;
+
+	// Appel a la method ancetre
+	bOk = KWDerivationRule::CheckOperandsCompleteness(kwcOwnerClass);
+
+	// Verification du vecteur de biais
+	if (bOk)
+	{
+		biasContinuousVectorRule =
+		    cast(KWDRContinuousVector*, GetSecondOperand()->GetReferencedDerivationRule(kwcOwnerClass));
+
+		// Le vecteur de poids doit etre constant
+		if (not biasContinuousVectorRule->CheckConstantOperands(true))
+		{
+			bOk = false;
+			AddError("Bias values in operand 2 should be constants");
+		}
+	}
+	return bOk;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Classe KWDRRankRegressor
 

--- a/src/Learning/KWModeling/KWDRPredictor.cpp
+++ b/src/Learning/KWModeling/KWDRPredictor.cpp
@@ -162,6 +162,8 @@ KWDRBiasedTargetValue::KWDRBiasedTargetValue()
 	GetFirstOperand()->SetStructureName("Classifier");
 	GetSecondOperand()->SetType(KWType::Structure);
 	GetSecondOperand()->SetStructureName("Vector");
+	GetSecondOperand()->SetOrigin(KWDerivationRuleOperand::OriginRule);
+	GetSecondOperand()->SetDerivationRule(new KWDRContinuousVector);
 }
 
 KWDRBiasedTargetValue::~KWDRBiasedTargetValue() {}

--- a/src/Learning/KWModeling/KWDRPredictor.h
+++ b/src/Learning/KWModeling/KWDRPredictor.h
@@ -151,6 +151,9 @@ public:
 
 	// Calcul de l'attribut derive
 	Symbol ComputeSymbolResult(const KWObject* kwoObject) const override;
+
+	// Verification que la regle est completement renseignee et compilable
+	boolean CheckOperandsCompleteness(const KWClass* kwcOwnerClass) const override;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/Learning/KWModeling/KWPredictorNaiveBayes.cpp
+++ b/src/Learning/KWModeling/KWPredictorNaiveBayes.cpp
@@ -212,7 +212,11 @@ KWAttribute* KWPredictorNaiveBayes::AddClassifierAttribute(KWDataPreparationClas
 	else
 	{
 		classifierRule = new KWDRSNBClassifier;
-		classifierRule->GetFirstOperand()->SetOrigin(KWDerivationRuleOperand::OriginRule);
+
+		// Parametrage apres nettoyage de la regle issue du constructeur
+		assert(classifierRule->GetFirstOperand()->GetOrigin() == KWDerivationRuleOperand::OriginRule);
+		assert(classifierRule->GetFirstOperand()->GetDerivationRule() != NULL);
+		delete classifierRule->GetFirstOperand()->GetDerivationRule();
 		classifierRule->GetFirstOperand()->SetDerivationRule(weightRule);
 	}
 	classifierRule->DeleteAllVariableOperands();
@@ -311,18 +315,18 @@ void KWPredictorNaiveBayes::AddClassifierPredictionAttributes(KWAttribute* class
 	    classifierPostOptimizer.PostOptimize(this, GetTrainedClassifier(), &cvScoreOffsets);
 	if (bAddBiasedPredictionAttribute)
 	{
-		// Creation d'une regle pour memoriser les offsets
-		offsetRule = new KWDRContinuousVector;
-		offsetRule->SetValueNumber(cvScoreOffsets.GetSize());
-		for (nTarget = 0; nTarget < cvScoreOffsets.GetSize(); nTarget++)
-			offsetRule->SetValueAt(nTarget, cvScoreOffsets.GetAt(nTarget));
-
 		// Creation d'une regle de prediction biasee de la valeur cible
 		biasedPredictionRule = new KWDRBiasedTargetValue;
 		biasedPredictionRule->GetFirstOperand()->SetOrigin(KWDerivationRuleOperand::OriginAttribute);
 		biasedPredictionRule->GetFirstOperand()->SetAttributeName(classifierAttribute->GetName());
-		biasedPredictionRule->GetSecondOperand()->SetOrigin(KWDerivationRuleOperand::OriginRule);
-		biasedPredictionRule->GetSecondOperand()->SetDerivationRule(offsetRule);
+		assert(biasedPredictionRule->GetSecondOperand()->GetOrigin() == KWDerivationRuleOperand::OriginRule);
+		assert(biasedPredictionRule->GetSecondOperand()->GetDerivationRule() != NULL);
+
+		// Parametrage de la regle de memorisation les offsets (accessible depuis le constructeur)
+		offsetRule = cast(KWDRContinuousVector*, biasedPredictionRule->GetSecondOperand()->GetDerivationRule());
+		offsetRule->SetValueNumber(cvScoreOffsets.GetSize());
+		for (nTarget = 0; nTarget < cvScoreOffsets.GetSize(); nTarget++)
+			offsetRule->SetValueAt(nTarget, cvScoreOffsets.GetAt(nTarget));
 
 		// Ajout de l'attribut dans la classe
 		biasedPredictionAttribute = GetTrainedClassifier()->CreatePredictionAttribute(
@@ -414,7 +418,11 @@ KWAttribute* KWPredictorNaiveBayes::AddRankRegressorAttribute(KWDataPreparationC
 	else
 	{
 		rankRegressorRule = new KWDRSNBRankRegressor;
-		rankRegressorRule->GetFirstOperand()->SetOrigin(KWDerivationRuleOperand::OriginRule);
+
+		// Parametrage apres nettoyage de la regle issue du constructeur
+		assert(rankRegressorRule->GetFirstOperand()->GetOrigin() == KWDerivationRuleOperand::OriginRule);
+		assert(rankRegressorRule->GetFirstOperand()->GetDerivationRule() != NULL);
+		delete rankRegressorRule->GetFirstOperand()->GetDerivationRule();
 		rankRegressorRule->GetFirstOperand()->SetDerivationRule(weightRule);
 	}
 	rankRegressorRule->DeleteAllVariableOperands();

--- a/src/Learning/KWUtils/KWVersion.cpp
+++ b/src/Learning/KWUtils/KWVersion.cpp
@@ -24,9 +24,6 @@ static boolean bVarPartAttributeGarbage = false;
 // pour les attributs internes categoriels
 static boolean bInnerAttributeGarbage = false;
 
-// Booleen de calcul du dictionnaire de deploiement associe au coclustering instances * variables
-static boolean bVarPartDeploymentMode = false;
-
 const ALString GetLearningApplicationName()
 {
 	return sKWLearningApplicationName;
@@ -606,5 +603,25 @@ boolean GetSNBForceDenseMode()
 
 boolean GetVarPartDeploymentMode()
 {
-	return bVarPartDeploymentMode;
+	static boolean bIsInitialized = false;
+	static boolean bVarPartDeploymentModeMode = false;
+	ALString sVarPartDeploymentModeMode;
+
+	// Determination du mode au premier appel
+	if (not bIsInitialized)
+	{
+		// Recherche de la valeur de la variable d'environnement de l'option
+		sVarPartDeploymentModeMode = p_getenv("KhiopsVarPartDeploymentMode");
+		sVarPartDeploymentModeMode.MakeLower();
+
+		// Determination du mode
+		if (sVarPartDeploymentModeMode == "true")
+			bVarPartDeploymentModeMode = true;
+		else if (sVarPartDeploymentModeMode == "false")
+			bVarPartDeploymentModeMode = false;
+
+		// Memorisation du flag d'initialisation
+		bIsInitialized = true;
+	}
+	return bVarPartDeploymentModeMode;
 }

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
@@ -256,7 +256,7 @@ boolean CCDeploymentSpec::PrepareVarPartCoclusteringDeployment(const CCHierarchi
 	KWAttribute* innerVariablePartitionIndexAttribute;
 	KWAttribute* innerVariableVarPartLabelsAttribute;
 	KWAttribute* varPartLabelInnerAttribute;
-	KWDRDynamicSymbolVector* varPartVariableRule;
+	KWDRSymbolVector* varPartVariableRule;
 	ObjectArray oaVarPartLabelAttributes;
 	KWDGAttribute* innerAttribute;
 	KWDGAttribute* varPartAttribute;
@@ -305,7 +305,7 @@ boolean CCDeploymentSpec::PrepareVarPartCoclusteringDeployment(const CCHierarchi
 		distributionValueAttribute->SetName(
 		    kwcDeploymentClass->BuildAttributeName(GetOutputAttributesPrefix() + "VariablesSet"));
 		oaDistributionValueAttributes.Add(distributionValueAttribute);
-		varPartVariableRule = new KWDRDynamicSymbolVector;
+		varPartVariableRule = new KWDRSymbolVector;
 		varPartVariableRule->DeleteAllOperands();
 		distributionValueAttribute->SetDerivationRule(varPartVariableRule);
 
@@ -1099,7 +1099,6 @@ KWAttribute* CCDeploymentSpec::AddInnerAttributePartitionAttribute(KWClass* kwcD
 	KWAttribute* dgAttribute;
 	KWDRIntervalBounds* intervalBoundsRule;
 	KWDRValueGroups* valueGroupsRule;
-	KWDerivationRuleOperand* intervalBoundsOperand;
 	KWDerivationRuleOperand* valueGroupOperand;
 	KWDRValueGroup* valueGroupRule;
 	ObjectArray* oaParts;
@@ -1122,18 +1121,13 @@ KWAttribute* CCDeploymentSpec::AddInnerAttributePartitionAttribute(KWClass* kwcD
 	if (innerAttribute->GetAttributeType() == KWType::Continuous)
 	{
 		intervalBoundsRule = new KWDRIntervalBounds;
-		intervalBoundsRule->DeleteAllOperands();
 
 		dgAttribute->SetDerivationRule(intervalBoundsRule);
-
+		intervalBoundsRule->SetIntervalBoundNumber(oaParts->GetSize() - 1);
 		for (nPart = 0; nPart < oaParts->GetSize() - 1; nPart++)
 		{
-			intervalBoundsOperand = new KWDerivationRuleOperand;
-			intervalBoundsOperand->SetType(KWType::Continuous);
-			intervalBoundsOperand->SetOrigin(KWDerivationRuleOperand::OriginConstant);
-			intervalBoundsOperand->SetContinuousConstant(
-			    cast(KWDGPart*, oaParts->GetAt(nPart))->GetInterval()->GetUpperBound());
-			intervalBoundsRule->AddOperand(intervalBoundsOperand);
+			intervalBoundsRule->SetIntervalBoundAt(
+			    nPart, cast(KWDGPart*, oaParts->GetAt(nPart))->GetInterval()->GetUpperBound());
 		}
 	}
 	else
@@ -1158,8 +1152,6 @@ KWAttribute* CCDeploymentSpec::AddInnerAttributePartitionAttribute(KWClass* kwcD
 			valueGroupOperand->SetType(KWType::Structure);
 
 			// Ajout des valeurs du groupe
-			valueGroupRule->DeleteAllOperands();
-
 			oaValues = new ObjectArray;
 			cast(KWDGPart*, oaParts->GetAt(nPart))->GetSymbolValueSet()->ExportValues(oaValues);
 
@@ -1263,20 +1255,14 @@ KWAttribute* CCDeploymentSpec::AddInnerAttributeVarPartLabelsAttribute(KWClass* 
 	    GetOutputAttributesPrefix() + innerAttribute->GetAttributeName() + "VarPartLabels"));
 
 	vectorRule = new KWDRSymbolVector;
-	vectorRule->DeleteAllOperands();
 	dgAttribute->SetDerivationRule(vectorRule);
 
 	oaParts = new ObjectArray;
 	innerAttribute->ExportParts(oaParts);
-
+	vectorRule->SetValueNumber(oaParts->GetSize());
 	for (nPart = 0; nPart < oaParts->GetSize(); nPart++)
 	{
-		varPartLabelOperand = new KWDerivationRuleOperand;
-		varPartLabelOperand->SetType(KWType::Symbol);
-		varPartLabelOperand->SetOrigin(KWDerivationRuleOperand::OriginConstant);
-		varPartLabelOperand->SetSymbolConstant(
-		    Symbol(cast(KWDGPart*, oaParts->GetAt(nPart))->GetVarPartLabel()));
-		vectorRule->AddOperand(varPartLabelOperand);
+		vectorRule->SetValueAt(nPart, Symbol(cast(KWDGPart*, oaParts->GetAt(nPart))->GetVarPartLabel()));
 	}
 	delete oaParts;
 

--- a/src/Learning/genum/MHGenumHistogramSpec.cpp
+++ b/src/Learning/genum/MHGenumHistogramSpec.cpp
@@ -171,7 +171,7 @@ int MHGenumHistogramSpec::ComputeMaxPartileNumber(int nTotalFrequency, Continuou
 	// Correction si l'on atteint pas le nombre minimal de valeur distincts par bin
 	if (dExpectedNumberDistinctValues / nMaxPartileNumber < nMinimumDistinctValueNumberPerBin)
 	{
-		// Dans ce cas, on limite le nombre max de bin de telle facon a avoir suffisament de possibilites
+		// Dans ce cas, on limite le nombre max de bin de telle facon a avoir suffisamment de possibilites
 		// de valeurs numerique distinctes
 		nMaxPartileNumber = int(floor(dExpectedNumberDistinctValues / nMinimumDistinctValueNumberPerBin));
 		nMaxPartileNumber = min(nMaxPartileNumber, nTotalBinNumber);


### PR DESCRIPTION
Impact générique sur KWDRStructure, qui accepte désormais des opérandes non constants
Impact minimaliste sur KWDRSymbolVector, qui implémente cette possibilité

Extension au cas de KWDRContinuousVector, pour le comportement des deux règles Vectro et VectorC soient le même

A faire après le merge: mettre à jour la documentattion utilisateur des règles concernées sur le repo khiops-doc