### PR TITLE
Fix pip rocky

### DIFF
--- a/.github/workflows/pack-pip.yml
+++ b/.github/workflows/pack-pip.yml
@@ -75,14 +75,6 @@ jobs:
         uses: ./.github/actions/test-khiops-install
         with:
           binary-path: ${{ env.BIN_DIR }}
-      - name: Run standard tests
-        uses: ./.github/actions/run-standard-tests
-        with:
-          warning_as_error: true
-          running-mode: parallel
-          config: release
-          binary-path: ${{ env.BIN_DIR }}
-          testing-context-description: pip-test-${{ matrix.os }}
       - name: Move pyproject-kni file to the root of the repository
         run: |
           mv packaging/pip/pyproject-kni.toml pyproject.toml
@@ -98,12 +90,79 @@ jobs:
           name: pkg-wheel-${{ matrix.os }}
           path: wheelhouse/*.whl
           if-no-files-found: error
+  test-khiops-core-wheel:
+    strategy:
+      matrix:
+        setup:
+          - {os: ubuntu-24.04, image: ''}
+          - {os: ubuntu-24.04-arm, image: ''}
+          - {os: ubuntu-22.04, image: rockylinux:9}
+          - {os: windows-2025, image: ''}
+          - {os: macos-15, image: ''}
+          - {os: macos-15-intel, image: ''}
+    runs-on: ${{ matrix.setup.os }}
+    container: ${{ matrix.setup.image }}
+    name: Test wheel
+    needs: [build-wheel]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: pkg-*
+          path: wheelhouse
+          merge-multiple: true
+      - name: Python setup for Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          # Install Python 3 if not present (already present in conda environment)
+          if ! command -v python3 &> /dev/null
+          then
+            # Python install: we don't use the setup-python action because of the following error:
+            # python3: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by python3)
+            # Detect Debian based OS
+            if [ -d "/etc/apt" ]
+            then
+              apt-get update
+              apt-get install -y python3 > /dev/null
+            else
+              yum check-update || true
+              yum install -y python3.11
+            fi
+          fi
+          echo "PYTHON=python3" >> "$GITHUB_ENV"
+      - name: Python setup for Windows or macOS
+        if: runner.os == 'Windows' || runner.os == 'macOS'
+        shell: bash
+        run: echo "PYTHON=python" >> "$GITHUB_ENV"
+      - name: Install built wheel in a custom directory
+        run: |
+          KHIOPS_INSTALL_DIR="${{ runner.temp }}/khiops-env"
+          $PYTHON -m venv "$KHIOPS_INSTALL_DIR"
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            source "$KHIOPS_INSTALL_DIR/Scripts/activate"
+            echo "BIN_DIR=$KHIOPS_INSTALL_DIR/Scripts" >> "$GITHUB_ENV"
+          else
+            source "$KHIOPS_INSTALL_DIR/bin/activate"
+            echo "BIN_DIR=$KHIOPS_INSTALL_DIR/bin" >> "$GITHUB_ENV"
+          fi
+          $PYTHON -m pip install --find-links=wheelhouse khiops-core
+          $PYTHON -m pip show -f khiops-core
+      - name: Run standard tests
+        uses: ./.github/actions/run-standard-tests
+        with:
+          warning_as_error: true
+          running-mode: parallel
+          config: release
+          binary-path: ${{ env.BIN_DIR }}
+          testing-context-description: pip-test-${{ matrix.setup.os }}-${{ matrix.setup.image
+            }}
   release-testpypi:
     # Publish only on tag pushes in the KhiopsML repository
     if: github.ref_type == 'tag' && github.repository_owner == 'KhiopsML' && inputs.python_repository
       == 'testpypi'
     name: Publish to Test.PyPI.org
-    needs: [build-wheel]
+    needs: [build-wheel, test-khiops-core-wheel]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -124,7 +183,7 @@ jobs:
     name: Publish to PyPI.org
     if: github.ref_type == 'tag' && github.repository_owner == 'KhiopsML' && inputs.python_repository
       == 'pypi'
-    needs: [build-wheel]
+    needs: [build-wheel, test-khiops-core-wheel]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/packaging/install.cmake
+++ b/packaging/install.cmake
@@ -9,12 +9,14 @@ endif()
 # Specification of the paths according to the OS
 if(IS_PIP)
   set(INCLUDE_DIR ${SKBUILD_HEADERS_DIR}) # pip installs to {prefix}/include/khiops_kni/KhiopsNativeInterface.h
-  set(LIB_DIR ${SKBUILD_DATA_DIR}/lib) # pip installs to {prefix}/lib/
+  set(DLL_DIR ${SKBUILD_SCRIPTS_DIR}) # pip installs dll to Scripts/ on Windows, bin/ on Unix
+  set(LIB_DIR ${SKBUILD_SCRIPTS_DIR}) # we installs the static lib alongside the dll
   set(DOC_DIR ${SKBUILD_NULL_DIR}) # With pip, license and README are already copied to pkg metadata, so we set DOC_DIR
                                    # to SKBUILD_NULL_DIR to avoid installing them again
 elseif(IS_WINDOWS)
   set(INCLUDE_DIR include)
   set(LIB_DIR lib)
+  set(DLL_DIR bin)
   set(DOC_DIR "./")
 else()
   set(INCLUDE_DIR usr/include)
@@ -25,10 +27,9 @@ endif()
 install(
   TARGETS KhiopsNativeInterface
   LIBRARY DESTINATION ${LIB_DIR} COMPONENT KNI
-  PUBLIC_HEADER DESTINATION ${INCLUDE_DIR} COMPONENT KNI
-  ARCHIVE COMPONENT KNI # lib on windows
-  RUNTIME COMPONENT KNI # dll on windows
-)
+  RUNTIME DESTINATION ${DLL_DIR} COMPONENT KNI # dll on windows
+  ARCHIVE DESTINATION ${LIB_DIR} COMPONENT KNI # import lib on windows
+  PUBLIC_HEADER DESTINATION ${INCLUDE_DIR} COMPONENT KNI)
 
 install(
   FILES ${PROJECT_SOURCE_DIR}/LICENSE

--- a/packaging/pip/pyproject-khiops.toml
+++ b/packaging/pip/pyproject-khiops.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 license = "BSD-3-Clause-Clear"
 license-files = ["LICENSE"]
 authors = [{name = "The Khiops Team", email = "khiops.team@orange.com"}]
-requires-python = ">=3.9"
 dependencies = [
     "openmpi ; platform_system in '[Linux, Darwin]'",
     "impi-rt ; platform_system == 'Windows'"
@@ -22,8 +21,9 @@ dependencies = [
 dynamic = ["version"]
 
 [tool.scikit-build]
-# Neither Python code nor CPython library usage in this package so we specify full compatibility with all Python 3 releases
-wheel.py-api = "py3"
+# CPython 3.9 stable ABI: use cp39 tag to ensure compatibility only with Python 3.9+
+# (py3 is for pure Python packages only)
+wheel.py-api = "cp39"
 # Read CMake minimal version from file
 cmake.version = "CMakeLists.txt" 
 # Generator specification and build configuration

--- a/packaging/pip/pyproject-khiops.toml
+++ b/packaging/pip/pyproject-khiops.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 license = "BSD-3-Clause-Clear"
 license-files = ["LICENSE"]
 authors = [{name = "The Khiops Team", email = "khiops.team@orange.com"}]
-requires-python = ">=3.9"
 dependencies = [
     "openmpi ; platform_system in '[Linux, Darwin]'",
     "impi-rt ; platform_system == 'Windows'"

--- a/packaging/pip/pyproject-kni.toml
+++ b/packaging/pip/pyproject-kni.toml
@@ -12,13 +12,13 @@ readme = "README.md"
 license = "BSD-3-Clause-Clear"
 license-files = ["LICENSE"]
 authors = [{name = "The Khiops Team", email = "khiops.team@orange.com"}]
-requires-python = ">=3.9"
 dependencies = []
 dynamic = ["version"]
 
 [tool.scikit-build]
-# Neither Python code nor CPython library usage in this package so we specify full compatibility with all Python 3 releases
-wheel.py-api = "py3"
+# CPython 3.9 stable ABI: use cp39 tag to ensure compatibility only with Python 3.9+
+# (py3 is for pure Python packages only)
+wheel.py-api = "cp39"
 # Read CMake minimal version from file
 cmake.version = "CMakeLists.txt"
 # Generator specification and build configuration

--- a/packaging/pip/pyproject-kni.toml
+++ b/packaging/pip/pyproject-kni.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 license = "BSD-3-Clause-Clear"
 license-files = ["LICENSE"]
 authors = [{name = "The Khiops Team", email = "khiops.team@orange.com"}]
-requires-python = ">=3.9"
 dependencies = []
 dynamic = ["version"]
 

--- a/packaging/pip/pyproject-knitransfer.toml
+++ b/packaging/pip/pyproject-knitransfer.toml
@@ -12,13 +12,13 @@ readme = "README.md"
 license = "BSD-3-Clause-Clear"
 license-files = ["LICENSE"]
 authors = [{name = "The Khiops Team", email = "khiops.team@orange.com"}]
-requires-python = ">=3.9"
 dependencies = []
 dynamic = ["version"]
 
 [tool.scikit-build]
-# Neither Python code nor CPython library usage in this package so we specify full compatibility with all Python 3 releases
-wheel.py-api = "py3"
+# CPython 3.9 stable ABI: use cp39 tag to ensure compatibility only with Python 3.9+
+# (py3 is for pure Python packages only)
+wheel.py-api = "cp39"
 # Read CMake minimal version from file
 cmake.version = "CMakeLists.txt"
 # Generator specification and build configuration

--- a/packaging/pip/pyproject-knitransfer.toml
+++ b/packaging/pip/pyproject-knitransfer.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 license = "BSD-3-Clause-Clear"
 license-files = ["LICENSE"]
 authors = [{name = "The Khiops Team", email = "khiops.team@orange.com"}]
-requires-python = ">=3.9"
 dependencies = []
 dynamic = ["version"]
 


### PR DESCRIPTION
- Fix the installation directories of KNI for pip/windows
- Wheel tagging: `wheel.py-api = "py3"` with `build = "cp39*"`
   - see commit notes