### PR TITLE
Add comprehensive instructions for CMake, C++, and UI development

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,226 @@
+# Khiops Workspace Instructions
+
+## Project Overview
+
+**Khiops** is an AutoML suite for supervised and unsupervised learning with data preparation, feature engineering, and scoring capabilities. It's a multi-platform C++ core with Python distribution (wheels, pip, conda) and native installers (Windows, Linux, macOS). Key features include:
+- **MODL**: Minimum Description Length-based model selection for decision trees and Naive Bayes classifiers
+- **Feature Selection**: Automatic selection of relevant features for modeling
+- **Discretization**: Optimal binning of continuous variables
+
+- **License**: BSD-3-Clause-Clear
+- **Current Version**: 11.0.1-a.2 (pre-release)
+- **Website**: https://khiops.org
+- **Source**: https://github.com/KhiopsML/khiops
+
+## Repository Structure
+
+```
+src/
+  ├─ Learning/        # ML algorithms, MODL, SNBPredictor, DTForest, data prep
+  ├─ Norm/            # Core numerical algorithms, base functionality
+  └─ Parallel/        # MPI-based parallelization
+test/
+  ├─ UnitTests/       # CTest unit tests (norm_test, parallel_test, etc.)
+  ├─ LearningTest/    # Integration/standard tests
+  └─ MemoryStatsVisualizer/
+scripts/              # Python and CMake helpers, copyright/encoding checks
+packaging/            # Conda, Linux RPM/Debian, Windows NSIS configs
+```
+
+## Core Development Conventions
+
+### C++ Code Guidelines
+
+**Detailed C++ coding guidelines** (style, naming, class structure, assertions) are in [`.github/instructions/cpp-changes.instructions.md`](.github/instructions/cpp-changes.instructions.md) — they auto-load when editing `*.cpp` or `*.h` files.
+
+### Pre-commit Hooks
+
+All commits must pass `.pre-commit-config.yaml`:
+
+- **C++/Java**: `clang-format` (strict)
+- **Python**: `black` (3.9+)
+- **CMake**: `cmake-format`
+- **JSON**: Auto-format (except test data)
+- **Custom Checks**: Copyright year verification, UTF-8 encoding
+
+### Naming Conventions
+
+- **Learning module**: `KW*` prefix (e.g., `KWData`, `KWUtils`, `KWKhiopsVersion`)
+- **Parallel module**: `PL*` prefix (e.g., `PLParallelTask`)
+- **Norm module**: Core/base prefixes
+- **Tests**: Separate implementation per module (`UnitTests/`, `StandardTests/`)
+
+### Version Management
+
+Version is defined in `src/Learning/KWUtils/KWKhiopsVersion.h`:
+
+```c++
+#define KHIOPS_VERSION KHIOPS_STR(11.0.1-a.2)
+```
+
+Python wheel version is automatically extracted from this via scikit-build-core metadata provider (in `packaging/pip/pyproject-khiops.toml` and `pyproject-kni.toml`).
+
+## Common Development Workflows
+
+### Adding a Feature
+
+1. **Branch from** `main` (or active feature branch)
+2. **Code** in appropriate module (`src/Learning`, `src/Norm`, or `src/Parallel`)
+3. **Run tests**: Configure with `-DTESTING=ON`, then `ctest`
+4. **Format code**: Pre-commit hooks will format; manually run if needed:
+   ```bash
+   clang-format -i src/path/to/file.cpp
+   cmake-format -i CMakeLists.txt
+   black scripts/
+   ```
+5. **Push & PR**: Ensure pre-commit checks pass before pushing
+
+### Debugging C++ Code
+
+- Use CMake preset with `Debug` build type: `cmake --preset macos-clang-debug`
+- Executables in `build/<preset>/bin/`
+- Use native debuggers (lldb on macOS, gdb on Linux)
+- Set breakpoints in `GlobalExit()` (`src/Norm/base/Standard.cpp`) to catch assertion failures and memory leaks — it is the only call to `exit` in the codebase
+
+### Cross-Platform Considerations
+
+- **Windows**: Uses MSVC, MS-MPI (standalone installer) or Intel MPI `impi-rt` (pip wheels), NSIS installer
+- **macOS**: Both Intel and Apple Silicon (ARM64) supported
+- **Linux**: x86_64 and ARM64 support, RPM/Debian packages
+- Always test platform-specific paths in `packaging/` directory
+
+## Important Patterns & Pitfalls
+
+### ✅ DO
+
+- Use `**/*.cpp` and `**/*.h` glob patterns for C++ code changes
+- Enable `TESTING=ON` when modifying core algorithms
+- Run full test suite before submitting PR
+- Check GitHub Actions workflows in `.github/workflows/`
+- Use CMake presets for consistent configuration across platforms
+- Respect pre-commit formatting — don't override clang-format
+
+### ❌ DON'T
+
+- Modify version in `CMakeLists.txt` (use `KWKhiopsVersion.h` only)
+- Assume MPI availability (some distributions exclude it; mark as optional)
+- Add Python dependencies to `pyproject.toml` without team review (wheel is C++-only)
+- Commit unformatted code (pre-commit will block it)
+- Mix platform-specific code without guards (`#ifdef _WIN32`, etc.)
+
+## GitHub Actions CI/CD
+
+CI workflow details are maintained in [`.github/instructions/ci-workflows.instructions.md`](.github/instructions/ci-workflows.instructions.md).
+
+Quick trigger conventions:
+- **Automatic on PR**: run test/packaging checks when relevant files change
+- **Automatic on tag push**: build release packaging artifacts
+- **Manual (`workflow_dispatch`)**: heavy/specialized jobs (e.g., macOS packaging, conda tests, container builds)
+
+## Module Reference
+
+| Module | Language | Purpose |
+|--------|----------|---------|
+| **src/Learning** | C++ | MODL, decision trees, Naive Bayes, feature selection, discretization |
+| **src/Norm** | C++ | Numerical algorithms, base data structures, memory allocator, assertions (`require`/`ensure`/`assert`), error management, GUI launcher |
+| **src/Parallel** | C++ | MPI task distribution, resource management |
+| **test/UnitTests** | C++ | Isolated component tests (norm_test, parallel_test) |
+| **test/LearningTest** | C++ | 800+ non-regression scenarios (Khiops, Coclustering, KNITransfer). Managed by `test/LearningTestTool/` |
+| **packaging/** | CMake, YAML, Python | Distribution configs, Conda, Docker, installers |
+
+
+## Building Khiops
+
+See the [development environment setup page](https://github.com/KhiopsML/khiops/wiki/Setting-Up-the-Development-Environment) before executing any of these steps.
+
+### Prerequisites
+
+- **CMake** ≥ 3.22
+- **Ninja** (default generator, required)
+- **MPI**: MPICH (Linux/macOS) or MS-MPI (Windows standalone) / Intel MPI `impi-rt` (Windows pip)
+- **Python** ≥ 3.9 (for wheel builds)
+
+### Build System
+
+Built with **CMake** and **Ninja**. Python wheels use **scikit-build-core** (configs in `packaging/pip/`). Native packages (RPM, Debian) are generated with **CPack**.
+
+### CMake Presets
+
+Khiops uses CMake presets for standard build configurations on each platform:
+
+| Platform | Debug Preset | Release Preset |
+|----------|-------------|----------------|
+| **Windows** | `windows-msvc-debug` | `windows-msvc-release` |
+| **Linux** | `linux-gcc-debug` | `linux-gcc-release` |
+| **macOS** | `macos-clang-debug` | `macos-clang-release` |
+
+```bash
+# List available presets
+cmake --list-presets
+
+# Configure + build (example: macOS release)
+cmake --preset macos-clang-release
+cmake --build --preset macos-clang-release
+```
+
+### Quick Build from Scratch
+
+```bash
+cd khiops
+cmake --fresh -S . -B build -D TESTING=OFF -D BUILD_JARS=ON -D CMAKE_BUILD_TYPE=Release
+cmake --build build/ --parallel
+```
+
+### Custom CMake Options
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `MPI` | ON | MPI support |
+| `TESTING` | OFF | Build and run unit tests with googletest |
+| `BUILD_LEX_YACC` | OFF | Rebuild JSON and Khiops Dictionary parsers (requires Flex/Bison) |
+| `BUILD_JARS` | ON | Build JARs for the Khiops Desktop GUI |
+| `C11` | ON | Use C++11 standard |
+| `GENERATE_VIEWS` | OFF | Regenerate GUI C++ files from `.dd` files |
+
+Presets can be modified via:
+- `CMakePresets.json`: shared file committed to the repo (for common/temporary settings)
+- `CMakeUserPresets.json`: user-specific file, not committed
+
+### Packaging (CPack and Python Wheels)
+
+Detailed packaging guidance is maintained in dedicated instruction files:
+- Python wheels (`khiops-core`, `khiops-kni`), `pyproject.toml`, and pip/conda distribution rules: [`.github/instructions/python-wheel.instructions.md`](.github/instructions/python-wheel.instructions.md)
+- CPack packaging (DEB, RPM, NSIS, archives), `packaging/install.cmake`, and `packaging/packaging.cmake`: [`.github/instructions/cmake-changes.instructions.md`](.github/instructions/cmake-changes.instructions.md)
+
+Use these instruction files as the source of truth for packaging changes.
+
+### Running Tests
+
+```bash
+# Unit tests with CTest (requires -DTESTING=ON)
+ctest --preset <preset-name>
+ctest --preset macos-clang-debug -j<N>   # Parallel execution
+
+# Test executables
+./build/<preset>/bin/norm_test
+./build/<preset>/bin/parallel_test
+./build/<preset>/bin/learning_test
+```
+
+## Debugging and Testing
+
+Detailed debugging/testing guidelines (memory allocator, assertions, error management, trace patterns, unit/integration tests) are in [`.github/instructions/cpp-changes.instructions.md`](.github/instructions/cpp-changes.instructions.md) and apply when editing C++ files.
+
+## User Interface Development
+
+Detailed UI guidelines (MVC pattern, `.dd` files, `genere`, and CMake integration) are in [`.github/instructions/ui-changes.instructions.md`](.github/instructions/ui-changes.instructions.md) and apply when editing UI-related files.
+
+## Parallel Library
+
+Detailed parallel-programming guidelines (`PLParallelTask`, shared variables, registration, simulated mode) are in [`.github/instructions/cpp-changes.instructions.md`](.github/instructions/cpp-changes.instructions.md) and apply when editing C++ files.
+
+## Contact & Resources
+
+- **Team Email**: khiops.team@orange.com
+- **Developer Wiki**: https://github.com/KhiopsML/khiops/wiki
+- **Issue Tracker**: https://github.com/KhiopsML/khiops/issues

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,7 @@ src/
 test/
   ├─ UnitTests/       # CTest unit tests (norm_test, parallel_test, etc.)
   ├─ LearningTest/    # Integration/standard tests
+  ├─ LearningTestTool/ # Python test infrastructure for non-regression tests
   └─ MemoryStatsVisualizer/
 scripts/              # Python and CMake helpers, copyright/encoding checks
 packaging/            # Conda, Linux RPM/Debian, Windows NSIS configs
@@ -46,6 +47,13 @@ All commits must pass `.pre-commit-config.yaml`:
 ### Naming Conventions
 
 - **Learning module**: `KW*` prefix (e.g., `KWData`, `KWUtils`, `KWKhiopsVersion`)
+  - `KD*`: Domain knowledge / feature construction (`KDDomainKnowledge/`)
+  - `KNI*`: Khiops Native Interface (`KhiopsNativeInterface/`, `KNITransfer/`)
+  - `MH*`: Histogram models (`MHHistograms/`, `genum/`, `khisto/`)
+  - `SNB*`: Selective Naive Bayes predictor (`SNBPredictor/`)
+  - `DT*`: Decision trees and random forests (`DTForest/`)
+  - `CC*`: Coclustering (`MODL_Coclustering/`)
+  - `KI*`: Model interpretation / Shapley values (`KIInterpretation/`)
 - **Parallel module**: `PL*` prefix (e.g., `PLParallelTask`)
 - **Norm module**: Core/base prefixes
 - **Tests**: Separate implementation per module (`UnitTests/`, `StandardTests/`)
@@ -125,7 +133,8 @@ Quick trigger conventions:
 | **src/Norm** | C++ | Numerical algorithms, base data structures, memory allocator, assertions (`require`/`ensure`/`assert`), error management, GUI launcher |
 | **src/Parallel** | C++ | MPI task distribution, resource management |
 | **test/UnitTests** | C++ | Isolated component tests (norm_test, parallel_test) |
-| **test/LearningTest** | C++ | 800+ non-regression scenarios (Khiops, Coclustering, KNITransfer). Managed by `test/LearningTestTool/` |
+| **test/LearningTest** | JSON and other textual formats| 800+ non-regression scenarios (Khiops, Coclustering, KNITransfer). Managed by `test/LearningTestTool/` |
+| **test/LearningTestTool** | Python | Test infrastructure for non-regression tests (comparison engine, result context management, timeout handling) |
 | **packaging/** | CMake, YAML, Python | Distribution configs, Conda, Docker, installers |
 
 
@@ -137,7 +146,7 @@ See the [development environment setup page](https://github.com/KhiopsML/khiops/
 
 - **CMake** ≥ 3.22
 - **Ninja** (default generator, required)
-- **MPI**: MPICH (Linux/macOS) or MS-MPI (Windows standalone) / Intel MPI `impi-rt` (Windows pip)
+- **MPI**: OpenMPI/MPICH (Linux/macOS) or MS-MPI (Windows standalone) / Intel MPI `impi-rt` (Windows pip)
 - **Python** ≥ 3.9 (for wheel builds)
 
 ### Build System

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -176,7 +176,8 @@ cmake --build --preset macos-clang-release
 
 ```bash
 cd khiops
-cmake --fresh -S . -B build -D TESTING=OFF -D BUILD_JARS=ON -D CMAKE_BUILD_TYPE=Release
+# Configure project and override default CMake options if needed (e.g., -DTESTING=OFF, -DMPI=OFF)
+cmake --fresh -S . -B build -D TESTING=OFF -D CMAKE_BUILD_TYPE=Release
 cmake --build build/ --parallel
 ```
 

--- a/.github/instructions/ci-workflows.instructions.md
+++ b/.github/instructions/ci-workflows.instructions.md
@@ -1,14 +1,14 @@
 ---
 name: ci-workflows
-description: "Use when modifying GitHub Actions workflows, CI triggers, matrices, packaging pipelines, or release automation under .github/workflows/."
-applyTo: [".github/workflows/**"]
+description: "Use when modifying GitHub Actions workflows, composite actions, CI triggers, matrices, packaging pipelines, or release automation under .github/workflows/ or .github/actions/."
+applyTo: ".github/workflows/**, .github/actions/**"
 ---
 
-# GitHub Actions Workflow Instructions for Khiops
+# GitHub Actions Workflow & Action Instructions for Khiops
 
 ## Scope
 
-This file applies to workflow changes in `.github/workflows/`.
+This file applies to workflow changes in `.github/workflows/` and composite actions in `.github/actions/`.
 
 Current workflows (11):
 - `run-unit-tests.yml`
@@ -22,6 +22,41 @@ Current workflows (11):
 - `test-conda.yml`
 - `build-linux-pack-containers.yml`
 - `update-kni-tutorial.yml`
+
+## Composite Actions (`.github/actions/`)
+
+Reusable composite actions called by workflows:
+
+| Action | Purpose | Key Inputs |
+|--------|---------|------------|
+| **build-khiops** | CMake configure + build via presets | `preset-name` (required), `override-flags`, `targets` |
+| **check-tag-version** | Verify Git tag matches `KHIOPS_VERSION` in source | None (reads `github.ref_name`) |
+| **run-standard-tests** | Run LearningTest suite (Khiops, Coclustering, KNI) | `running-mode`, `config`, `binary-path`, `testing-context-description`, `warning_as_error` |
+| **test-khiops-install** | Validate `khiops_env`, `khiops -s`, MPI config | `bin-dir` |
+| **test-khiops-on-iris** | Functional Iris test for Khiops + Coclustering | `os-decription`, `show-openmpi-errors` |
+| **test-kni** | Test KNI C and Java examples (mono/multi-table) | None |
+
+### Action Usage Map
+
+| Workflow | Actions Used |
+|----------|-------------|
+| `run-unit-tests.yml` | `build-khiops` |
+| `run-standard-tests.yml` | `build-khiops`, `run-standard-tests` |
+| `pack-pip.yml` | `test-khiops-install`, `run-standard-tests` |
+| `pack-debian.yml` | `check-tag-version`, `run-standard-tests`, `test-khiops-install`, `test-kni` |
+| `pack-rpm.yml` | `check-tag-version`, `run-standard-tests`, `test-khiops-install`, `test-kni` |
+| `pack-nsis.yml` | `build-khiops`, `check-tag-version`, `run-standard-tests`, `test-khiops-install`, `test-kni` |
+| `pack-macos.yml` | `build-khiops` |
+| `test-conda.yml` | `run-standard-tests`, `test-khiops-install` |
+
+### Action Guidelines
+
+- **Prefer extending existing actions** over duplicating steps across workflows
+- Actions handle **platform-specific logic** (MPI setup, vcvars, Python detection) — keep this in the action, not in workflows
+- **`build-khiops`** manages MPI installation per OS: `brew install mpich` (macOS), `apt-get openmpi` (Linux), `mpi4py`/`setup-mpi` (Windows)
+- **`run-standard-tests`** runs different scopes: debug mode → Iris/IrisLight only; release mode → full Standard tests
+- **`check-tag-version`** must be called early in release packaging workflows before building artifacts
+- Keep action inputs minimal and well-documented; avoid adding inputs that duplicate workflow-level logic
 
 ## Trigger Strategy
 

--- a/.github/instructions/ci-workflows.instructions.md
+++ b/.github/instructions/ci-workflows.instructions.md
@@ -1,0 +1,95 @@
+---
+name: ci-workflows
+description: "Use when modifying GitHub Actions workflows, CI triggers, matrices, packaging pipelines, or release automation under .github/workflows/."
+applyTo: [".github/workflows/**"]
+---
+
+# GitHub Actions Workflow Instructions for Khiops
+
+## Scope
+
+This file applies to workflow changes in `.github/workflows/`.
+
+Current workflows (11):
+- `run-unit-tests.yml`
+- `run-standard-tests.yml`
+- `pre-commit-checks.yml`
+- `pack-pip.yml`
+- `pack-debian.yml`
+- `pack-rpm.yml`
+- `pack-nsis.yml`
+- `pack-macos.yml`
+- `test-conda.yml`
+- `build-linux-pack-containers.yml`
+- `update-kni-tutorial.yml`
+
+## Trigger Strategy
+
+Keep trigger behavior aligned with repository conventions:
+- **PR-triggered workflows**: run only when relevant files change (source changes for tests, packaging/CMake changes for packaging)
+- **Tag-triggered workflows**: packaging/release workflows
+- **Manual workflows** (`workflow_dispatch`): heavy or exceptional jobs (macOS packaging, conda tests, container builds, tutorial sync)
+
+When adding a new workflow or trigger:
+- Use `paths` filters to avoid unnecessary CI load
+- Prefer reusing existing trigger patterns before introducing new ones
+- Ensure the trigger matches the expected development workflow (PR validation vs release artifact build)
+
+## Test Workflows
+
+Testing responsibilities:
+- `run-unit-tests.yml`: unit tests and fast validation
+- `run-standard-tests.yml`: end-to-end scenarios (Khiops, Coclustering, KNITransfer), serial and parallel paths
+- `pre-commit-checks.yml`: formatting and repository policy checks (`clang-format`, `black`, `cmake-format`, copyright, encoding)
+
+Guidelines:
+- Keep unit and integration scopes separated
+- Ensure parallel test coverage remains explicit when relevant
+- Keep per-platform matrices synchronized with supported platforms
+
+## Packaging Workflows
+
+Packaging responsibilities:
+- `pack-pip.yml`: Python wheels (`khiops-core`, `khiops-kni`)
+- `pack-debian.yml`: DEB packages
+- `pack-rpm.yml`: RPM packages
+- `pack-nsis.yml`: Windows NSIS installer
+- `pack-macos.yml`: macOS package/archive
+
+Guidelines:
+- Keep package naming/versioning consistent with `KHIOPS_VERSION`
+- Keep packaging workflow logic aligned with CMake packaging files:
+  - `packaging/install.cmake`
+  - `packaging/packaging.cmake`
+- Do not duplicate business logic in workflows when CMake/packaging scripts already implement it
+
+## Platform Matrix and Compatibility
+
+Supported CI targets include Windows, Linux, and macOS, with x64/ARM64 where applicable.
+
+When changing matrices:
+- Keep consistency with official support matrix
+- Validate architecture-specific conditions (e.g., ARM64-specific container/image constraints)
+- Avoid dropping existing platform coverage without explicit rationale
+
+## Best Practices
+
+- Prefer small, composable job steps over monolithic shell scripts
+- Cache only stable dependencies; avoid stale build artifact reuse
+- Keep workflow names and job names explicit and stable
+- Use descriptive step names to ease CI debugging
+- Keep secrets usage minimal and scoped per job
+
+## Common Pitfalls
+
+- Adding broad triggers (`on: [push, pull_request]`) without `paths` filters
+- Duplicating build/test logic that already exists in scripts/CMake
+- Diverging release/tag behavior across packaging workflows
+- Changing matrix dimensions in one workflow but not the related ones
+- Introducing platform-specific commands without proper conditionals
+
+## Related Instruction Files
+
+- CMake and CPack behavior: `.github/instructions/cmake-changes.instructions.md`
+- Wheel packaging behavior: `.github/instructions/python-wheel.instructions.md`
+- C++ build/test impacts: `.github/instructions/cpp-changes.instructions.md`

--- a/.github/instructions/cmake-changes.instructions.md
+++ b/.github/instructions/cmake-changes.instructions.md
@@ -1,0 +1,678 @@
+---
+name: cmake-changes
+description: "Use when modifying CMake files, build configuration, presets, or CTest setup. Covers CMake conventions, preset management, component organization, and cross-platform builds."
+applyTo: ["**/CMakeLists.txt", "CMakePresets.json", "**/CMakePresets.json", "CMakeUserPresets.json","packaging/install.cmake", "packaging/packaging.cmake", "scripts/generate_gui.cmake", "scripts/get_mpi_implementation.cmake"]
+---
+
+# CMake Build Configuration Instructions for Khiops
+
+## CMake Overview
+
+Khiops uses **CMake 3.22+** with **Ninja** as the default generator. Build configuration is managed through:
+- **CMakePresets.json** — Shared, committed presets for team builds
+- **CMakeUserPresets.json** — User-local presets (not committed)
+- **Preset-specific CMakeLists.txt** — Per-module configuration files
+- **`packaging/install.cmake`** — All `install()` rules (centralized)
+- **`packaging/packaging.cmake`** — CPack configuration for DEB, RPM, NSIS, archives
+- **`scripts/generate_gui.cmake`** — Helper functions for generating C++ GUI code from `.dd` files
+- **`scripts/get_mpi_implementation.cmake`** — Helper function to detect the active MPI implementation
+
+## Preset Management
+
+### Available Presets
+
+All presets are defined in `CMakePresets.json`:
+
+| Platform | Debug Preset | Release Preset |
+|----------|-------------|----------------|
+| **macOS** | `macos-clang-debug` | `macos-clang-release` |
+| **Linux** | `linux-gcc-debug` | `linux-gcc-release` |
+| **Windows** | `windows-msvc-debug` | `windows-msvc-release` |
+
+### Using Presets
+
+```bash
+# List all presets
+cmake --list-presets
+
+# Configure with preset
+cmake --preset macos-clang-debug
+
+# Build with preset
+cmake --build --preset macos-clang-debug
+
+# Run tests with preset
+ctest --preset macos-clang-debug -j<N>
+```
+
+### Modifying Presets
+
+**For shared changes** (affects team):
+- Edit `CMakePresets.json` in repository root
+- Commit changes to git
+- Common changes: compiler paths, default flags, new platforms
+
+**For personal changes** (local only):
+- Create or edit `CMakeUserPresets.json` (git-ignored)
+- Override preset values without affecting team builds
+- Example: enable sanitizers, custom compiler, local paths
+
+**Preset structure**:
+
+```json
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "my-preset",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/my-preset",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "MPI": true,
+        "TESTING": true
+      }
+    }
+  ]
+}
+```
+
+## CMake Variables & Build Options
+
+### Core Variables
+
+| Variable | Default | Purpose | Valid Values |
+|----------|---------|---------|--------------|
+| `CMAKE_BUILD_TYPE` | Release | Build configuration | Debug, Release, RelWithDebInfo, MinSizeRel |
+| `MPI` | ON | Enable MPI parallelization | ON, OFF |
+| `TESTING` | OFF | Build unit tests | ON, OFF |
+| `BUILD_LEX_YACC` | OFF | Rebuild grammar parsers | ON, OFF |
+| `BUILD_JARS` | ON | Build Java GUI components | ON, OFF |
+| `GENERATE_VIEWS` | OFF | Regenerate UI from `.dd` files | ON, OFF |
+| `C11` | ON | Use C++11 standard | ON, OFF |
+
+### Setting Variables
+
+**At configure time**:
+
+```bash
+cmake --preset macos-clang-debug -D TESTING=ON -D MPI=OFF
+```
+
+**In CMakePresets.json**:
+
+```json
+"cacheVariables": {
+  "CMAKE_BUILD_TYPE": "Debug",
+  "TESTING": true,
+  "MPI": false
+}
+```
+
+**In CMakeLists.txt**:
+
+```cmake
+set(MPI ON CACHE BOOL "Enable MPI" FORCE)
+```
+
+## CMakeLists.txt Structure
+
+### File Organization
+
+Each module has a `CMakeLists.txt`:
+- **Top-level**: `CMakeLists.txt` — Coordinates all modules
+- **Module-level**: `src/Learning/CMakeLists.txt`, `src/Norm/CMakeLists.txt`, etc.
+- **Sub-module**: Each component has its own `CMakeLists.txt`
+
+### Standard Layout
+
+```cmake
+cmake_minimum_required(VERSION 3.22)
+project(khiops)
+
+# Enable testing (if needed)
+if(TESTING)
+  enable_testing()
+endif()
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Define libraries and executables
+add_library(KWLearning STATIC ...)
+add_executable(khiops ...)
+
+# Link dependencies
+target_link_libraries(KWLearning PUBLIC KWNorm)
+target_link_libraries(khiops PRIVATE KWLearning)
+
+# Install rules
+install(TARGETS khiops DESTINATION bin COMPONENT KHIOPS_CORE)
+install(TARGETS KWLearning DESTINATION lib COMPONENT KHIOPS_CORE)
+
+# Add subdirectories
+add_subdirectory(src/Norm)
+add_subdirectory(src/Learning)
+add_subdirectory(src/Parallel)
+```
+
+### Naming Conventions
+
+**Targets** (libraries, executables):
+- Main libraries: `KW*` (e.g., `KWLearning`, `KWNorm`, `KWData`)
+- Parallel: `PL*` (e.g., `PLParallelTask`)
+- Test executables: `*_test` (e.g., `norm_test`, `learning_test`)
+
+**Variables**:
+- `MY_VAR` (uppercase with underscores)
+- Prefix with module name: `LEARNING_SOURCES`, `NORM_HEADERS`
+
+**Functions**:
+- `my_function_name` (lowercase with underscores)
+- Custom functions: `khiops_add_executable()`, `khiops_add_test()`
+
+## Component & Installation Setup
+
+### `packaging/install.cmake` — Single Source for All Install Rules
+
+**All `install()` commands are centralized in `packaging/install.cmake`**, not scattered across individual `CMakeLists.txt` files. This file is included by the top-level `CMakeLists.txt`.
+
+**When adding a new installed target**, edit `packaging/install.cmake`. Do NOT add `install()` calls inside module-level `CMakeLists.txt`.
+
+Installation paths adapt to the build context via condition flags:
+
+| Flag | Meaning |
+|------|---------|
+| `IS_PIP` | Building for pip wheel (uses `SKBUILD_*` variables for paths) |
+| `IS_CONDA` | Building for conda (some installs disabled) |
+| `IS_WINDOWS` | Windows-specific paths and layout |
+| `IS_LINUX` | Linux paths (`usr/bin`, `usr/lib`, etc.) |
+| `IS_MACOS` | macOS paths (no GUI support) |
+| `IS_FEDORA_LIKE` | RPM-based distros (Fedora/Rocky-specific paths) |
+
+Example structure inside `install.cmake`:
+
+```cmake
+# Destination changes depending on context
+if(IS_PIP)
+  set(LIB_DIR ${SKBUILD_DATA_DIR}/lib)
+elseif(IS_WINDOWS)
+  set(LIB_DIR lib)
+else()
+  set(LIB_DIR usr/lib)
+endif()
+
+# Install rule uses computed destination
+install(
+  TARGETS KhiopsNativeInterface
+  LIBRARY DESTINATION ${LIB_DIR} COMPONENT KNI
+  PUBLIC_HEADER DESTINATION ${INCLUDE_DIR} COMPONENT KNI
+)
+```
+
+### Install Components
+
+Each installed file belongs to a named component. Components map to distributed packages:
+
+| Component | Contents | Distributed in |
+|-----------|----------|-----------------|
+| `KHIOPS_CORE` | Core Khiops binaries (no GUI, no docs) | pip wheel, khiops-core Native installers (DEB, RPM) |
+| `KHIOPS` | Full GUI distribution | khiops Native installers (DEB, RPM) |
+| `KNI` | KhiopsNativeInterface shared lib + header | `khiops-kni` pip wheel, KNI Native installers (DEB, RPM) |
+| `KNI_TRANSFER` | KNITransfer test binary | Separate tech package |
+| `KHISTO` | Khisto histogram tool | Separate package |
+
+Test executables have **no component** and are therefore never installed:
+
+```cmake
+# In CMakeLists.txt: build only, no install
+add_executable(norm_test ...)
+# No install() call for test targets
+```
+
+## Platform-Specific Configuration
+
+`set_khiops_options()` function in top-level `CMakeLists.txt` configures platform-specific options, it should be used on each target to ensure consistent configuration across platforms. For example:
+```cmake
+set_khiops_options(MODL)
+```
+
+### MPI Configuration
+
+```cmake
+if(MPI)
+  find_package(MPI REQUIRED)
+  target_link_libraries(PLParallelTask PUBLIC MPI::MPI_CXX)
+else()
+  message(STATUS "MPI disabled — sequential execution only")
+endif()
+```
+
+The only library that depends on MPI is `PLMPI`, which is only built when `MPI` is enabled. All other libraries and executables should be independent of MPI to allow building without it.
+
+### `scripts/get_mpi_implementation.cmake` — MPI Implementation Detection
+
+This script provides the `get_mpi_implementation()` function, which detects which MPI implementation is installed (OpenMPI, MPICH, or Intel MPI) and sets the appropriate variables.
+
+**When to use**: when build behavior must differ depending on the MPI implementation (e.g., different launcher commands or library flags).
+
+```cmake
+# In CMakeLists.txt
+include(${PROJECT_SOURCE_DIR}/scripts/get_mpi_implementation.cmake)
+get_mpi_implementation()
+
+# After the call, these variables are set:
+# MPI_IMPL     — "openmpi", "mpich", or "intel" (empty if not detected)
+# IS_OPEN_MPI  — TRUE if OpenMPI
+# IS_MPICH     — TRUE if MPICH
+# IS_INTEL_MPI — TRUE if Intel MPI
+
+if(IS_MPICH)
+  # MPICH-specific configuration
+endif()
+```
+
+**Detection strategy** (adapts to environment):
+- **Standard**: searches `MPI_LIBRARIES` path (from `find_package(MPI)`)
+- **pip**: queries `importlib.metadata` for installed package names
+- **conda build**: reads `$ENV{mpi}` variable
+- **conda runtime**: runs `conda list | grep mpi`
+
+### `scripts/generate_gui.cmake` — GUI Code Generation from `.dd` Files
+
+This script provides two functions for generating C++ view classes from `.dd` attribute specification files using the `genere` tool. Only active when `GENERATE_VIEWS=ON`.
+
+**Functions**:
+- `generate_gui_add_view(ClassName ClassLabel AttributeFileName LogFile [options])` — registers a code generation step triggered when the `.dd` file changes
+- `generate_gui_add_view_add_dependency(TargetName)` — ensures `genere` is built before the target
+
+```cmake
+# In CMakeLists.txt
+include(${PROJECT_SOURCE_DIR}/scripts/generate_gui.cmake)
+
+generate_gui_add_view(KWDatabase "Database" KWDatabase.dd KWDatabase.dd.log -nomodel -noarrayview)
+
+add_executable(myTarget ...)
+if(GENERATE_VIEWS)
+  target_sources(myTarget PRIVATE KWDatabase.dd.log)  # Required: triggers re-generation
+endif()
+generate_gui_add_view_add_dependency(myTarget)
+```
+
+**Options** (same as the `genere` tool):
+
+| Option | Effect |
+|--------|--------|
+| `-nomodel` | Skip generating the model class |
+| `-noview` | Skip generating view and array-view classes |
+| `-noarrayview` | Skip generating the array-view class |
+| `-super <ClassName>` | Set a custom parent class |
+| `-nousersection` | Do not generate `// ## Custom` user sections |
+
+**Important**: the `.dd.log` file must be added as a target source with `target_sources()`. Without it, `generate_gui_add_view` is never triggered. The log file acts as a build signal — it is the declared output of the custom command.
+
+**Workflow**:
+1. Set `GENERATE_VIEWS=ON` in preset or on command line
+2. Modify the `.dd` file
+3. Build — `genere` regenerates the C++ view files automatically
+4. Code in `// ## Custom ... // ##` sections is preserved across regenerations
+
+### Library Search
+
+```cmake
+# Find system library
+find_package(MPI REQUIRED)
+
+# Or use optional find
+find_package(FLEX)
+find_package(BISON)
+
+if(NOT FLEX_FOUND OR NOT BISON_FOUND)
+  message(WARNING "Lex/Yacc not available — using pre-generated files")
+endif()
+```
+
+## CTest & Testing Setup
+
+### Adding Tests
+
+```cmake
+# Enable testing
+enable_testing()
+
+# Add a test executable
+add_executable(norm_test test/UnitTests/norm_test.cpp ...)
+
+# Register it with CTest
+add_test(NAME NormTest COMMAND norm_test)
+
+# With custom working directory or environment
+add_test(
+  NAME LearningTest
+  COMMAND learning_test --verbose
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+```
+
+### Test Organization
+
+```cmake
+# Unit tests (isolated, fast)
+if(TESTING)
+  add_executable(norm_test ${NORM_TEST_SOURCES})
+  target_link_libraries(norm_test PRIVATE KWNorm gtest)
+  add_test(NAME NormUnitTests COMMAND norm_test)
+endif()
+
+```
+
+### CTest Execution
+
+```bash
+# Run all tests
+ctest --preset macos-clang-debug
+
+# Run specific test
+ctest --preset macos-clang-debug -R NormTest
+
+# Parallel execution
+ctest --preset macos-clang-debug -j4
+
+# Verbose output
+ctest --preset macos-clang-debug --verbose
+
+# Stop on first failure
+ctest --preset macos-clang-debug --stop-on-failure
+```
+
+## External Dependencies
+
+### Finding Packages
+
+```cmake
+# Required dependency
+find_package(MPI REQUIRED)
+
+# Optional dependency
+find_package(FLEX)
+if(FLEX_FOUND)
+  target_include_directories(MyTarget PRIVATE ${FLEX_INCLUDE_DIRS})
+else()
+  message(STATUS "FLEX not found — grammar generation disabled")
+endif()
+```
+
+### Linking
+
+```cmake
+# Link public dependency (visible to consumers)
+target_link_libraries(MyLib PUBLIC OtherLib)
+
+# Link private dependency (internal only)
+target_link_libraries(MyLib PRIVATE InternalLib)
+
+# Link interface (header-only, no linking needed)
+target_link_libraries(MyLib INTERFACE HeaderOnlyLib)
+```
+
+### Custom Find Modules
+
+For third-party packages without official CMake support:
+
+```cmake
+# Place in cmake/FindMyPackage.cmake
+# Then use:
+find_package(MyPackage REQUIRED)
+```
+
+## Common CMake Operations
+
+### Adding a New Library
+
+```cmake
+# Collect sources
+file(GLOB SOURCES "src/*.cpp")
+file(GLOB HEADERS "src/*.h")
+
+# Create library
+add_library(MyLib STATIC ${SOURCES} ${HEADERS})
+
+# Set options and properties
+set_khiops_options(MyLib)
+
+# Set include directories
+target_include_directories(MyLib
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>
+)
+
+# Link dependencies
+target_link_libraries(MyLib PUBLIC KWNorm)
+
+# In packaging/install.cmake: install rule
+install(
+  TARGETS MyLib
+  LIBRARY DESTINATION lib COMPONENT KHIOPS_CORE
+  ARCHIVE DESTINATION lib COMPONENT KHIOPS_CORE
+)
+```
+
+### Adding an Executable
+
+```cmake
+# In the module CMakeLists.txt: build only
+add_executable(my_program src/main.cpp)
+set_khiops_options(my_program)
+target_link_libraries(my_program PRIVATE MyLib)
+
+# In packaging/install.cmake: install rule
+install(TARGETS my_program DESTINATION bin COMPONENT KHIOPS_CORE)
+```
+
+## CPack & Packaging (`packaging/packaging.cmake`)
+
+### `packaging/packaging.cmake` — CPack Configuration
+
+All CPack configuration for native packages (DEB, RPM, NSIS, Archive) is in **`packaging/packaging.cmake`**, included by the top-level `CMakeLists.txt`.
+
+This file sets:
+- Package metadata (vendor, contact, homepage, license)
+- Per-component descriptions (shown in package managers)
+- Generator-specific settings (DEB, RPM, ARCHIVE, NSIS)
+
+### Key CPack Variables
+
+```cmake
+# Global metadata (packaging.cmake)
+set(CPACK_PACKAGE_VENDOR "Orange")
+set(CPACK_PACKAGE_CONTACT "Khiops Team <khiops.team@orange.com>")
+set(CPACK_PACKAGE_HOMEPAGE_URL https://khiops.org)
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+
+# Component-based packaging (one package per component)
+set(CPACK_DEB_COMPONENT_INSTALL YES)
+set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+
+# Package version taken from KHIOPS_VERSION
+set(CPACK_DEBIAN_PACKAGE_VERSION ${KHIOPS_VERSION})
+```
+
+### Adding a Component Description
+
+Each component distributed as a package needs a description in `packaging.cmake`:
+
+```cmake
+# In packaging/packaging.cmake
+set(CPACK_COMPONENT_MY_COMPONENT_DESCRIPTION
+    "Short title
+Longer multi-line description of what this component provides.
+Describe contents, purpose, and dependencies.")
+```
+
+> **Convention**: `CPACK_COMPONENT_<UPPERCASE_COMPONENT_NAME>_DESCRIPTION`
+
+### Building Packages
+
+```bash
+# Configure
+cmake --preset linux-gcc-release
+
+# Build
+cmake --build --preset linux-gcc-release
+
+# Generate DEB packages
+cpack --preset linux-gcc-release -G DEB
+
+# Generate RPM packages
+cpack --preset linux-gcc-release -G RPM
+
+# Generate Archive (tar.gz)
+cpack --preset linux-gcc-release -G TGZ
+
+# Only one component
+cpack --preset linux-gcc-release -G DEB -D CPACK_COMPONENTS_ALL=KHIOPS_CORE
+```
+
+Packages are output to `build/<preset>/packages/`.
+
+### DEB-Specific Settings
+
+```cmake
+# In packaging/packaging.cmake — modify these when changing DEB packaging
+set(CPACK_DEBIAN_PACKAGE_RELEASE 1)         # Package iteration (not software version)
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)     # Use standard Debian naming convention
+set(CPACK_DEBIAN_PACKAGE_SECTION "math")    # Debian section
+set(CPACK_DEBIAN_PACKAGE_VERSION ${KHIOPS_VERSION})  # Full version including pre-release suffix
+```
+
+### Archive Naming
+
+```cmake
+# In packaging/packaging.cmake — user-friendly archive filenames
+set(CPACK_ARCHIVE_KHIOPS_CORE_FILE_NAME khiops-core-${KHIOPS_VERSION})
+set(CPACK_ARCHIVE_KNI_FILE_NAME kni-${KHIOPS_VERSION})
+set(CPACK_ARCHIVE_KHISTO_FILE_NAME khisto-${KHIOPS_VERSION})
+```
+
+## Pre-commit & Validation
+
+### Running Pre-commit Checks
+
+```bash
+# Check CMake formatting
+cmake-format --check CMakeLists.txt
+
+# Auto-format
+cmake-format -i CMakeLists.txt
+
+# Validate syntax
+cmake --lint=style CMakeLists.txt
+```
+
+**Pre-commit hook checks**:
+- `cmake-format` for style consistency
+- Syntax validation (optional)
+- Copyright year verification
+- UTF-8 encoding
+
+## Common Pitfalls
+
+### ❌ Adding install() Outside `packaging/install.cmake`
+
+```cmake
+# ❌ Wrong: install() inside a module CMakeLists.txt
+# src/Learning/CMakeLists.txt
+add_executable(MODL ...)
+install(TARGETS MODL DESTINATION bin COMPONENT KHIOPS_CORE)  # Don't do this here
+
+# ✅ Right: build in CMakeLists.txt, install in packaging/install.cmake
+# src/Learning/CMakeLists.txt
+add_executable(MODL ...)
+
+# packaging/install.cmake
+install(TARGETS MODL DESTINATION ${BIN_DIR} COMPONENT KHIOPS_CORE)
+```
+
+### ❌ Forgetting COMPONENT in install()
+
+```cmake
+# ❌ Wrong: Installs to default (all) components
+install(TARGETS myexe DESTINATION bin)
+
+# ✅ Right: Explicitly specify component
+install(TARGETS myexe DESTINATION bin COMPONENT KHIOPS_CORE)
+```
+
+### ❌ Using Glob with Git Ignore
+
+```cmake
+# ❌ Bad: Misses new files added after configure
+file(GLOB SOURCES "src/*.cpp")
+
+# ✅ Better: Explicit list or wildcard with explicit paths
+set(SOURCES
+  src/file1.cpp
+  src/file2.cpp
+)
+# Or regenerate after adding files
+```
+
+### ❌ Not Setting Build Type in Preset
+
+```json
+{
+  "cacheVariables": {
+    // ❌ Missing CMAKE_BUILD_TYPE
+    "TESTING": true
+  }
+}
+
+// ✅ Add explicit build type
+{
+  "cacheVariables": {
+    "CMAKE_BUILD_TYPE": "Debug",
+    "TESTING": true
+  }
+}
+```
+
+### ❌ Hardcoding Paths
+
+```cmake
+# ❌ Wrong: Not portable
+set(MPI_PATH "/usr/lib/mpich")
+
+# ✅ Right: Let find_package() locate it
+find_package(MPI REQUIRED)
+```
+
+### ❌ Breaking Cross-Platform with Absolute Paths
+
+```cmake
+# ❌ Wrong: Windows-only path
+target_include_directories(MyLib PRIVATE "C:\\dev\\include")
+
+# ✅ Right: Relative or find_package()
+target_include_directories(MyLib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+```
+
+### ❌ Installing Test Executables
+
+```cmake
+# ❌ Wrong: Tests included in distribution
+install(TARGETS norm_test DESTINATION bin COMPONENT KHIOPS_CORE)
+
+# ✅ Right: No component = not installed
+add_executable(norm_test ...)
+# No install() call for test targets
+```
+
+## Resources
+
+- **CMake Documentation**: https://cmake.org/cmake/help/latest/
+- **CMake Best Practices**: https://cliutils.gitlab.io/modern-cmake/
+- **CMakePresets Reference**: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
+- **scikit-build-core**: https://scikit-build-core.readthedocs.io/
+- **Khiops CMake Structure**: Top-level `CMakeLists.txt` and per-module configs in `src/*/CMakeLists.txt`

