### PR TITLE
Add a trace in kht_test to indicate the use of khiops_env

### DIFF
--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -279,6 +279,8 @@ def evaluate_tool_on_test_dir(
         + str(tool_process_number)
         + ", platform: "
         + results.get_context_platform_type()
+        + ", khiops_env: "
+        + str(use_khiops_env)
         + ")"
         + exe_path_info
     )


### PR DESCRIPTION
Add a trace to indicate if kit_test uses khiops_env. It looks like:
```bash
starting Test TestKhiops Standard Adult (processes: 18, platform: Linux, khiops_env: True)
  exe: /usr/bin/MODL_openmpi
```