### PR TITLE
Update windows runner to windows-2025

### DIFF
--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -39,13 +39,17 @@ jobs:
   build:
     outputs:
       khiops-version: ${{ steps.get-version.outputs.khiops-version }}
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
       - name: Check the tag consistency with the source version
         if: github.ref_type == 'tag'
         uses: ./.github/actions/check-tag-version
+      - name: Install NSIS
+        uses: repolevedavaj/install-nsis@v1.1.0
+        with:
+          nsis-version: '3.10'
       - name: Install Java Temurin
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -10,20 +10,19 @@ on:
         description: Sign installer and binaries
   pull_request:
     paths:
-      - "**CMakeLists.txt"
-      - "!test/**CMakeLists.txt"
-      - "!test/UniTests/**"
-      - "!test/LearningTestTool/**"
-      - "!test/MemoryStatsVisualizer/**"
+      - '**CMakeLists.txt'
+      - '!test/**CMakeLists.txt'
+      - '!test/UniTests/**'
+      - '!test/LearningTestTool/**'
+      - '!test/MemoryStatsVisualizer/**'
       - packaging/windows/nsis/*.nsh
       - packaging/windows/nsis/*.nsi
       - .github/workflows/pack-nsis.yml
   push:
-    tags: ["*"]
+    tags: ['*']
 # Cancel any ongoing run of this workflow on the same PR or ref
 concurrency:
-  group:
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
     }}
   cancel-in-progress: true
 # Environment variables:
@@ -77,7 +76,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: '21'
       - name: Put the package version on the environment and output
         id: get-version
         shell: bash
@@ -125,8 +124,7 @@ jobs:
         uses: ./.github/actions/build-khiops
         with:
           preset-name: windows-msvc-release
-          targets:
-            MODL MODL_Coclustering norm_jar khiops_jar KhiopsNativeInterface
+          targets: MODL MODL_Coclustering norm_jar khiops_jar KhiopsNativeInterface
             KNITransfer _khiopsgetprocnumber _khiopslauncher
           override-flags: -DTESTING=OFF -DBUILD_JARS=ON
       - name: Setup SM_CLIENT_CERT_FILE from base64 secret data
@@ -140,7 +138,7 @@ jobs:
         if: ${{ inputs.signature-activation }}
         with:
           input: build/windows-msvc-release/bin/
-          keypair-alias: KP_Khiops_HSM
+          keypair-alias: ${{ env.KEYPAIR }}
           simple-signing-mode: true
         env:
           SM_HOST: ${{ secrets.SM_HOST }}
@@ -194,7 +192,7 @@ jobs:
         if: ${{ inputs.signature-activation }}
         with:
           input: packaging/windows/nsis/khiops-${{ env.KHIOPS_VERSION }}-setup.exe
-          keypair-alias: KP_Khiops_HSM
+          keypair-alias: ${{ env.KEYPAIR }}
           simple-signing-mode: true
         env:
           SM_HOST: ${{ secrets.SM_HOST }}

--- a/.github/workflows/pack-nsis.yml
+++ b/.github/workflows/pack-nsis.yml
@@ -10,19 +10,20 @@ on:
         description: Sign installer and binaries
   pull_request:
     paths:
-      - '**CMakeLists.txt'
-      - '!test/**CMakeLists.txt'
-      - '!test/UniTests/**'
-      - '!test/LearningTestTool/**'
-      - '!test/MemoryStatsVisualizer/**'
+      - "**CMakeLists.txt"
+      - "!test/**CMakeLists.txt"
+      - "!test/UniTests/**"
+      - "!test/LearningTestTool/**"
+      - "!test/MemoryStatsVisualizer/**"
       - packaging/windows/nsis/*.nsh
       - packaging/windows/nsis/*.nsi
       - .github/workflows/pack-nsis.yml
   push:
-    tags: ['*']
+    tags: ["*"]
 # Cancel any ongoing run of this workflow on the same PR or ref
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref
     }}
   cancel-in-progress: true
 # Environment variables:
@@ -35,6 +36,7 @@ env:
   CERTIFICATE: Cert_Khiops
   SAMPLES_VERSION: 11.0.0
   ASSETS_VERSION: 11.0.1
+  NSIS_VERSION: 3.11
 jobs:
   build:
     outputs:
@@ -47,14 +49,35 @@ jobs:
         if: github.ref_type == 'tag'
         uses: ./.github/actions/check-tag-version
       - name: Install NSIS
-        uses: repolevedavaj/install-nsis@v1.1.0
-        with:
-          nsis-version: '3.10'
+        # Copy code from repolevedavaj/install-nsis
+        run: |
+          Invoke-WebRequest -UserAgent "Wget" https://sourceforge.net/projects/nsis/files/NSIS%203/$env:NSIS_VERSION/nsis-$env:NSIS_VERSION-setup.exe/download -OutFile C:\WINDOWS\Temp\nsis-$env:NSIS_VERSION-setup.exe
+          $process = Start-Process "C:\WINDOWS\Temp\nsis-$env:NSIS_VERSION-setup.exe" -ArgumentList "/S" -Wait -PassThru
+          $exitCode = $process.ExitCode
+            if ($exitCode -eq 0) {
+                Write-Host "Installer ran successfully."
+            } else {
+                Write-Host "Installer failed with exit code $exitCode."
+                exit $exitCode
+            }
+          echo "C:\Program Files (x86)\NSIS\Bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+          echo "C:\Program Files (x86)\NSIS" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+        shell: pwsh
+      - name: Ensure makensis is available
+        run: |
+          Get-Command makensis
+          makensis /VERSION
+        shell: pwsh
+      - name: Apply NSIS long string patch
+        run: |
+          Invoke-WebRequest -UserAgent "Wget" https://sourceforge.net/projects/nsis/files/NSIS%203/$env:NSIS_VERSION/nsis-$env:NSIS_VERSION-strlen_8192.zip/download -OutFile C:\WINDOWS\Temp\nsis-$env:NSIS_VERSION-strlen_8192.zip
+          Expand-Archive "C:\WINDOWS\Temp\nsis-$env:NSIS_VERSION-strlen_8192.zip" -DestinationPath "C:\Program Files (x86)\NSIS" -Force
+        shell: pwsh
       - name: Install Java Temurin
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: "21"
       - name: Put the package version on the environment and output
         id: get-version
         shell: bash
@@ -102,7 +125,8 @@ jobs:
         uses: ./.github/actions/build-khiops
         with:
           preset-name: windows-msvc-release
-          targets: MODL MODL_Coclustering norm_jar khiops_jar KhiopsNativeInterface
+          targets:
+            MODL MODL_Coclustering norm_jar khiops_jar KhiopsNativeInterface
             KNITransfer _khiopsgetprocnumber _khiopslauncher
           override-flags: -DTESTING=OFF -DBUILD_JARS=ON
       - name: Setup SM_CLIENT_CERT_FILE from base64 secret data


### PR DESCRIPTION
NISIS doesn't exist on windows-2025 (https://github.com/actions/runner-images/issues/11754https://github.com/actions/runner-images/issues/11754https://github.com/actions/runner-images/issues/11754) 
We install NSIS from scratch inspired by repolevedavaj/install-nsis.