### PR TITLE
Improve kht_test to handle KNITransfer and OpenMPI with khiops_env

### DIFF
--- a/test/LearningTestTool/py/_kht_constants.py
+++ b/test/LearningTestTool/py/_kht_constants.py
@@ -65,7 +65,7 @@ Liste des suffixes MPI pour les outils pouvant tourner en parallele
 Le binaire parallelisable est pris en priorité sans suffixe, si il n'existe pas on prend
 le binaire avec un suffixe mpi
 """
-TOOL_MPI_SUFFIXES = {"_openmpi", "_mpich"}
+TOOL_MPI_SUFFIXES = {"_openmpi", "_mpich", "_intel"}
 
 """ Dictionnaire des noms des sous-repertoires de LearningTest avec le nom d'outil en cle """
 TOOL_DIR_NAMES = {
@@ -162,3 +162,11 @@ MAX_TIMEOUT = 3600
 
 # Nombre maximum de lancement de test dans le cas d'un depassement du timeout
 MAX_RUN_NUMBER = 3
+
+"""
+Constantes internes
+"""
+# Nombre de processus par defaut quand le nombre de processus n'est pas defini dans les variables d'environnement
+# C'est le cas par exemple avec openmpi, qui calcule automatiquement le nombre de processus a utiliser en fonction du nombre de coeurs disponibles
+# Cetet valeur permet de savoir que le nombre de processus n'est pas defini
+NO_PROCESS_NUMBER = -1

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -48,11 +48,24 @@ def build_tool_exe_path(tool_binaries_dir, tool_name, use_khiops_env):
     # Determination du chemin vers l'executable et du nombre de processus
     # a partir des variables d'environnement positionnees par le script khiops_env
     if use_khiops_env:
-        results.process_number = int(os.environ["KHIOPS_PROC_NUMBER"])
+        try:
+            results.process_number = int(os.environ["KHIOPS_PROC_NUMBER"])
+        except (KeyError, ValueError) as exception:
+            # valeur par defaut indiquant que le nombre de processus n'est pas defini, il est calcule automatiquement par openmpi
+            results.process_number = kht.NO_PROCESS_NUMBER
         if tool_name == kht.KHIOPS:
             tool_exe_path = os.environ["KHIOPS_PATH"]
         elif tool_name == kht.COCLUSTERING:
             tool_exe_path = os.environ["KHIOPS_COCLUSTERING_PATH"]
+        elif tool_name == kht.KNI:
+            # cas particulier de KNITransfer, qui n'est pas positionne dans une variable d'environnement dans khiops_env,
+            # mais dont le chemin est deduit du chemin de KHIOPS_PATH
+            tool_exe_path = os.path.join(
+                os.path.dirname(os.environ["KHIOPS_PATH"]), kht.TOOL_EXE_NAMES[kht.KNI]
+            )
+            if not os.path.isfile(tool_exe_path):
+                tool_exe_path = None
+                error_message = "Executable for tool name " + tool_name + " not found"
         else:
             error_message = "No exe path can be determined for tool name " + tool_name
         return tool_exe_path, error_message
@@ -258,6 +271,8 @@ def evaluate_tool_on_test_dir(
 
     # Recherche du contexte parallele
     tool_process_number = results.process_number
+    if tool_process_number == kht.NO_PROCESS_NUMBER:
+        tool_process_number = "auto"  # valeur par defaut indiquant que le nombre de processus n'est pas defini, il est calcule automatiquement par openmpi
     if tool_name not in kht.PARALLEL_TOOL_NAMES:
         tool_process_number = 1
 


### PR DESCRIPTION
- with khiops_env and OpenMPI, the process number is automatically discovered by mpiexec. The mpiexec command does not include the ‘-n proc_number’ option. This is handled correctly in kht_test: instead of the process number, we display 'auto' in the log.
- KNITransfer is not handled by khiops_env, we deduce its path from the MODL's one