### PR TITLE
Repair Linux wheels to convert linux_* tags to manylinux_* (required …

### DIFF
--- a/packaging/pip/pyproject-khiops.toml
+++ b/packaging/pip/pyproject-khiops.toml
@@ -76,9 +76,9 @@ build = "cp39*"
 skip = ["*musllinux*", "*win32"]
 
 [tool.cibuildwheel.linux]
-# All dependencies are provided by the mpi Pip packages, we can't manage to add them to the repair command, so we disable it.
-# repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} --exclude libmpi.so.12"
-repair-wheel-command = ""
+# Repair wheel to convert linux_* tags to manylinux_* (required by PyPI).
+# libmpi is excluded from bundling because it is provided at runtime by the openmpi pip package.
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} --exclude libmpi.so.40"
 
 [tool.cibuildwheel.macos]
 # All dependencies are provided by the mpi Pip packages, we can't manage to add them to the repair command, so we disable it.

--- a/packaging/pip/pyproject-kni.toml
+++ b/packaging/pip/pyproject-kni.toml
@@ -72,8 +72,8 @@ build = "cp39*"
 skip = ["*musllinux*", "*win32*"]
 
 [tool.cibuildwheel.linux]
-# No dependency
-repair-wheel-command = ""
+# Repair wheel to convert linux_* tags to manylinux_* (required by PyPI)
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
 # No dependency

--- a/packaging/pip/pyproject-knitransfer.toml
+++ b/packaging/pip/pyproject-knitransfer.toml
@@ -72,8 +72,11 @@ build = "cp39*"
 skip = ["*musllinux*", "*win32*"]
 
 [tool.cibuildwheel.linux]
-# No dependency
-repair-wheel-command = ""
+# Repair wheel to convert linux_* tags to manylinux_* (required by PyPI)
+# Exclude KNI library from bundling since it is provided at runtime by the kni pip package
+# Note: the .so suffix (11) must match the project major version; cibuildwheel only expands
+# {wheel} and {dest_dir} here, so the version number cannot be derived automatically
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} --exclude libKhiopsNativeInterface.so.11"
 
 [tool.cibuildwheel.macos]
 # No dependency


### PR DESCRIPTION
…by PyPI)

To fix the error 
> khiops_core-11.0.1a3-py3-none-linux_aarch64.whl' has an unsupported  platform tag 'linux_aarch64'

we use `auditwheel repair` for Linux wheels