### PR TITLE
Remove warning macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,7 +368,7 @@ if(TESTING)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY "https://github.com/google/googletest.git"
-    GIT_TAG "v1.13.0")
+    GIT_TAG "v1.17.0")
   # For Windows: Prevent overriding the parent project's compiler/linker settings
   #
   # - set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,8 @@
   ],
   "ignorePaths": [
     "packaging/dockerfiles/**"
-  ]
+  ],
+  "pre-commit": {
+    "enabled": true
+  }
 }

--- a/src/Learning/KWData/KWRelationCreationRule.h
+++ b/src/Learning/KWData/KWRelationCreationRule.h
@@ -198,8 +198,9 @@ public:
 						       IntVector* ivMandatoryInputOperands) const override;
 
 	// Collecte de tous les attribut en entree et sortie des regles de creation d'instances
-	virtual void CollectCreationRuleAllAttributes(const KWAttribute* derivedAttribute,
-						      NumericKeyDictionary* nkdAllNonDeletableAttributes) const;
+	virtual void
+	CollectCreationRuleAllAttributes(const KWAttribute* derivedAttribute,
+					 NumericKeyDictionary* nkdAllNonDeletableAttributes) const override;
 
 	// Copie
 	void CopyFrom(const KWDerivationRule* kwdrSource) override;

--- a/src/Norm/base/JSONObject.h
+++ b/src/Norm/base/JSONObject.h
@@ -197,7 +197,7 @@ public:
 	JSONValue* GetValueAt(int nIndex) const;
 
 	// Ecriture avec indentation et sauts de lignes si le mode pretty print est true
-	void WriteIndent(ostream& ost, int nIndentLevel, boolean bPrettyPrint) const;
+	void WriteIndent(ostream& ost, int nIndentLevel, boolean bPrettyPrint) const override;
 
 	// Conversion du type en chaine de caracteres
 	const ALString TypeToString() const override;
@@ -232,7 +232,7 @@ public:
 	const ALString& GetString() const;
 
 	// Affichage avec options de pretty print
-	void WriteIndent(ostream& ost, int nIndentLevel, boolean bPrettyPrint) const;
+	void WriteIndent(ostream& ost, int nIndentLevel, boolean bPrettyPrint) const override;
 
 	// Conversion du type en chaine de caracteres
 	const ALString TypeToString() const override;
@@ -266,7 +266,7 @@ public:
 	double GetNumber() const;
 
 	// Affichage avec options de pretty print
-	void WriteIndent(ostream& ost, int nIndentLevel, boolean bPrettyPrint) const;
+	void WriteIndent(ostream& ost, int nIndentLevel, boolean bPrettyPrint) const override;
 
 	// Conversion du type en chaine de caracteres
 	const ALString TypeToString() const override;
@@ -300,7 +300,7 @@ public:
 	boolean GetBoolean() const;
 
 	// Affichage avec options de pretty print
-	void WriteIndent(ostream& ost, int nIndentLevel, boolean bPrettyPrint) const;
+	void WriteIndent(ostream& ost, int nIndentLevel, boolean bPrettyPrint) const override;
 
 	// Conversion du type en chaine de caracteres
 	const ALString TypeToString() const override;
@@ -330,7 +330,7 @@ public:
 	int GetType() const override;
 
 	// Affichage avec options de pretty print
-	void WriteIndent(ostream& ost, int nIndentLevel, boolean bPrettyPrint) const;
+	void WriteIndent(ostream& ost, int nIndentLevel, boolean bPrettyPrint) const override;
 
 	// Conversion du type en chaine de caracteres
 	const ALString TypeToString() const override;
@@ -374,7 +374,7 @@ public:
 	JSONNull* GetNullValue() const;
 
 	// Affichage avec options de pretty print
-	void Write(ostream& ost) const;
+	void Write(ostream& ost) const override;
 
 	// Affichage de facon compacte en une seule ligne
 	void WriteCompact(ostream& ost) const;


### PR DESCRIPTION
- Add `override` in headers in order to remove warning when building on macOS.
- Add pre-commit hook in renovate
- Update the googleTest version