### PR TITLE
Fix last run wrong scenario file registered by Khiops coclustering

### DIFF
--- a/packaging/install.cmake
+++ b/packaging/install.cmake
@@ -151,8 +151,10 @@ if(UNIX)
   configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/debian/khiops-core/postinst.in ${TMP_DIR}/postinst @ONLY
                  NEWLINE_STYLE UNIX)
   set(KHIOPS_BINARY_PATH "$KHIOPS_PATH")
+  set(TOOL_EXT "_kh")
   configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops.in ${TMP_DIR}/khiops @ONLY NEWLINE_STYLE UNIX)
   set(KHIOPS_BINARY_PATH "$KHIOPS_COCLUSTERING_PATH")
+  set(TOOL_EXT "_khc")
   configure_file(${PROJECT_SOURCE_DIR}/packaging/linux/common/khiops.in ${TMP_DIR}/khiops_coclustering @ONLY
                  NEWLINE_STYLE UNIX)
 
@@ -216,9 +218,11 @@ else(UNIX)
   # They both build from the same file: khiops.cmd.in
   set(MODL_PATH "KHIOPS_PATH")
   set(TOOL_NAME "Khiops")
+  set(TOOL_EXT "_kh")
   configure_file(${PROJECT_SOURCE_DIR}/packaging/windows/khiops.cmd.in ${TMP_DIR}/khiops.cmd @ONLY NEWLINE_STYLE CRLF)
   set(MODL_PATH "KHIOPS_COCLUSTERING_PATH")
   set(TOOL_NAME "Khiops_coclustering")
+  set(TOOL_EXT "_khc")
   configure_file(${PROJECT_SOURCE_DIR}/packaging/windows/khiops.cmd.in ${TMP_DIR}/khiops_coclustering.cmd @ONLY
                  NEWLINE_STYLE CRLF)
 

--- a/packaging/linux/common/khiops.in
+++ b/packaging/linux/common/khiops.in
@@ -75,7 +75,7 @@ launch_khiops() {
     if [[ $# -eq 0 ]]; then
         # run without parameters
         # run and save scenario and log files in directory KHIOPS_LAST_RUN_DIR
-        $KHIOPS_MPI_COMMAND "@KHIOPS_BINARY_PATH@" -o "${KHIOPS_LAST_RUN_DIR}"/scenario._kh -e "${KHIOPS_LAST_RUN_DIR}"/log.txt
+        $KHIOPS_MPI_COMMAND "@KHIOPS_BINARY_PATH@" -o "${KHIOPS_LAST_RUN_DIR}"/scenario.@TOOL_EXT@ -e "${KHIOPS_LAST_RUN_DIR}"/log.txt
     else
         # run with parameters
         $KHIOPS_MPI_COMMAND "@KHIOPS_BINARY_PATH@" "$@"

--- a/packaging/windows/khiops.cmd.in
+++ b/packaging/windows/khiops.cmd.in
@@ -53,7 +53,7 @@ REM Start without parameters
 if not exist "%KHIOPS_LAST_RUN_DIR%" md "%KHIOPS_LAST_RUN_DIR%"
 if not exist "%KHIOPS_LAST_RUN_DIR%" goto PARAMS
 
-%KHIOPS_MPI_COMMAND% "%@MODL_PATH@%" -o "%KHIOPS_LAST_RUN_DIR%\scenario._kh" -e "%KHIOPS_LAST_RUN_DIR%\log.txt"
+%KHIOPS_MPI_COMMAND% "%@MODL_PATH@%" -o "%KHIOPS_LAST_RUN_DIR%\scenario.@TOOL_EXT@" -e "%KHIOPS_LAST_RUN_DIR%\log.txt"
 if %errorlevel% EQU 0 goto END
 goto ERR_RETURN_CODE
 


### PR DESCRIPTION
Quand on lance Khiops en mode GUI sous Windows, l'outil enregistre le scenario de la session sous C:\Users\<userid>\khiops_data\lastrun, dans le fichier scenario._kh.
Avec Khiops coclustering, le scénario doit être enregistré dans scenario._khc (extension ._khc ai lieu de ._kh).
Le bug est que Khiops coclustering enregistre le scenario dans le fichier scenario._kh (le même que pour Khiops).

Correction minimaliste, et sans doute suffisante.
Testé sous Windows, en lançant l'action de fabrication de l'installeur, et en réinstallant l'outil.