--- a/.github/instructions/cmake-changes.instructions.md
+++ b/.github/instructions/cmake-changes.instructions.md
@@ -217,9 +217,9 @@ Each installed file belongs to a named component. Components map to distributed 
 
 | Component | Contents | Distributed in |
 |-----------|----------|-----------------|
-| `KHIOPS_CORE` | Core Khiops binaries (no GUI, no docs) | pip wheel, khiops-core Native installers (DEB, RPM) |
-| `KHIOPS` | Full GUI distribution | khiops Native installers (DEB, RPM) |
-| `KNI` | KhiopsNativeInterface shared lib + header | `khiops-kni` pip wheel, KNI Native installers (DEB, RPM) |
+| `KHIOPS_CORE` | Core Khiops binaries (no GUI, no docs) | pip wheel, khiops-core Native installers (DEB, RPM), conda |
+| `KHIOPS` | Full GUI distribution | khiops Native installers (DEB, RPM)|
+| `KNI` | KhiopsNativeInterface shared lib + header | `khiops-kni` pip wheel, KNI Native installers (DEB, RPM), conda |
 | `KNI_TRANSFER` | KNITransfer test binary | Separate tech package |
 | `KHISTO` | Khisto histogram tool | Separate package |
 

--- a/.github/instructions/cpp-changes.instructions.md
+++ b/.github/instructions/cpp-changes.instructions.md
@@ -35,25 +35,33 @@ void MyClass::DoSomething() {
 - **Class-to-file mapping**: Use one main class per file; filename matches class name
 - **Module prefix**:
   - **Learning module**: `KW*` (e.g., `KWData.h`, `KWDataPreparation.cpp`)
+  - **Learning sub-modules**:
+    - `KD*`: Domain knowledge / feature construction (`KDDomainKnowledge/`)
+    - `KNI*`: Khiops Native Interface (`KhiopsNativeInterface/`, `KNITransfer/`)
+    - `MH*`: Histogram models (`MHHistograms/`, `genum/`, `khisto/`)
+    - `SNB*`: Selective Naive Bayes predictor (`SNBPredictor/`)
+    - `DT*`: Decision trees and random forests (`DTForest/`)
+    - `CC*`: Coclustering (`MODL_Coclustering/`)
+    - `KI*`: Model interpretation / Shapley values (`KIInterpretation/`)
   - **Parallel module**: `PL*` (e.g., `PLParallelTask.h`, `PLTaskInput.cpp`)
   - **Norm module**: Core utilities (e.g., `ALString.h`, `Object.h`)
 
 ### Comments
 
-- **Language**: French (company convention)
+- **Language**: French (with the accented characters replaced with their ASCII counterparts, company convention)
 - **Style**: `//` only (never `/* */`)
 - **Placement**: Preceded by a blank line
 - **Group comments**: Use banner `///////////` before group descriptions
 
 ```cpp
-// Compute the optimal discretization boundaries
+// Calcul des bornes de discretisation optimales
 int DiscretizeVariable()
 {
 	// ...
 }
 
 ///////////
-// Helper methods for data validation
+// Methodes utilitaires de validation des donnees
 void CheckDataIntegrity()
 {
 	// ...
@@ -153,19 +161,19 @@ Every `Object` subclass should implement:
 class MyClass : public Object
 {
 public:
-	// Data operations
+	// Operations sur les donnees
 	Object* Clone() const override;
 	void CopyFrom(const Object* oSource) override;
 	int Compare(const Object* oOther) const override;
 
-	// Integrity checking
+	// Controle d'integrite
 	boolean Check() const override;
 	const ALString GetObjectLabel() const override;
 
-	// Memory tracking
+	// Suivi de la memoire
 	longint GetUsedMemory() const override;
 
-	// Error management
+	// Gestion des erreurs
 	void AddError(const ALString& sLabel, const ALString& sMessage);
 	void AddWarning(const ALString& sLabel, const ALString& sMessage);
 };
@@ -272,11 +280,11 @@ If allocation is not freed:
 ```cpp
 int main()
 {
-	MemSetAllocIndexExit(42);  // Debug specific allocation ID
+	MemSetAllocIndexExit(42);  // Debuggage d'un identifiant d'allocation specifique
 
-	// ... your code ...
+	// ... votre code ...
 
-	return 0;  // Breakpoint in GlobalExit() on memory leak
+	return 0;  // Point d'arret dans GlobalExit() en cas de fuite memoire
 }
 ```
 
@@ -349,11 +357,29 @@ void MyClass::Function()
 - **Data structures**: Use `ObjectArray`, `ObjectDictionary` from Norm
 - **Error handling**: `AddError()`, `AddWarning()`, `Check()` methods
 - **Parallel tasks**: Inherit from `PLParallelTask` if parallelizable
+- **Sub-module prefixes**:
+  - `KD*`: Domain knowledge / feature construction (`KDDomainKnowledge/`)
+  - `KNI*`: Khiops Native Interface (`KhiopsNativeInterface/`, `KNITransfer/`)
+  - `MH*`: Histogram models (`MHHistograms/`, `genum/`, `khisto/`)
+  - `SNB*`: Selective Naive Bayes predictor (`SNBPredictor/`)
+  - `DT*`: Decision trees and random forests (`DTForest/`)
+  - `CC*`: Coclustering (`MODL_Coclustering/`)
+  - `KI*`: Model interpretation / Shapley values (`KIInterpretation/`)
 
 ### Parallel Module (`PL*` prefix)
 
 - **Shared variables**: `DeclareSharedParameter()`, `DeclareTaskInput()`, `DeclareTaskOutput()`
-- **Master/slave pattern**: Implement `MasterInitialize()`, `SlaveProcess()`, `MasterAggregateResults()`
+- **Master/slave pattern**: Subclass `PLParallelTask` and implement all pure virtual methods:
+  - `GetTaskName() const` — unique task name
+  - `Create() const` — returns a new instance of the task
+  - `MasterInitialize()` — master initialization
+  - `MasterPrepareTaskInput(double& dTaskPercent, boolean& bIsTaskFinished)` — prepare input for next slave
+  - `MasterAggregateResults()` — aggregate results from a slave
+  - `MasterFinalize(boolean bProcessEndedCorrectly)` — master cleanup
+  - `SlaveInitialize()` — slave initialization
+  - `SlaveProcess()` — main slave processing (reads `taskInput`, writes `taskOutput`)
+  - `SlaveFinalize(boolean bProcessEndedCorrectly)` — slave cleanup
+- **Optional override**: `ComputeResourceRequirements()` — declare memory/disk needs before launch
 - **No multi-threading**: All parallelization via MPI
 
 ### Norm Module (Core)
@@ -443,7 +469,7 @@ Allocated resources are accessible via `GetSlaveResourceGrant()` and `GetMasterR
 
 ### Task Registration
 
-All parallel tasks must be registered at program startup (in `MODL.cpp`):
+All parallel tasks must be registered at program startup (in `KWLearningProject.cpp` for MODL):
 ```cpp
 PLParallelTask::RegisterTask(new MyTask);
 ```
@@ -557,7 +583,7 @@ Build with `-DTESTING=ON`, run with `ctest`.
 
 ### Integration Tests
 
-Integration tests use the python library KhiopsTestTool (`test/LearningTestTool/`). `LearningTest` automates non-regression scenarios and handles platform variations.
+Integration tests use the python library LearningTestTool (`test/LearningTestTool/`). `LearningTest` automates non-regression scenarios and handles platform variations.
 
 ### Tracing
 

--- a/.github/instructions/cpp-changes.instructions.md
+++ b/.github/instructions/cpp-changes.instructions.md
@@ -1,0 +1,581 @@
+---
+name: cpp-changes
+description: "Use when modifying C++ code in Learning, Norm, or Parallel modules. Covers naming conventions, code style, assertion patterns, memory management, and pre-commit requirements."
+applyTo: ["**/*.cpp", "**/*.h"]
+---
+
+# C++ Coding Instructions for Khiops
+
+## Code Style & Formatting
+
+### Line Length & Indentation
+
+- **Max line length**: 120 characters, prefer ≤ 100
+- **Indentation**: **Tabs** (not spaces)
+- **Braces**: Allman style — opening brace on its own line at same indentation
+
+```cpp
+// ✅ Correct
+void MyClass::DoSomething()
+{
+	if (condition)
+	{
+		// Code here
+	}
+}
+
+// ❌ Wrong: Braces on same line
+void MyClass::DoSomething() {
+    if (condition) {  // Also wrong: spaces instead of tabs
+```
+
+### File Naming
+
+- **Convention**: `UpperCamelCase.cpp` and `UpperCamelCase.h`
+- **Class-to-file mapping**: Use one main class per file; filename matches class name
+- **Module prefix**:
+  - **Learning module**: `KW*` (e.g., `KWData.h`, `KWDataPreparation.cpp`)
+  - **Parallel module**: `PL*` (e.g., `PLParallelTask.h`, `PLTaskInput.cpp`)
+  - **Norm module**: Core utilities (e.g., `ALString.h`, `Object.h`)
+
+### Comments
+
+- **Language**: French (company convention)
+- **Style**: `//` only (never `/* */`)
+- **Placement**: Preceded by a blank line
+- **Group comments**: Use banner `///////////` before group descriptions
+
+```cpp
+// Compute the optimal discretization boundaries
+int DiscretizeVariable()
+{
+	// ...
+}
+
+///////////
+// Helper methods for data validation
+void CheckDataIntegrity()
+{
+	// ...
+}
+```
+
+## Variable Naming (Hungarian Notation)
+
+Khiops uses Hungarian notation extensively. Prefix variables with type indicators:
+
+| Prefix | Type | Example |
+|--------|------|---------|
+| `n` | `int` | `nSize`, `nIndex` |
+| `b` | `boolean` | `bIsValid`, `bHasChildren` |
+| `c` | `char` | `cDelimiter` |
+| `l` | `longint` | `lFileSize` |
+| `d` | `double` | `dMeanValue`, `dThreshold` |
+| `s` | `ALString` / `char*` | `sLabel`, `sFileName` |
+| `o` | `Object*` | `oDatabase`, `oTable` |
+| `i`, `j`, `k` | Loop indices | `for (int i = 0; i < n; i++)` |
+| `io` | `IntObject*` | `ioCounter` |
+| `do` | `DoubleObject*` | `doStdDev` |
+| `oa` | `ObjectArray*` | `oaColumns` |
+| `ol` | `ObjectList*` | `olItems` |
+| `ov` | `ObjectVector*` | `ovData` |
+| `iv` | `IntVector*` | `ivIndices` |
+| `dv` | `DoubleVector*` | `dvScores` |
+| `sv` | `StringVector*` | `svLabels` |
+
+```cpp
+// ✅ Correct
+int nCount = 0;
+double dSum = 0.0;
+ALString sFileName = "data.txt";
+ObjectArray* oaColumns = new ObjectArray;
+
+// ❌ Wrong: Missing type prefix
+int count = 0;           // Should be nCount
+double sum = 0.0;        // Should be dSum
+string fileName = "";    // Should be sFileName + ALString
+```
+
+## Class Structure Rules
+
+### Constructor & Initialization
+
+- **One constructor per class, no parameters**
+- **Initialization in dedicated methods**: `Initialize()`, `InitializeWithData()`
+- **Avoid constructor side-effects**: Use `MasterInitialize()`/`SlaveInitialize()` for parallel tasks
+
+```cpp
+// ✅ Correct
+class KWData : public Object
+{
+public:
+	KWData();
+	void Initialize();
+
+	// ...
+};
+
+// ❌ Wrong: Multi-param constructor
+class KWData : public Object
+{
+public:
+	KWData(const ALString& sName, int nRows) { }  // Don't do this
+};
+```
+
+### Access Control
+
+- **No `private` sections** — use `protected` for implementation details
+- **All attributes accessed via `Get`/`Set` accessors**, never directly
+- **Standard accessor pattern**:
+
+```cpp
+// ✅ Correct
+class KWData : public Object
+{
+public:
+	void SetName(const ALString& sValue);
+	const ALString& GetName() const;
+
+protected:
+	ALString sName;
+};
+
+// ❌ Wrong: Direct attribute access
+oData->sName = "new name";  // Use SetName() instead
+```
+
+### Standard Methods
+
+Every `Object` subclass should implement:
+
+```cpp
+class MyClass : public Object
+{
+public:
+	// Data operations
+	Object* Clone() const override;
+	void CopyFrom(const Object* oSource) override;
+	int Compare(const Object* oOther) const override;
+
+	// Integrity checking
+	boolean Check() const override;
+	const ALString GetObjectLabel() const override;
+
+	// Memory tracking
+	longint GetUsedMemory() const override;
+
+	// Error management
+	void AddError(const ALString& sLabel, const ALString& sMessage);
+	void AddWarning(const ALString& sLabel, const ALString& sMessage);
+};
+```
+
+## C++ Feature Restrictions
+
+Khiops deliberately restricts modern C++ features for consistency, safety, and cross-platform portability:
+
+| Feature | Policy | Notes |
+|---------|--------|-------|
+| `const` | ✅ **DO use** | Always on methods and parameters |
+| `override` | ✅ **DO use** | Mark inherited methods |
+| `inline` | ✅ **DO use** | For frequent accessors and critical loops |
+| Method overloading | ❌ **DON'T** | Use specific names (e.g., `GetValueAsInt()`, `GetValueAsString()`) |
+| C++ references | ❌ **DON'T** | Exception: `ALString` passed as `const ALString&` |
+| Multiple inheritance | ❌ **DON'T** | Single inheritance from `Object` only, always `public` |
+| C++ STL | ❌ **Mostly DON'T** | Exceptions: `fstream`, `cout`/`cin`, `regex`, `chrono` |
+| Templates | ❌ **DON'T** | Use `ObjectArray`, `ObjectList`, etc. instead |
+| C++ exceptions | ❌ **DON'T** | Use assertions and error codes instead |
+| Multi-threading | ❌ **DON'T** | Use `Parallel` library (MPI) instead |
+| C API | ❌ **DON'T** | Use Khiops libraries (rare exceptions for low-level) |
+| Third-party libraries | ❌ **DON'T** | Exception: MPI, googletest only |
+
+```cpp
+// ✅ Correct: Use custom containers
+ObjectArray oaItems;
+oaItems.Add(new MyObject);
+
+// ❌ Wrong: STL, templates
+std::vector<MyObject*> items;
+template<typename T> class Container { };
+
+// ✅ Correct: Use Khiops error handling
+require(oObject != NULL);
+if (nValue < 0) AddError("Invalid value");
+
+// ❌ Wrong: Exceptions
+if (nValue < 0) throw std::invalid_argument("...");
+```
+
+## Assertions & Design by Contract
+
+Follow the **Design by Contract** paradigm. The `Norm` library provides assertion macros:
+
+| Macro | When to Use | Example |
+|-------|------------|---------|
+| `require` | Method pre-condition | After variable declarations |
+| `ensure` | Method post-condition | Before `return` |
+| `assert` | Generic assertions | Anywhere in code |
+| `check` | Null pointer check | `check(object)` ≡ `assert(object != NULL)` |
+| `cast` | Safe downcast | `cast(MyClass*, object)` with type check in debug |
+
+```cpp
+// ✅ Correct
+void KWData::SetRowCount(int nValue)
+{
+	// Pre-condition
+	require(nValue >= 0);
+
+	nRowCount = nValue;
+
+	// Post-condition
+	ensure(GetRowCount() == nValue);
+}
+
+// ❌ Wrong: No pre/post conditions
+void KWData::SetRowCount(int nValue)
+{
+	nRowCount = nValue;
+}
+
+// ✅ Correct: Check null
+check(oColumn);
+oColumn->SetName("col1");
+
+// ✅ Correct: Safe cast
+cast(KWNumericColumn*, oColumn)->SetMin(0.0);
+```
+
+**Important**: Assertions are **active in debug builds only**. In release, they compile to empty statements. To debug assertion failures:
+
+1. Set breakpoint in `GlobalExit()` (`src/Norm/base/Standard.cpp`)
+2. Run in debug mode — execution halts at the failing assertion with full call stack
+
+## Memory Management
+
+Khiops has **custom memory allocator** optimized for scalability. Debug mode tracks all allocations:
+
+```
+Memory stats (number of pointers, and memory space)
+  Alloc: 735444  Free: 735444  MaxAlloc: 11228
+  Requested: 77674392  Granted: 100574416  Free: 100574416  MaxGranted: 20819400
+```
+
+### Memory Leak Detection
+
+If allocation is not freed:
+
+1. Call `MemSetAllocIndexExit(<id>)` at `main()` start
+2. Set breakpoint in `GlobalExit()`
+3. Run debug build — execution halts with full stack trace
+
+```cpp
+int main()
+{
+	MemSetAllocIndexExit(42);  // Debug specific allocation ID
+
+	// ... your code ...
+
+	return 0;  // Breakpoint in GlobalExit() on memory leak
+}
+```
+
+### Allocation Patterns
+
+```cpp
+// ✅ Correct: dynamic allocation for collections
+ObjectArray* oaData = new ObjectArray;
+oaData->Add(new MyObject);
+
+// Cleanup when done
+delete oaData;
+
+// ✅ Correct: stack allocation for small objects
+ALString sLabel;
+sLabel = "my_label";
+
+// ❌ Wrong: STL containers (use ObjectArray instead)
+std::vector<Object*> data;
+```
+
+## Pre-commit Hooks & Formatting
+
+All commits must pass `.pre-commit-config.yaml`:
+
+1. **clang-format**: C++ code formatting (strict, non-negotiable)
+2. **Copyright check**: Year must match current year
+3. **Encoding check**: Must be UTF-8
+
+### Running Pre-commit Checks Locally
+
+```bash
+# Install pre-commit
+pip install pre-commit
+
+# Run all checks
+pre-commit run --all-files
+
+# Format C++ file manually
+clang-format -i src/path/to/file.cpp
+
+# Check copyright year
+python scripts/check-obsolete-copyright.py src/path/to/file.cpp
+
+# Check encoding
+python scripts/check-encoding.py src/path/to/file.cpp
+```
+
+### Common Formatting Fixes
+
+```cpp
+// ❌ Will fail clang-format
+void MyClass::Function(  ){int x=5;if(true){do_something( );}}
+
+// ✅ After clang-format
+void MyClass::Function()
+{
+	int x = 5;
+	if (true)
+	{
+		do_something();
+	}
+}
+```
+
+## Module-Specific Conventions
+
+### Learning Module (`KW*` prefix)
+
+- **Data structures**: Use `ObjectArray`, `ObjectDictionary` from Norm
+- **Error handling**: `AddError()`, `AddWarning()`, `Check()` methods
+- **Parallel tasks**: Inherit from `PLParallelTask` if parallelizable
+
+### Parallel Module (`PL*` prefix)
+
+- **Shared variables**: `DeclareSharedParameter()`, `DeclareTaskInput()`, `DeclareTaskOutput()`
+- **Master/slave pattern**: Implement `MasterInitialize()`, `SlaveProcess()`, `MasterAggregateResults()`
+- **No multi-threading**: All parallelization via MPI
+
+### Norm Module (Core)
+
+- **Base classes**: `Object`, `ALString`, numeric types
+- **No cross-module dependencies upward**: Norm never depends on Learning or Parallel
+- **Self-contained utilities**: Collections, string handling, memory management
+
+## Parallel Library (`PLParallelTask`)
+
+Full reference: `src/Parallel/doc/bibliotheque parallele.md`
+
+### Architecture
+
+The parallel library uses MPI (Message Passing Interface) for distributed computing. It is split into two libraries:
+- **`PLParallelTask`**: user-facing library — the sole entry point for developing parallel features
+- **`PLMPI`**: technical library wrapping MPI calls (can be replaced by another framework)
+- **`PLSamples`**: didactic examples
+
+`PLParallelTask` can be used **without** `PLMPI` and without MPI installed — the program will run sequentially. Adding `PLMPI` later enables parallel execution of the same code.
+
+### Master/Slave Framework
+
+Create a parallel task by subclassing `PLParallelTask` and implementing virtual methods:
+
+**Slave methods:**
+
+| Method | Description |
+|--------|-------------|
+| `SlaveInitialize` | Slave initialization |
+| `SlaveProcess` | Parallel processing (called in loop) |
+| `SlaveFinalize` | Slave cleanup |
+
+**Master methods:**
+
+| Method | Description |
+|--------|-------------|
+| `MasterInitialize` | Master initialization |
+| `MasterPrepareTaskInput` | Prepare input data for the next slave |
+| `MasterAggregateResults` | Aggregate results received from a slave |
+| `MasterFinalize` | Master cleanup |
+
+Calling `Run()` executes the task. Slaves are instantiated dynamically; the number of slaves is computed automatically based on available resources.
+
+### Execution Modes
+
+- **Parallel**: multiple MPI processes, full master/slave protocol
+- **Sequential**: when not enough cores are available; no MPI calls, minimal overhead. Same user code as parallel
+- **Simulated parallel**: single process but mimics parallel behavior (serialization, separate master/slave objects). Enable with `PLParallelTask::SetParallelSimulated(true)`. **If the program works in simulated parallel mode, it will work in parallel.**
+
+Development workflow: **debug in sequential, test in simulated parallel, deploy in parallel**.
+
+### Shared Variables
+
+Data exchange between master and slaves uses shared variables, declared in the task constructor:
+
+| Declaration | Role | Sent |
+|------------|------|------|
+| `DeclareSharedParameter` | Constants | After `MasterInitialize` -> before `SlaveInitialize` (once) |
+| `DeclareTaskInput` | Slave inputs | After `MasterPrepareTaskInput` -> before `SlaveProcess` (each iteration) |
+| `DeclareTaskOutput` | Slave outputs | After `SlaveProcess` -> before `MasterAggregateResults` (each iteration) |
+
+Write access is controlled by assertions — each variable type can only be modified in specific methods.
+
+**Simple types:** `PLShared_Boolean`, `PLShared_Int`, `PLShared_Double`, `PLShared_LongInt`, `PLShared_String`, `PLShared_Char`
+
+**Vectors:** `PLShared_StringVector`, `PLShared_IntVector`, `PLShared_LongintVector`, `PLShared_DoubleVector`
+
+**Containers:** `PLShared_ObjectArray`, `PLShared_ObjectDictionary`, `PLShared_ObjectList` (contained objects must implement `PLSharedObject`)
+
+**Custom types:** subclass `PLSharedObject`, implement `Create()`, `SerializeObject(PLSerializer*)`, `DeserializeObject(PLSerializer*)`. Convention: prefix with `PLShared_`, provide `SetValue`/`GetValue` accessors.
+
+### Resource Management
+
+The class `RMParallelResourceManager` computes the number of slaves based on:
+- System resources (auto-discovered: RAM, cores, disk)
+- User constraints (`RMResourceConstraints`, set via UI)
+- Task requirements (override `ComputeResourceRequirements()`)
+
+Requirements to declare per master and slave:
+- Memory min/max
+- Disk space min/max
+- Memory used by shared variables
+- Allocation policy (master-preferred, slave-preferred, or balanced)
+
+Allocated resources are accessible via `GetSlaveResourceGrant()` and `GetMasterResourceGrant()`.
+
+### Task Registration
+
+All parallel tasks must be registered at program startup (in `MODL.cpp`):
+```cpp
+PLParallelTask::RegisterTask(new MyTask);
+```
+This allows sleeping slaves to instantiate the correct task class when woken by the master.
+
+### Best Practices & Pitfalls
+
+- **Variable scoping**: master variables (`Master*` methods only) and slave variables (`Slave*` methods only) are **separate** — a class attribute set in `MasterInitialize` has no value in slave methods. Use shared variables for cross-process data.
+- **Naming convention**: prefix shared variables with `input_`, `output_`, or `shared_` to clarify their role
+- **Constructor**: avoid using the constructor for initialization — use `MasterInitialize`/`SlaveInitialize` instead (constructor runs on both master and slave)
+- **Registration**: declaring a shared variable is not enough — it must be registered in the constructor with `DeclareSharedParameter`, `DeclareTaskInput`, or `DeclareTaskOutput`
+- **Return values**: all virtual methods return `true` on success, `false` on failure. Returning `false` stops the task and `Run()` returns `false`
+- **Example classes** (sorted by complexity): `PEHelloWorldTask` -> `PEProtocolTestTask` -> `PEPiTask` -> `PEIOParallelTestTask` -> `PEFileSearchTask`
+
+## Common Pitfalls
+
+### ❌ Using STL Instead of Khiops Collections
+
+```cpp
+// Wrong
+std::vector<KWColumn*> columns;
+std::map<string, int> labelCounts;
+
+// Right
+ObjectArray oaColumns;
+StringIntDictionary* sdLabelCounts = new StringIntDictionary;
+```
+
+### ❌ Not Checking Pre-conditions
+
+```cpp
+// Wrong: No require()
+void SetValue(int nValue)
+{
+	nMyValue = nValue;
+}
+
+// Right: Validate input
+void SetValue(int nValue)
+{
+	require(nValue >= 0);
+	nMyValue = nValue;
+}
+```
+
+### ❌ Using C++ Exceptions
+
+```cpp
+// Wrong
+if (error_condition) throw std::runtime_error("...");
+
+// Right
+require(!error_condition);  // Pre-condition
+if (error_condition) AddError("Context", "Error message");
+```
+
+### ❌ Forgetting Copyright Year in New Files
+
+```cpp
+// ❌ Wrong or outdated
+// Copyright (c) 2020 Orange
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+// ✅ Correct (current year)
+// Copyright (c) 2026 Orange
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+```
+
+## Testing & Debugging
+
+### Error Management
+
+Two categories:
+- **Programming errors**: caught by assertions, active in debug mode only, must be fixed before delivery
+- **User errors**: caught by input validation, active in all modes
+
+User errors are handled via `Object` methods: `AddMessage`, `AddWarning`, `AddError` with `GetClassLabel`/`GetObjectLabel` for context. The `Global` class manages display and logging.
+
+### Object Display
+
+Override `void Write(ostream& ost) const` in `Object` subclasses, then use stream output for inspection:
+
+```cpp
+cout << myObject;
+```
+
+### Unit Tests
+
+Static `Test()` methods on classes, run via GoogleTest:
+
+```cpp
+class KWData : public Object
+{
+public:
+	// ...
+	static boolean Test();
+};
+
+boolean KWData::Test()
+{
+	boolean bOK = true;
+
+	// Test logic here
+	bOK = bOK && (GetValue() == expected);
+
+	return bOK;
+}
+```
+
+Build with `-DTESTING=ON`, run with `ctest`.
+
+### Integration Tests
+
+Integration tests use the python library KhiopsTestTool (`test/LearningTestTool/`). `LearningTest` automates non-regression scenarios and handles platform variations.
+
+### Tracing
+
+Use a trace flag toggle for debugging:
+
+```cpp
+// At function top
+const boolean bTrace = false;  // Toggle for debugging
+
+if (bTrace)
+	cout << "Debug: value = " << nValue << endl;
+
+// Compiler optimizes away when false
+```
+
+## Resources
+
+- **Full style guide**: [Coding Guidelines](https://github.com/KhiopsML/khiops/wiki/Coding-Guidelines)
+- **Debugging guide**: [Debugging and Testing](https://github.com/KhiopsML/khiops/wiki/Debugging-and-Testing)
+- **Design by Contract**: [Wikipedia](https://en.wikipedia.org/wiki/Design_by_contract)
+- **clang-format config**: `.clang-format` in repository root

--- a/.github/instructions/learning-test-tool.instructions.md
+++ b/.github/instructions/learning-test-tool.instructions.md
@@ -1,0 +1,194 @@
+---
+description: "Use when modifying LearningTestTool Python scripts, test families, result comparison logic, or test infrastructure under test/LearningTestTool/. Covers test tool commands, directory conventions, result context management, and comparison patterns."
+applyTo: "test/LearningTestTool/**"
+---
+
+# LearningTestTool Instructions
+
+## Overview
+
+LearningTestTool is the **non-regression test infrastructure** for Khiops. It manages 800+ test cases across 40+ suites for three tools (KMODL, MODL_Coclustering, KNITransfer). See `test/LearningTestTool/README.md` for full usage details.
+
+## Directory Structure
+
+```
+test/LearningTestTool/
+  ├─ py/                     # All Python implementation
+  │   ├─ kht_test.py         # Main command: run tests & compare results
+  │   ├─ kht_apply.py        # Apply maintenance instructions on test dirs
+  │   ├─ kht_collect_results.py  # Gather results by filter (errors, warnings)
+  │   ├─ kht_export.py       # Backup/archive test trees
+  │   ├─ kht_env.py          # Display Khiops environment variables
+  │   ├─ kht_help.py         # Show command overview
+  │   ├─ _kht_constants.py   # All shared constants (paths, tool names, timeouts)
+  │   ├─ _kht_utils.py       # Utility functions, directory type validation
+  │   ├─ _kht_families.py    # Test family definitions (basic, full, complete)
+  │   ├─ _kht_results_management.py  # Result context: platform, computing mode
+  │   ├─ _kht_check_results.py       # Cross-platform result comparison engine
+  │   ├─ _kht_standard_instructions.py  # Built-in maintenance instructions
+  │   └─ _kht_one_shot_instructions.py  # One-off maintenance instructions
+  ├─ sh/                     # Linux/macOS shell wrappers → py/
+  └─ cmd/                    # Windows batch wrappers → py/
+```
+
+## File Naming Convention
+
+- **`kht_*.py`**: User-facing command scripts (entry points)
+- **`_kht_*.py`**: Internal modules (prefixed with `_`, not called directly)
+
+## LearningTest Directory Hierarchy
+
+The tool operates on a strict 4-level directory hierarchy:
+
+| Level | Name | Example | Contains |
+|-------|------|---------|----------|
+| home dir | `LearningTest/` | `test/LearningTest/` | Tool dirs + dataset collections |
+| tool dir | `Test<Tool>/` | `TestKhiops/` | Suite dirs |
+| suite dir | `<SuiteName>/` | `Standard/` | Test dirs |
+| test dir | `<TestName>/` | `IrisLight/` | `test.prm`, `results/`, `results.ref*` |
+
+Each test dir contains:
+- `test.prm` — Khiops scenario file (required)
+- `test.json` — Optional JSON parameters
+- `results/` — Current test output
+- `results.ref*` — Reference results (may have context suffixes)
+- `comparisonResults.log` — Comparison output
+
+## Three Khiops Tools
+
+| Tool Name | Executable | Test Dir | Parallel |
+|-----------|-----------|----------|----------|
+| `Khiops` | `MODL` | `TestKhiops/` | Yes |
+| `Coclustering` | `MODL_Coclustering` | `TestCoclustering/` | Yes |
+| `KNI` | `KNITransfer` | `TestKNI/` | No |
+
+Constants are in `_kht_constants.py`: `TOOL_NAMES`, `TOOL_EXE_NAMES`, `TOOL_DIR_NAMES`, `PARALLEL_TOOL_NAMES`.
+
+## Test Families
+
+Defined in `_kht_families.py`. Each family is a list of test suites per tool:
+
+| Family | Scope | Approximate Duration |
+|--------|-------|---------------------|
+| `basic` | Minimal smoke test (`Standard` suite only) | ~1 min |
+| `full` | All non-regression suites (default) | ~1 hour |
+| `full-no-kni` | Same as `full` without KNI | ~1 hour |
+| `complete` | Exhaustive testing | ~1 day |
+| `all` | All subdirectories (management, not testing) | N/A |
+
+To add a test suite to a family, add it to `FAMILY_TEST_SUITES[family, tool]` in `_kht_families.py`.
+
+## Main Commands
+
+### `kht_test` — Run Tests
+
+```bash
+kht_test <binaries_dir> [source_dir] [options]
+```
+
+- **`binaries_dir`**: path to tool executables, or aliases `r` (release), `d` (debug), `check` (comparison only)
+- **`source_dir`**: test/suite/tool/home dir (auto-detected level)
+- Key options: `--family`, `--n` (MPI processes), `--min-test-time`, `--max-test-time`, `--timeout-limit`
+
+### `kht_apply` — Maintenance Instructions
+
+```bash
+kht_apply <instruction> [source_dir]
+```
+
+Built-in instructions: `errors`, `makeref`, `list`, `logs`. Custom one-shot instructions defined in `_kht_one_shot_instructions.py`.
+
+### `kht_collect_results` — Gather Results
+
+```bash
+kht_collect_results <source_dir> <target_dir> [--all|--errors|--warnings]
+```
+
+### `kht_export` — Archive Tests
+
+```bash
+kht_export <source_dir> <target_dir> [--all|--scripts|--references|--datasets]
+```
+
+## Result Context Management
+
+Reference results can specialize by **computing mode** and **platform** via directory name suffixes:
+
+```
+results.ref                          # Default (fallback)
+results.ref-parallel                 # Parallel-specific
+results.ref-sequential               # Sequential-specific
+results.ref-Darwin_Linux             # macOS or Linux
+results.ref-parallel-Darwin_Linux    # Parallel + macOS/Linux
+results.ref-Windows                  # Windows-specific
+```
+
+Suffix syntax (defined in `_kht_results_management.py`):
+- `-` (AND): separates type axes (computing, platform)
+- `_` (OR): separates values within an axis
+
+The comparison engine selects the most specialized matching `results.ref*` directory for the current context (platform + sequential/parallel).
+
+## Result Comparison (`_kht_check_results.py`)
+
+The comparison engine is hierarchical:
+1. File count per directory
+2. File names
+3. Per file: line count → line content → field content (tab-separated) → token content (JSON/KDIC)
+
+**Tolerance mechanisms** (cross-platform resilience):
+- Filters copyright lines, MPI process prefixes (`[0] `), debug memory stats
+- Numerical tolerance for floating-point differences (warnings, not errors)
+- Tolerance for scenario failures matching reference
+- Tolerance for accented characters in filenames (system-dependent encoding)
+- Tolerance for resource-related error messages differing across platforms
+
+**Error detection** via special files in results (by priority):
+1. `process_timeout_error.log`
+2. `return_code_error.log`
+3. `stdout_error.log`
+4. `stderr_error.log`
+
+## Timeout Management
+
+Defined in `_kht_constants.py`:
+```
+timeout(test) = MIN_TIMEOUT + TIMEOUT_RATIO × reference_time(test)
+```
+- `MIN_TIMEOUT` = 600 seconds
+- `TIMEOUT_RATIO` = 10
+- Up to 3 retries on timeout
+
+## Environment Variables
+
+Key variables used during tests (set automatically by the tool):
+
+| Variable | Purpose |
+|----------|---------|
+| `KhiopsExpertMode` | Enable expert mode |
+| `KhiopsCrashTestMode` | Enable crash test mode |
+| `KhiopsFastExitMode` | Fast exit mode |
+| `KhiopsDefaultMemoryLimit` | Default memory limit |
+| `KhiopsHardMemoryLimitMode` | Hard memory limit mode |
+| `KHIOPS_API_MODE` | API mode |
+
+User-configurable variables: `KhiopsPreparationTraceMode`, `KhiopsParallelTrace`, `KhiopsFileServerActivated`, `KhiopsMemStatsLogFileName`, etc. See `kht_env.py` for full list.
+
+## Conventions & Pitfalls
+
+### ✅ DO
+
+- Use constants from `_kht_constants.py` — never hardcode tool names, directory names, or file names
+- Add new test suites to the appropriate family in `_kht_families.py`
+- Follow the 4-level directory hierarchy strictly (home → tool → suite → test)
+- Keep `results.ref*` directory names normalized (respect type order, value order)
+- Use `_kht_utils.py` validation functions (`check_test_dir`, `check_suite_dir`, etc.)
+- Comments in French (project convention for this codebase)
+
+### ❌ DON'T
+
+- Add a tool without updating all dictionaries in `_kht_constants.py` (`TOOL_NAMES`, `TOOL_EXE_NAMES`, `TOOL_DIR_NAMES`) — assertions will catch inconsistencies
+- Create `results.ref*` directories with non-normalized names
+- Modify comparison tolerance without understanding cross-platform impact
+- Bypass the directory hierarchy validation (the tool auto-detects the level)
+- Use absolute paths in `test.prm` scenarios — paths are relative to the LearningTest root

--- a/.github/instructions/ui-changes.instructions.md
+++ b/.github/instructions/ui-changes.instructions.md
@@ -1,0 +1,116 @@
+---
+name: ui-changes
+description: "Use when modifying Khiops UI model/view classes, .dd attribute specification files, or UI generation flow with genere and generate_gui.cmake."
+applyTo: ["**/*.dd", "src/**/UI*.h", "src/**/UI*.cpp", "src/**/*View*.h", "src/**/*View*.cpp", "scripts/generate_gui.cmake"]
+---
+
+# UI Development Instructions for Khiops
+
+Full reference: https://github.com/KhiopsML/khiops/wiki/User-Interface-Development-and-Usage
+
+## UI Architecture
+
+The UI is defined at an abstract level using a Model-View pattern. Instantiate a `view` object with its `model` object; the GUI engine handles window/dialog creation.
+
+**Class hierarchy:**
+- `UIObject` -> `UIData` -> `UIUnit` -> `UICard` (contains `UIObjectView`, `UIConfirmationCard`, `UIQuestionCard`, `UIFileChooserCard`) and `UIList` (contains `UIObjectArrayView`)
+- `UIObject` -> `UIData` -> `UIElement` -> `UIBooleanElement`, `UICharElement`, `UIIntElement`, `UIDoubleElement`, `UIStringElement`
+- `UIObject` -> `UIAction`
+
+**UI modes** (set via `UIObject::SetUIMode`):
+- **Graphic**: Windows/dialog boxes (Java via JNI)
+- **Textual**: Shell-based input/output
+
+## MVC Synchronization Pattern
+
+Each `UIUnit` subclass implements two handlers:
+- `EventRefresh()`: called before opening and after each action (interface -> sub-units), synchronizes model data to the view
+- `EventUpdate()`: called after closing and before each action (sub-units -> interface), saves view changes to the model
+
+Rule of thumb:
+- Keep `EventRefresh()` side-effect free except for UI state updates
+- Validate and persist changes in `EventUpdate()`
+
+## `genere` Tool
+
+`genere` automatically generates C++ model and view classes from `.dd` attribute specification files:
+
+```bash
+genere [options] <ClassName> <ClassLabel> <AttributeFileName>
+```
+
+Generates up to 3 classes:
+- `ClassName` (model, subclass of `Object`)
+- `ClassNameView` (card view, subclass of `UIObjectView`)
+- `ClassNameArrayView` (list view, subclass of `UIObjectArrayView`)
+
+**Key options:** `-nomodel`, `-noview`, `-noarrayview`, `-super <SuperClassName>`, `-outputdir <Dir>`
+
+## `.dd` Attribute Specification Files
+
+`.dd` files are semicolon-separated and describe GUI card/list attributes.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| Rank | Yes | Order number in the class |
+| Name | Yes | Attribute name (used in getters/setters) |
+| Type | Yes | `boolean`, `char`, `int`, `double`, `ALString` |
+| Status | No | `Standard` (default) or `Derived` (read-only) |
+| Style | No | GUI widget style (e.g., `CheckBox`, `Spinner`, `ComboBox`) |
+| Invisible | No | Hide in GUI (default: `false`) |
+| Label | No | Display label (default: same as Name) |
+
+Example (`KWRecodingSpec.dd`):
+```
+Rank;Name;Type;Style;Label
+1;FilterAttributes;boolean;CheckBox;Keep informative variables only
+2;MaxFilteredAttributeNumber;int;Spinner;Max number of filtered variables
+```
+
+## Preserving Manual Customizations
+
+When generated files are regenerated, only sections in custom markers are preserved:
+- `// ## Custom ...`
+- `// ##`
+
+Place all manual edits inside these blocks.
+
+## CMake Integration for UI Generation
+
+UI generation is wired through `scripts/generate_gui.cmake` and the `generate_gui_add_view` helpers.
+
+Typical usage in `CMakeLists.txt`:
+
+```cmake
+generate_gui_add_view(KWDatabase "Database" KWDatabase.dd KWDatabase.dd.log -nomodel -noarrayview)
+generate_gui_add_view_add_dependency(KWUserInterface)
+```
+
+Enable generation with:
+- `GENERATE_VIEWS=ON` in `CMakePresets.json`/`CMakeUserPresets.json`
+- or `-D GENERATE_VIEWS=ON` at configure time
+
+Important:
+- The `.dd.log` output must be part of target sources so regeneration is triggered when `.dd` changes.
+
+## Command-Line Options (UI/Batch Usage)
+
+Default options for Khiops executables:
+```
+-e <file>    store logs in the file
+-b           batch mode, with no GUI
+-i <file>    replay commands stored in a file
+-j <file>    JSON file used to set replay parameters
+-o <file>    record commands in a file
+-O <file>    same as -o but without replay
+-r <s>:<s>   search and replace in the command file
+-p <file>    store last progression messages
+-h           print help
+```
+
+## Common Pitfalls
+
+- Editing generated code outside `// ## Custom` blocks (changes lost on regeneration)
+- Forgetting to enable `GENERATE_VIEWS` when changing `.dd` files
+- Declaring fields in `.dd` without corresponding model/view logic expectations
+- Mixing UI-mode assumptions: always verify behavior in both graphic and batch/textual execution paths

--- a/.github/instructions/ui-changes.instructions.md
+++ b/.github/instructions/ui-changes.instructions.md
@@ -28,7 +28,7 @@ Each `UIUnit` subclass implements two handlers:
 - `EventUpdate()`: called after closing and before each action (sub-units -> interface), saves view changes to the model
 
 Rule of thumb:
-- Keep `EventRefresh()` side-effect free except for UI state updates
+- Keep `EventRefresh()` side-effect-free except for UI state updates
 - Validate and persist changes in `EventUpdate()`
 
 ## `genere` Tool


### PR DESCRIPTION
- Created `cmake-changes.instructions.md` to provide guidelines on modifying CMake files, including preset management, build configuration, and installation setup.
- Added `cpp-changes.instructions.md` detailing C++ coding standards, naming conventions, memory management, and error handling practices for the Learning, Norm, and Parallel modules.
- Introduced `ui-changes.instructions.md` outlining the UI architecture, MVC synchronization, usage of the `genere` tool, and guidelines for `.dd` attribute specification files.