### PR TITLE
Add warning for I*V coclustering with less than two variables

### DIFF
--- a/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.cpp
+++ b/src/Learning/MODL_Coclustering/CCCoclusteringBuilder.cpp
@@ -284,7 +284,7 @@ boolean CCCoclusteringBuilder::CheckVarPartSpecifications() const
 				 " for Instances x Variables coclustering, beyong the identifier variable, apart from "
 				 "the identifier variable.");
 		}
-		// Elles doivent etre utilisable dans le dictionnaire
+		// Elles doivent etre utilisables dans le dictionnaire
 		else
 		{
 			// Parcours des variables internes

--- a/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
@@ -834,6 +834,17 @@ boolean CCLearningProblem::CheckCoclusteringSpecifications() const
 				    GetClassName() +
 				    " for Instances x Variables coclustering, apart from the identifier variable.");
 			}
+			// Warning s'il y a uniquement une variable interne
+			else if (nInternalAttributeNumber == 1)
+			{
+				AddWarning("Only one used variable is available in dictionary " + GetClassName());
+			}
+			// Warning s'il y a uniquement deux variables internes
+			else if (nInternalAttributeNumber == 2)
+			{
+				AddWarning("In case of two variables only, it is recommanded to use variables "
+					   "coclustering instead of instances x variables coclustering.");
+			}
 		}
 	}
 	return bOk;


### PR DESCRIPTION
In case of two variables only, it is recommanded to use variables coclustering instead of instances x variables coclustering.