### PR TITLE
989 khiops raw gui not active despite driver being installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,12 @@ cmake_policy(SET CMP0058 NEW)
 cmake_policy(SET CMP0063 NEW)
 cmake_policy(SET CMP0083 NEW)
 
+# De-duplicate libraries on link lines (CMake 3.29+); silences Apple ld "ignoring duplicate libraries" warnings that
+# arise from diamond static-lib deps
+if(POLICY CMP0156)
+  cmake_policy(SET CMP0156 NEW)
+endif()
+
 # Do not add warning flags for MSVC cmake_policy(SET CMP0092 NEW)
 
 # Warn about in-source builds

--- a/src/Learning/DTForest/DTAttributeSelection.cpp
+++ b/src/Learning/DTForest/DTAttributeSelection.cpp
@@ -313,7 +313,7 @@ ObjectArray* DTAttributeSelection::GetTreeAttributesFromLevels(const int nMaxAtt
 	// Repris de l'algo de Weighted Random Sampling with a reservoir Information Processing Letters 97(2006) 181-185
 
 	DTTreeAttribute* dtAttribute;
-	int nAttribute, nMax;
+	int nAttribute;
 
 	if (nMaxAttributesNumber <= 0)
 		return NULL;
@@ -324,9 +324,6 @@ ObjectArray* DTAttributeSelection::GetTreeAttributesFromLevels(const int nMaxAtt
 	ObjectArray oaListAttributes;
 
 	ivSortedListIndexes.SetSize(0);
-
-	nMax = (nMaxAttributesNumber > oaTreeAttributeSelection.GetSize()) ? oaTreeAttributeSelection.GetSize()
-									   : nMaxAttributesNumber;
 
 	for (nAttribute = 0; nAttribute < nMaxAttributesNumber; nAttribute++)
 	{

--- a/src/Learning/DTForest/DTDecisionTreeCreationTask.cpp
+++ b/src/Learning/DTForest/DTDecisionTreeCreationTask.cpp
@@ -649,7 +649,6 @@ boolean DTDecisionTreeCreationTask::SlaveProcess()
 	DTDecisionTreeSpec* reportTreeSpec = NULL;
 	KWLearningSpec* learningSpecTree = NULL;
 	KWLearningSpec* slaveLearningSpec = NULL;
-	int nNativeVariableNumber;
 	ALString sVariableName;
 	ALString sTmp;
 	ALString sMessage;
@@ -666,7 +665,6 @@ boolean DTDecisionTreeCreationTask::SlaveProcess()
 	DTAttributeSelection* attributegenerator;
 	boolean bRegressionWithEqualFreqDiscretization = false;
 	boolean bRegressionWithMODLDiscretization = false;
-	int nBuidTreeNumber;
 	int nOldSeedTree;
 
 	if (randomForestParameter.GetDecisionTreeParameter()->GetVerboseMode())
@@ -676,6 +674,7 @@ boolean DTDecisionTreeCreationTask::SlaveProcess()
 	}
 
 #ifdef GENERATE_PYTHON_REPORTING_TRACES
+	int nBuidTreeNumber;
 	const int oldMaxErrorFlowNumber = Global::GetMaxErrorFlowNumber();
 	Global::ActivateErrorFlowControl();
 	Global::SetMaxErrorFlowNumber(10000);
@@ -760,13 +759,12 @@ boolean DTDecisionTreeCreationTask::SlaveProcess()
 			 IntToString(GetTaskIndex() + 1) + "\t" + ALString("Grant memory : \t") +
 			 ALString(LongintToHumanReadableString(GetSlaveResourceGrant()->GetMemory())));
 	DTTimer_SlaveProcess.Start();
+	nBuidTreeNumber = 0;
 #endif
 
 	KWClass* kwcUpdatedClass = shared_learningSpec.GetLearningSpec()->GetClass();
 
 	randomForestParameter.CopyFrom(input_forestParameter->GetForestParameter());
-
-	nBuidTreeNumber = 0;
 
 	// Calcul des arbres
 	if (bOk and not TaskProgression::IsInterruptionRequested())
@@ -819,9 +817,6 @@ boolean DTDecisionTreeCreationTask::SlaveProcess()
 				oaInputAttributeStats = BuildRootAttributeStats(
 				    learningSpecTree, &blOrigine, shared_odAttributeStats->GetObjectDictionary());
 			}
-
-			// Calcul du nombre de variables initiales
-			nNativeVariableNumber = slaveLearningSpec->GetInitialAttributeNumber();
 
 			// creation pour un slice de selection :
 			// - des arbres dttree
@@ -904,9 +899,9 @@ boolean DTDecisionTreeCreationTask::SlaveProcess()
 						    learningSpecTree, &blOrigine,
 						    shared_odAttributeStats->GetObjectDictionary());
 					}
-
+#ifdef GENERATE_PYTHON_REPORTING_TRACES
 					nBuidTreeNumber++;
-
+#endif
 					nOldSeedTree = GetRandomSeed();
 					SetRandomSeed(attributegenerator->GetRandomSeed());
 

--- a/src/Learning/DTForest/DTForestAttributeSelection.cpp
+++ b/src/Learning/DTForest/DTForestAttributeSelection.cpp
@@ -51,7 +51,6 @@ void DTForestAttributeSelection::Initialization(const ObjectDictionary* odInputA
 {
 	require(odInputAttributeStats != NULL);
 
-	longint nNbInstence = 0;
 	DTTreeAttribute* taAttribute;
 	KWAttributeStats* attributeStats;
 	KWAttribute* attribute;
@@ -63,10 +62,9 @@ void DTForestAttributeSelection::Initialization(const ObjectDictionary* odInputA
 	odInputAttributeStats->ExportObjectArray(&oaAttributeStats);
 	nOriginalAttributesNumber = oaAttributeStats.GetSize();
 
-	// nombre d'objet dasn la base
+	// nombre d'objet dans la base
 	attributeStats = cast(KWAttributeStats*, oaAttributeStats.GetAt(0));
-	nNbInstence = attributeStats->GetInstanceNumber();
-	//	cout << "les attibut : " << nOriginalAttributesNumber << endl;
+
 	for (nAttribute = 0; nAttribute < nOriginalAttributesNumber; nAttribute++)
 	{
 		attributeStats = cast(KWAttributeStats*, oaAttributeStats.GetAt(nAttribute));
@@ -102,7 +100,6 @@ void DTForestAttributeSelection::BuildForestUniformSelections(int nmaxselectionn
 		nMaxSelectionNumber = nmaxselectionnumber;
 		int nSelection, nAttribute;
 		int nTinf, nTnull;
-		int nKinf, nKnull;
 		int nAttributesNumber;
 		int nSeed = nRandomSeed;
 		ObjectArray oaVariablesNull;
@@ -116,20 +113,16 @@ void DTForestAttributeSelection::BuildForestUniformSelections(int nmaxselectionn
 
 		Clean();
 
-		nKinf = 0;
-		nKnull = 0;
 		// calcul des ensemble de variable inf et null
 		for (nAttribute = 0; nAttribute < nOrigineAttributesNumber; nAttribute++)
 		{
 			taAttribute = cast(DTTreeAttribute*, oaOriginalAttributesUsed.GetAt(nAttribute));
 			if (taAttribute->dLevel == 0.0)
 			{
-				nKnull++;
 				oaVariablesNull.Add(taAttribute);
 			}
 			else
 			{
-				nKinf++;
 				oaVariablesInf.Add(taAttribute);
 			}
 		}
@@ -140,7 +133,6 @@ void DTForestAttributeSelection::BuildForestUniformSelections(int nmaxselectionn
 			// le dictionnaire de lecture de la base (i.e : flaggues avec SetUsed(false) et SetLoaded(false)
 			// ) D'autre part, on  a deja verifie que les attributs restants peuvent etre traites en memoire
 			// (et le cas echeant, on a deja decharge les attributs les moins informatifs)
-
 			if (dPct == 0.0)
 				nAttributesNumber =
 				    (int)(sqrtl(nOrigineAttributesNumber) + log2l(nOrigineAttributesNumber)); // MB
@@ -173,7 +165,7 @@ void DTForestAttributeSelection::BuildForestUniformSelections(int nmaxselectionn
 			else
 				oaOriginalAttributesUsed.Shuffle();
 
-			// cretation nouvelle liste de variables
+			// creation nouvelle liste de variables
 			svRandattibuteselection = new DTAttributeSelection;
 
 			svRandattibuteselection->SetRandomSeed(nSeed);
@@ -758,13 +750,7 @@ boolean DTAttributeSelectionsSlices::Check() const
 			slice = cast(KWDataTableSlice*, oaSlices.GetAt(nSlice));
 
 			// Erreur si probleme d'ordre
-			// if (previousSlice != NULL and previousSlice->CompareLexicographicOrder(slice) >= 0)
-			//{
-			//	AddError("Wrong ordering between " + slice->GetClassLabel() + "s " +
-			//		 previousSlice->GetObjectLabel() + " and " + slice->GetObjectLabel());
-			//	bOk = false;
-			//	break;
-			//}
+			assert(previousSlice == NULL or previousSlice->CompareLexicographicOrder(slice) < 0);
 			previousSlice = slice;
 
 			// Erreur si tranche deja utilisee

--- a/src/Learning/DTForest/DTGrouperMODLOptimization.cpp
+++ b/src/Learning/DTForest/DTGrouperMODLOptimization.cpp
@@ -1325,7 +1325,6 @@ void DTGrouperMODL::FastPostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequ
 	int nStepNumber;
 	int nModalityNumber;
 	int nGroupNumber;
-	int nTargetNumber;
 	IntVector ivModalityIndexes;
 	IntVector ivGroupIndexes;
 	DoubleVector dvGroupCosts;
@@ -1362,10 +1361,9 @@ void DTGrouperMODL::FastPostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequ
 	if (bPrintInitialTables)
 		cout << *kwftSource << endl << *kwftTarget << endl;
 
-	// Memorisation des nombre de modalites, groupes et classes cibles
+	// Memorisation des nombre de modalites et groupes
 	nModalityNumber = kwftSource->GetFrequencyVectorNumber();
 	nGroupNumber = kwftTarget->GetFrequencyVectorNumber();
-	nTargetNumber = kwftSource->GetFrequencyVectorSize();
 
 	// Initialisation des vecteurs d'index des modalites et des groupes
 	ivModalityIndexes.SetSize(nModalityNumber);
@@ -1521,7 +1519,6 @@ void DTGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 	int nStepNumber;
 	int nModalityNumber;
 	int nGroupNumber;
-	int nTargetNumber;
 	IntVector ivModalityIndexes;
 	IntVector ivGroupIndexes;
 	DoubleVector dvGroupCosts;
@@ -1569,10 +1566,10 @@ void DTGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 	if (bPrintInitialTables)
 		cout << *kwftSource << endl << *kwftTarget << endl;
 
-	// Memorisation des nombre de modalites, groupes et classes cibles
+	// Memorisation des nombre de modalites et groupes
 	nModalityNumber = kwftSource->GetFrequencyVectorNumber();
 	nGroupNumber = kwftTarget->GetFrequencyVectorNumber();
-	nTargetNumber = kwftSource->GetFrequencyVectorSize();
+
 	// Initialisation du nombre de modalites du groupe poubelle
 	nGarbageModalityNumber = cast(KWFrequencyVector*, frequencyList->GetHead())->GetModalityNumber();
 	nNewGarbageModalityNumber = 0;
@@ -2035,7 +2032,6 @@ void DTGrouperMODL::PostOptimizeGroupsWithGarbageSearch(ObjectArray* oaInitialGr
 	boolean bContinue;
 	int nModalityNumber;
 	int nGroupNumber;
-	int nTargetNumber;
 	DoubleVector dvGroupCosts;
 	DoubleVector dvGroupOutDeltaCosts;
 	DoubleVector dvGroupInDeltaCosts;
@@ -2077,10 +2073,9 @@ void DTGrouperMODL::PostOptimizeGroupsWithGarbageSearch(ObjectArray* oaInitialGr
 	if (bPrintInitialGroups)
 		cout << *oaInitialGroups << endl << *oaNewGroups << endl;
 
-	// Memorisation des nombre de modalites, groupes et classes cibles
+	// Memorisation des nombre de modalites et groupes
 	nModalityNumber = oaInitialGroups->GetSize();
 	nGroupNumber = oaNewGroups->GetSize();
-	nTargetNumber = cast(KWMODLGroup*, oaInitialGroups->GetAt(0))->GetFrequencyVector()->GetSize();
 	nTrueGroupNumber = nGroupNumber;
 
 	// Initialisation du nombre de modalites du groupe poubelle

--- a/src/Learning/KDDomainKnowledge/KDClassBuilder.cpp
+++ b/src/Learning/KDDomainKnowledge/KDClassBuilder.cpp
@@ -899,20 +899,17 @@ void KDClassBuilder::DisplayUsedConstructedBlockRules(const SortedList* slUsedCo
 {
 	POSITION position;
 	KDSparseUsedConstructedBlockRule* usedConstructedBlockRule;
-	int nRule;
 
 	require(slUsedConstructedBlockRules != NULL);
 	require(slUsedConstructedBlockRules->GetCompareFunction() == KDSparseUsedConstructedBlockRuleCompareCostName);
 
 	// Parcours des regles de la liste
 	ost << "Used constructed block rules\t" << slUsedConstructedBlockRules->GetCount() << endl;
-	nRule = 0;
 	position = slUsedConstructedBlockRules->GetHeadPosition();
 	while (position != NULL)
 	{
 		usedConstructedBlockRule =
 		    cast(KDSparseUsedConstructedBlockRule*, slUsedConstructedBlockRules->GetNext(position));
-		nRule++;
 
 		// Affichage de la regle
 		ost << *usedConstructedBlockRule->GetConstructedBlockRule() << "\t";

--- a/src/Learning/KDDomainKnowledge/KDMultiTableFeatureConstruction.cpp
+++ b/src/Learning/KDDomainKnowledge/KDMultiTableFeatureConstruction.cpp
@@ -2117,7 +2117,6 @@ void KDMultiTableFeatureConstruction::BuildAllSelectionRulesFromSelectionOperand
 	double dSelectionOperandProb;
 	KDClassSelectionStats* classSelectionStats;
 	KDClassSelectionOperandStats* classSelectionOperandStats;
-	boolean bRuleFiltered;
 	int nInitialRuleNumber;
 
 	require(selectionRule != NULL);
@@ -2437,7 +2436,6 @@ void KDMultiTableFeatureConstruction::BuildAllSelectionRulesFromSelectionOperand
 		}
 	}
 	// Parcours des tailles de selection
-	bRuleFiltered = false;
 	for (nSize = 1; nSize <= dvSelectionSizeRandomDrawingNumbers.GetSize(); nSize++)
 	{
 		dSelectionRandomDrawingNumber = dvSelectionSizeRandomDrawingNumbers.GetAt(nSize - 1);
@@ -2477,8 +2475,7 @@ void KDMultiTableFeatureConstruction::BuildAllSelectionRulesFromSelectionOperand
 			oaAllSelectionParts.SetSize(0);
 
 			// Filtrage des regles pour ne garder que les regles de probabilite suffisantes pour etre tirees
-			bRuleFiltered =
-			    FilterConstructedRulesForRandomDrawing(dRandomDrawingNumber, oaAllConstructedRules);
+			FilterConstructedRulesForRandomDrawing(dRandomDrawingNumber, oaAllConstructedRules);
 
 			// Nettoyage des selections d'operandes
 			oaSelectionOperandIndexedFrequencies.DeleteAll();

--- a/src/Learning/KNITransfer/KNIDatabaseTransferView.cpp
+++ b/src/Learning/KNITransfer/KNIDatabaseTransferView.cpp
@@ -35,7 +35,6 @@ void KNIDatabaseTransferView::KNITransferDatabase()
 {
 	KNIMTRecodingOperands recodingOperands;
 	KWMTDatabaseTextFile* sourceMTDatabase;
-	KWMTDatabaseTextFile* targetMTDatabase;
 	KWDatabase* workingTargetDatabase;
 	Timer timerTransfer;
 	int nMapping;
@@ -43,9 +42,8 @@ void KNIDatabaseTransferView::KNITransferDatabase()
 	int nRecordNumber;
 	ALString sTmp;
 
-	// Acces aux bases source et cible
+	// Acces aux bases source
 	sourceMTDatabase = cast(KWMTDatabaseTextFile*, sourceDatabase);
-	targetMTDatabase = cast(KWMTDatabaseTextFile*, targetDatabase);
 
 	// On passe par une autre table en sortie, pour pouvoir specifier son chemin si elle n'en a pas
 	workingTargetDatabase = targetDatabase->Clone();

--- a/src/Learning/KNITransfer/KNITransferProblemView.cpp
+++ b/src/Learning/KNITransfer/KNITransferProblemView.cpp
@@ -54,6 +54,7 @@ void KNITransferProblemView::SetObject(Object* object)
 
 	// Acces a l'objet edite
 	learningProblem = cast(KNITransferProblem*, object);
+	(void)learningProblem; // Evite un warning si on n'utilise pas l'objet dans cette methode
 }
 
 KNITransferProblem* KNITransferProblemView::GetTransferProblem()

--- a/src/Learning/KWDRRuleLibrary/KWDRDateTime.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRDateTime.cpp
@@ -1237,13 +1237,11 @@ TimestampTZ KWDRBuildTimestampTZ::ComputeTimestampTZResult(const KWObject* kwoOb
 	TimestampTZ tstzTimestamp;
 	Continuous cMinutes;
 	int nMinutes;
-	boolean bOk;
 
 	require(IsCompiled());
 
 	// Modifie la time zone que si les operandes sont valides
 	tsTimestamp = GetFirstOperand()->GetTimestampValue(kwoObject);
-	bOk = false;
 	tstzTimestamp.Reset();
 	if (tsTimestamp.Check())
 	{
@@ -1251,7 +1249,7 @@ TimestampTZ KWDRBuildTimestampTZ::ComputeTimestampTZResult(const KWObject* kwoOb
 		if (cMinutes != KWContinuous::GetMissingValue())
 		{
 			nMinutes = int(floor(cMinutes + 0.5));
-			bOk = tstzTimestamp.Init(tsTimestamp, nMinutes);
+			tstzTimestamp.Init(tsTimestamp, nMinutes);
 		}
 	}
 	return tstzTimestamp;

--- a/src/Learning/KWDRRuleLibrary/KWDRMultiTable.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRMultiTable.cpp
@@ -3261,14 +3261,12 @@ Continuous KWDRTableCountSum::ComputeContinuousStats(const ObjectArray* oaObject
 	int nObject;
 	KWObject* kwoContainedObject;
 	Continuous cValue;
-	int nObjectNumber;
 	Continuous cCountSum;
 
 	require(oaObjects != NULL);
 
 	// Calcul de la somme parmi les sous-objets avec valeur non manquante
 	cCountSum = 0;
-	nObjectNumber = 0;
 	valueOperand = GetSecondOperand();
 	for (nObject = 0; nObject < oaObjects->GetSize(); nObject++)
 	{
@@ -3277,7 +3275,6 @@ Continuous KWDRTableCountSum::ComputeContinuousStats(const ObjectArray* oaObject
 		if (cValue != KWContinuous::GetMissingValue())
 		{
 			cCountSum += cValue;
-			nObjectNumber++;
 		}
 	}
 	return cCountSum;
@@ -3288,7 +3285,6 @@ Continuous KWDRTableCountSum::ComputeContinuousStatsFromContinuousVector(int nRe
 {
 	int nValue;
 	Continuous cValue;
-	int nValueNumber;
 	Continuous cCountSum;
 	int nDefaultValueNumber;
 
@@ -3297,12 +3293,10 @@ Continuous KWDRTableCountSum::ComputeContinuousStatsFromContinuousVector(int nRe
 
 	// Prise en compte de la valeur par defaut si elle n'est pas manquante
 	cCountSum = 0;
-	nValueNumber = 0;
 	nDefaultValueNumber = nRecordNumber - cvValues->GetSize();
 	if (cDefaultValue != KWContinuous::GetMissingValue() and nRecordNumber > cvValues->GetSize())
 	{
 		cCountSum = nDefaultValueNumber * cDefaultValue;
-		nValueNumber = nDefaultValueNumber;
 	}
 
 	// Calcul de la somme parmi les valeurs non manquantes
@@ -3312,7 +3306,6 @@ Continuous KWDRTableCountSum::ComputeContinuousStatsFromContinuousVector(int nRe
 		if (cValue != KWContinuous::GetMissingValue())
 		{
 			cCountSum += cValue;
-			nValueNumber++;
 		}
 	}
 	return cCountSum;

--- a/src/Learning/KWDRRuleLibrary/KWDRVector.cpp
+++ b/src/Learning/KWDRRuleLibrary/KWDRVector.cpp
@@ -355,9 +355,6 @@ Symbol KWDRSymbolValueAt::ComputeSymbolResult(const KWObject* kwoObject) const
 	require(IsCompiled());
 	require(KWType::IsSimple(GetSecondOperand()->GetType()));
 
-	KWDerivationRuleOperand* firstOperand;
-	firstOperand = GetFirstOperand();
-
 	// Recherche de la partition
 	symbolVector = cast(KWDRSymbolVector*, GetFirstOperand()->GetStructureValue(kwoObject));
 

--- a/src/Learning/KWData/KWClass.cpp
+++ b/src/Learning/KWData/KWClass.cpp
@@ -3279,15 +3279,9 @@ boolean KWClass::InternalCheckNativeAcyclicity(boolean bVerbose, KWAttribute* pa
 {
 	boolean bOk = true;
 	KWAttribute* attribute;
-	KWClass* parentClass;
 	KWClass* attributeClass;
 
 	require(nkdComponentClasses != NULL);
-
-	// Recherche de la classe parent a partir de l'attribut parent
-	parentClass = NULL;
-	if (parentAttribute != NULL)
-		parentClass = parentAttribute->GetParentClass();
 
 	// Ajout de la classe courante dans le dictionnaire des classes utilisees
 	// pour l'analyse de l'utilisation recursive

--- a/src/Learning/KWData/KWDerivationRule.cpp
+++ b/src/Learning/KWData/KWDerivationRule.cpp
@@ -1241,7 +1241,7 @@ void KWDerivationRule::Compile(KWClass* kwcOwnerClass)
 Continuous KWDerivationRule::ComputeContinuousResult(const KWObject* kwoObject) const
 {
 	// Doit etre reimplemente si le type est Continuous
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject; // Pour eviter le warning
 	assert(false);
 	return 0;
 }
@@ -1249,7 +1249,7 @@ Continuous KWDerivationRule::ComputeContinuousResult(const KWObject* kwoObject) 
 Symbol KWDerivationRule::ComputeSymbolResult(const KWObject* kwoObject) const
 {
 	// Doit etre reimplemente si le type est Symbol
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject; // Pour eviter le warning
 	assert(false);
 	return Symbol();
 }
@@ -1259,7 +1259,7 @@ Date KWDerivationRule::ComputeDateResult(const KWObject* kwoObject) const
 	Date dtValue;
 
 	// Doit etre reimplemente si le type est Date
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject; // Pour eviter le warning
 	dtValue.Reset();
 	assert(false);
 	return dtValue;
@@ -1270,7 +1270,7 @@ Time KWDerivationRule::ComputeTimeResult(const KWObject* kwoObject) const
 	Time tmValue;
 
 	// Doit etre reimplemente si le type est Time
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject; // Pour eviter le warning
 	tmValue.Reset();
 	assert(false);
 	return tmValue;
@@ -1281,7 +1281,7 @@ Timestamp KWDerivationRule::ComputeTimestampResult(const KWObject* kwoObject) co
 	Timestamp tsValue;
 
 	// Doit etre reimplemente si le type est Timestamp
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject; // Pour eviter le warning
 	tsValue.Reset();
 	assert(false);
 	return tsValue;
@@ -1292,7 +1292,7 @@ TimestampTZ KWDerivationRule::ComputeTimestampTZResult(const KWObject* kwoObject
 	TimestampTZ tstzValue;
 
 	// Doit etre reimplemente si le type est Timestamp
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject; // Pour eviter le warning
 	tstzValue.Reset();
 	assert(false);
 	return tstzValue;
@@ -1301,7 +1301,7 @@ TimestampTZ KWDerivationRule::ComputeTimestampTZResult(const KWObject* kwoObject
 Symbol KWDerivationRule::ComputeTextResult(const KWObject* kwoObject) const
 {
 	// Doit etre reimplemente si le type est Text
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject; // Pour eviter le warning
 	assert(false);
 	return Symbol();
 }
@@ -1309,7 +1309,7 @@ Symbol KWDerivationRule::ComputeTextResult(const KWObject* kwoObject) const
 SymbolVector* KWDerivationRule::ComputeTextListResult(const KWObject* kwoObject) const
 {
 	// Doit etre reimplemente si le type est TextList
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject; // Pour eviter le warning
 	assert(false);
 	return NULL;
 }
@@ -1317,7 +1317,8 @@ SymbolVector* KWDerivationRule::ComputeTextListResult(const KWObject* kwoObject)
 KWObject* KWDerivationRule::ComputeObjectResult(const KWObject* kwoObject, const KWLoadIndex liAttributeLoadIndex) const
 {
 	// Doit etre reimplemente si le type est Object
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject;            // Pour eviter le warning
+	(void)liAttributeLoadIndex; // Pour eviter le warning
 	assert(false);
 	return NULL;
 }
@@ -1326,7 +1327,8 @@ ObjectArray* KWDerivationRule::ComputeObjectArrayResult(const KWObject* kwoObjec
 							const KWLoadIndex liAttributeLoadIndex) const
 {
 	// Doit etre reimplemente si le type est ObjectArray
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject;            // Pour eviter le warning
+	(void)liAttributeLoadIndex; // Pour eviter le warning
 	assert(false);
 	return NULL;
 }
@@ -1334,7 +1336,7 @@ ObjectArray* KWDerivationRule::ComputeObjectArrayResult(const KWObject* kwoObjec
 Object* KWDerivationRule::ComputeStructureResult(const KWObject* kwoObject) const
 {
 	// Doit etre reimplemente si le type est Structure
-	kwoObject = NULL; // Pour eviter le warning
+	(void)kwoObject; // Pour eviter le warning
 	assert(false);
 	return NULL;
 }
@@ -1344,8 +1346,8 @@ KWDerivationRule::ComputeContinuousValueBlockResult(const KWObject* kwoObject,
 						    const KWIndexedKeyBlock* indexedKeyBlock) const
 {
 	// Doit etre reimplemente si le type est ContinuousValueBlock
-	kwoObject = NULL; // Pour eviter le warning
-	indexedKeyBlock = NULL;
+	(void)kwoObject;       // Pour eviter le warning
+	(void)indexedKeyBlock; // Pour eviter le warning
 	assert(false);
 	return NULL;
 }
@@ -1354,8 +1356,8 @@ KWSymbolValueBlock* KWDerivationRule::ComputeSymbolValueBlockResult(const KWObje
 								    const KWIndexedKeyBlock* indexedKeyBlock) const
 {
 	// Doit etre reimplemente si le type est SymbolValueBlock
-	kwoObject = NULL; // Pour eviter le warning
-	indexedKeyBlock = NULL;
+	(void)kwoObject;       // Pour eviter le warning
+	(void)indexedKeyBlock; // Pour eviter le warning
 	assert(false);
 	return NULL;
 }
@@ -1365,8 +1367,8 @@ KWDerivationRule::ComputeObjectArrayValueBlockResult(const KWObject* kwoObject,
 						     const KWIndexedKeyBlock* indexedKeyBlock) const
 {
 	// Doit etre reimplemente si le type est ObjectArrayValueBlock
-	kwoObject = NULL; // Pour eviter le warning
-	indexedKeyBlock = NULL;
+	(void)kwoObject;       // Pour eviter le warning
+	(void)indexedKeyBlock; // Pour eviter le warning
 	assert(false);
 	return NULL;
 }

--- a/src/Learning/KWData/KWObjectKey.cpp
+++ b/src/Learning/KWData/KWObjectKey.cpp
@@ -46,11 +46,11 @@ void KWObjectKey::SetSize(int nValue)
 			// Une recopie directe des valeurs ne pose pas de probleme, puisque le compteur de reference
 			// des symbol est inchange entre avant et apres le retaillage
 			if (nValue < nSize)
-				memcpy(sNewKeyFields, sKeyFields, nValue * sizeof(Symbol));
+				memcpy((void*)sNewKeyFields, sKeyFields, nValue * sizeof(Symbol));
 			else
 			{
-				memcpy(sNewKeyFields, sKeyFields, nSize * sizeof(Symbol));
-				memset(&sNewKeyFields[nSize], 0, (nValue - nSize) * sizeof(Symbol));
+				memcpy((void*)sNewKeyFields, sKeyFields, nSize * sizeof(Symbol));
+				memset((void*)&sNewKeyFields[nSize], 0, (nValue - nSize) * sizeof(Symbol));
 			}
 			DISABLE_WARNING_POP
 
@@ -315,7 +315,7 @@ void KWObjectKey::NewKeyFields(int nInitialisationSize)
 	// Suppression du warning class-memaccess
 	DISABLE_WARNING_PUSH
 	DISABLE_WARNING_CLASS_MEMACCESS
-	memset(sKeyFields, 0, nInitialisationSize * sizeof(Symbol));
+	memset((void*)sKeyFields, 0, nInitialisationSize * sizeof(Symbol));
 	DISABLE_WARNING_POP
 	nSize = nInitialisationSize;
 }

--- a/src/Learning/KWData/KWTextTokenizer.cpp
+++ b/src/Learning/KWData/KWTextTokenizer.cpp
@@ -577,7 +577,6 @@ void KWTextTokenizer::TokenizeText(const char* sText, int nTextLength)
 {
 	debug(const boolean bTrace = false);
 	LongintDictionary* ldCollectedTokens;
-	LongintDictionary* ldSpecificTokens;
 	const char* sStringValue;
 	unsigned char cChar;
 	boolean bIsSpace;
@@ -593,7 +592,6 @@ void KWTextTokenizer::TokenizeText(const char* sText, int nTextLength)
 
 	// Acces aux tokens du bon type
 	ldCollectedTokens = cast(LongintDictionary*, gdCollectedTokens);
-	ldSpecificTokens = cast(LongintDictionary*, gdSpecificTokens);
 
 	// Parcours des caracteres de la chaines pour extraire les tokens
 	sStringValue = sText;
@@ -1369,7 +1367,6 @@ void KWTextWordTokenizer::TokenizeText(const char* sText, int nTextLength)
 {
 	debug(const boolean bTrace = false);
 	LongintDictionary* ldCollectedTokens;
-	LongintDictionary* ldSpecificTokens;
 	const char* sStringValue;
 	char cChar;
 	boolean bIsTokenPunctuation;
@@ -1387,7 +1384,6 @@ void KWTextWordTokenizer::TokenizeText(const char* sText, int nTextLength)
 
 	// Acces aux tokens du bon type
 	ldCollectedTokens = cast(LongintDictionary*, gdCollectedTokens);
-	ldSpecificTokens = cast(LongintDictionary*, gdSpecificTokens);
 
 	// Parcours des caracteres de la chaines pour extraire les tokens
 	sStringValue = sText;

--- a/src/Learning/KWData/KWTimestamp.cpp
+++ b/src/Learning/KWData/KWTimestamp.cpp
@@ -435,7 +435,6 @@ Timestamp KWTimestampFormat::StringToTimestamp(const char* const sValue) const
 {
 	boolean bCheck = true;
 	char sDateValue[12];
-	int nTotalMainCharNumber;
 	Timestamp tsConvertedString;
 	Date dtValue;
 	Time tmValue;
@@ -448,11 +447,6 @@ Timestamp KWTimestampFormat::StringToTimestamp(const char* const sValue) const
 	dtValue.Reset();
 	tmValue.Reset();
 	tsConvertedString.Reset();
-
-	// Longueur du format sans la partie decimale optionnelle des secondes
-	nTotalMainCharNumber = nTotalCharNumber;
-	if (timeFormat.GetDecimalPointOffset() != -1)
-		nTotalMainCharNumber--;
 
 	// Acces a la longueur de la valeur a convertir
 	nLength = (int)strlen(sValue);

--- a/src/Learning/KWData/KWTokenFrequency.h
+++ b/src/Learning/KWData/KWTokenFrequency.h
@@ -45,7 +45,7 @@ public:
 	int CompareLengthFrequency(const KWTokenFrequency* otherTokenFrequency) const;
 
 	// Memoire utilisee
-	longint GetUsedMemory() const;
+	longint GetUsedMemory() const override;
 
 	// Affichage
 	void Write(ostream& ost) const override;

--- a/src/Learning/KWDataPreparation/KIShapleyTable.cpp
+++ b/src/Learning/KWDataPreparation/KIShapleyTable.cpp
@@ -58,7 +58,6 @@ double KIShapleyTable::ComputeMeanAbsoluteShapleyValues(const KWDataGridStats* a
 	IntVector ivSourcePartFrequencies;
 	IntVector ivTargetPartFrequencies;
 	int nTotalFrequency;
-	int nSourcePartNumber;
 	int nTargetPartNumber;
 	int nSourcePart;
 	int nTarget;
@@ -97,7 +96,6 @@ double KIShapleyTable::ComputeMeanAbsoluteShapleyValues(const KWDataGridStats* a
 		// Calcul des effectifs par partie pour l'attribut source et cible de la grille de travail
 		currentAttributeDataGridStats->ExportAttributePartFrequenciesAt(0, &ivSourcePartFrequencies);
 		currentAttributeDataGridStats->ExportAttributePartFrequenciesAt(1, &ivTargetPartFrequencies);
-		nSourcePartNumber = ivSourcePartFrequencies.GetSize();
 		nTargetPartNumber = ivTargetPartFrequencies.GetSize();
 		nTotalFrequency = targetDataGridStats->ComputeGridFrequency();
 
@@ -146,7 +144,6 @@ double KIShapleyTable::ComputeMeanAbsoluteShapleyValues(const KWDataGridStats* a
 		// Calcul des effectifs par partie pour l'attribut source et cible de la grille de travail
 		currentAttributeDataGridStats->ExportAttributePartFrequenciesAt(0, &ivSourcePartFrequencies);
 		currentAttributeDataGridStats->ExportAttributePartFrequenciesAt(1, &ivTargetPartFrequencies);
-		nSourcePartNumber = ivSourcePartFrequencies.GetSize();
 		nTargetPartNumber = ivTargetPartFrequencies.GetSize();
 		nTotalFrequency = targetDataGridStats->ComputeGridFrequency();
 

--- a/src/Learning/KWDataPreparation/KWDGMPartMergeAction.cpp
+++ b/src/Learning/KWDataPreparation/KWDGMPartMergeAction.cpp
@@ -28,7 +28,6 @@ KWDGMPart* KWDGMPartMergeAction::PerformPartMerge(KWDGMPartMerge* partMerge)
 	KWDGMPart* mergedPart;
 	KWDGMAttribute* attribute;
 	int nAttribute;
-	double dMergeCost;
 	ObjectArray oaTransferredCells1;
 	ObjectArray oaMergedCells1;
 	ObjectArray oaMergedCells2;
@@ -214,7 +213,6 @@ KWDGMPart* KWDGMPartMergeAction::PerformPartMerge(KWDGMPartMerge* partMerge)
 	}
 
 	// Fusion des cellules a fusionner
-	dMergeCost = 0;
 	for (nCell = 0; nCell < oaMergedCells1.GetSize(); nCell++)
 	{
 		cellM1 = cast(KWDGMCell*, oaMergedCells1.GetAt(nCell));
@@ -225,7 +223,6 @@ KWDGMPart* KWDGMPartMergeAction::PerformPartMerge(KWDGMPartMerge* partMerge)
 
 		// Mise a jour du cout de la cellule destination
 		dMergeCellCost = dataGridCosts->ComputeCellCost(cellM2);
-		dMergeCost += dMergeCellCost - cellM1->GetCost() - cellM2->GetCost();
 		cellM2->SetCost(dMergeCellCost);
 
 		// Suppression de la cellule origine du dictionnaire des cellules

--- a/src/Learning/KWDataPreparation/KWDRDataGrid.cpp
+++ b/src/Learning/KWDataPreparation/KWDRDataGrid.cpp
@@ -1151,7 +1151,6 @@ const ALString KWDRDataGridRule::ComputeCellLabel(const KWObject* kwoObject) con
 	int nOperand;
 	int nAttributeIndex;
 	int nPartIndex;
-	int nFactor;
 	Continuous cValue;
 	Symbol sValue;
 
@@ -1161,7 +1160,6 @@ const ALString KWDRDataGridRule::ComputeCellLabel(const KWObject* kwoObject) con
 	// Calcul de l'index de la cellule
 	nCellIndex = 0;
 	bIsMissingValue = false;
-	nFactor = 1;
 	for (nOperand = 1; nOperand < GetOperandNumber(); nOperand++)
 	{
 		nAttributeIndex = nOperand - 1;

--- a/src/Learning/KWDataPreparation/KWDRTablePartition.cpp
+++ b/src/Learning/KWDataPreparation/KWDRTablePartition.cpp
@@ -117,7 +117,6 @@ boolean KWDRPartition::CheckOperandsFamily(const KWDerivationRule* ruleFamily) c
 	int nOperand;
 	KWDerivationRuleOperand* operand;
 	int nPartNumber;
-	int nTotalCellNumber;
 	double dTotalCellNumber;
 	ALString sTmp;
 
@@ -182,13 +181,11 @@ boolean KWDRPartition::CheckOperandsFamily(const KWDerivationRule* ruleFamily) c
 	// Calcul du nombre total de cellules a partir des partitions univariees
 	if (bOk)
 	{
-		nTotalCellNumber = 1;
 		dTotalCellNumber = 1;
 		for (nOperand = 0; nOperand < GetOperandNumber() - 1; nOperand++)
 		{
 			nPartNumber = cast(KWDRUnivariatePartition*, GetOperandAt(nOperand)->GetDerivationRule())
 					  ->GetPartNumber();
-			nTotalCellNumber *= nPartNumber;
 			dTotalCellNumber *= nPartNumber;
 		}
 

--- a/src/Learning/KWDataPreparation/KWDiscretizerMODL.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizerMODL.cpp
@@ -1550,7 +1550,6 @@ void KWDiscretizerMODL::IntervalListPostOptimization(const KWFrequencyTable* kwf
 	double dBestDeltaCost;
 	int nIntervalNumber;
 	int nSurnumerousIntervalNumber;
-	int nStepNumber;
 
 	require(kwftSource != NULL);
 	require(headInterval != NULL);
@@ -1590,11 +1589,8 @@ void KWDiscretizerMODL::IntervalListPostOptimization(const KWFrequencyTable* kwf
 
 	// Recherche iterative de la meilleure amelioration
 	bContinue = true;
-	nStepNumber = 0;
 	while (bContinue)
 	{
-		nStepNumber++;
-
 		// Test si arret de tache demandee
 		lDisplayFreshness++;
 		if (TaskProgression::IsRefreshNecessary(lDisplayFreshness) and
@@ -1771,7 +1767,6 @@ void KWDiscretizerMODL::IntervalListBoundaryPostOptimization(const KWFrequencyTa
 	KWMODLLineDeepOptimization* mergeSplitInterval;
 	double dBestDeltaCost;
 	int nIntervalNumber;
-	int nStepNumber;
 
 	require(kwftSource != NULL);
 	require(headInterval != NULL);
@@ -1806,11 +1801,8 @@ void KWDiscretizerMODL::IntervalListBoundaryPostOptimization(const KWFrequencyTa
 
 	// Recherche iterative de la meilleure amelioration
 	bContinue = true;
-	nStepNumber = 0;
 	while (bContinue)
 	{
-		nStepNumber++;
-
 		// Test si arret de tache demandee
 		lDisplayFreshness++;
 		if (TaskProgression::IsRefreshNecessary(lDisplayFreshness) and
@@ -2369,7 +2361,6 @@ void KWDiscretizerMODL::UpdateBoundaryPostOptimizationSortedListWithMergeSplit(
 	KWMODLLineDeepOptimization* prevInterval;
 	KWMODLLineDeepOptimization* prevPrevInterval;
 	KWMODLLineDeepOptimization* nextInterval;
-	KWMODLLineDeepOptimization* nextNextInterval;
 
 	require(kwftSource != NULL);
 	require(mergeSplitList != NULL);
@@ -2384,9 +2375,6 @@ void KWDiscretizerMODL::UpdateBoundaryPostOptimizationSortedListWithMergeSplit(
 	prevInterval = cast(KWMODLLineDeepOptimization*, interval->GetPrev());
 	prevPrevInterval = cast(KWMODLLineDeepOptimization*, prevInterval->GetPrev());
 	nextInterval = cast(KWMODLLineDeepOptimization*, interval->GetNext());
-	nextNextInterval = NULL;
-	if (nextInterval != NULL)
-		nextNextInterval = cast(KWMODLLineDeepOptimization*, nextInterval->GetNext());
 
 	////////////////////////////////////////////////////////////////////////////////
 	// On supprime les intervalles necessaires des listes

--- a/src/Learning/KWDataPreparation/KWGrouperMODLOptimization.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperMODLOptimization.cpp
@@ -1070,7 +1070,6 @@ void KWGrouperMODL::PostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequency
 	boolean bContinue;
 	int nModalityNumber;
 	int nGroupNumber;
-	int nTargetNumber;
 	DoubleVector dvGroupCosts;
 	DoubleVector dvGroupOutDeltaCosts;
 	DoubleVector dvGroupInDeltaCosts;
@@ -1100,10 +1099,9 @@ void KWGrouperMODL::PostOptimizeGroups(KWFrequencyTable* kwftSource, KWFrequency
 	if (bPrintInitialTables)
 		cout << *kwftSource << endl << *kwftTarget << endl;
 
-	// Memorisation des nombre de modalites, groupes et classes cibles
+	// Memorisation des nombre de modalites et groupes
 	nModalityNumber = kwftSource->GetFrequencyVectorNumber();
 	nGroupNumber = kwftTarget->GetFrequencyVectorNumber();
-	nTargetNumber = kwftSource->GetFrequencyVectorSize();
 
 	// Initialisation des valeurs de groupes
 	dvGroupCosts.SetSize(nGroupNumber);
@@ -3510,7 +3508,6 @@ void KWGrouperMODL::ExhaustiveMergeGroupingWithGarbageSearch(int nMinGroupNumber
 	IntVector* ivOptimumNumbers;
 	IntVector* ivGroups;
 	IntVector* ivSecondGroups;
-	int nInitialGroupNumber;
 
 	require(oaInitialGroups != NULL);
 	require(1 <= nMinGroupNumber and nMinGroupNumber <= oaInitialGroups->GetSize());
@@ -3522,9 +3519,6 @@ void KWGrouperMODL::ExhaustiveMergeGroupingWithGarbageSearch(int nMinGroupNumber
 
 	// Initialisation des merges
 	oaInitialGroupMerges = BuildGroupMerges(oaInitialGroups);
-
-	// Nombre initial de groupes
-	nInitialGroupNumber = oaInitialGroups->GetSize();
 
 	// Recherche du nombre optimal de groupes sans et avec poubelle
 	ivOptimumNumbers = OptimizeGroupsWithGarbageSearch(nMinGroupNumber, oaInitialGroups, oaInitialGroupMerges,

--- a/src/Learning/KWDataPreparation/KWGrouperUnsupervisedMODL.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperUnsupervisedMODL.cpp
@@ -31,8 +31,6 @@ int KWGrouperUnsupervisedMODL::ComputePreprocessedMaxLineNumber(KWFrequencyTable
 	boolean bTwoLevelHierarchy = true;
 	const int nMinTwoLevelLineNumber = 100;
 	int nBestValueNumber;
-	double dPriorCost;
-	double dSecondgroupPriorCost;
 	int nSecondGroupBestValueNumber;
 
 	require(table != NULL);
@@ -40,7 +38,7 @@ int KWGrouperUnsupervisedMODL::ComputePreprocessedMaxLineNumber(KWFrequencyTable
 	require(table->GetFrequencyVectorNumber() == table->GetInitialValueNumber());
 
 	// Calcul de la coupure suite au meilleur encodage
-	dPriorCost = ComputeBestPriorCost(table, 0, table->GetInitialValueNumber(), nBestValueNumber);
+	ComputeBestPriorCost(table, 0, table->GetInitialValueNumber(), nBestValueNumber);
 
 	// Si on a un vraie coupure, on recoupe la deuxieme partie en deux
 	// On applique cette heuristique, car souvent, la premiere coupure fait trop peu de groupe meme avec peu de
@@ -56,8 +54,8 @@ int KWGrouperUnsupervisedMODL::ComputePreprocessedMaxLineNumber(KWFrequencyTable
 	if (bTwoLevelHierarchy and nBestValueNumber < nMinTwoLevelLineNumber and
 	    nBestValueNumber < table->GetInitialValueNumber() - 1)
 	{
-		dSecondgroupPriorCost = ComputeBestPriorCost(table, nBestValueNumber, table->GetInitialValueNumber(),
-							     nSecondGroupBestValueNumber);
+		ComputeBestPriorCost(table, nBestValueNumber, table->GetInitialValueNumber(),
+				     nSecondGroupBestValueNumber);
 
 		// On ajoute la premiere partie du second groupe au premier groupe
 		nBestValueNumber += nSecondGroupBestValueNumber;

--- a/src/Learning/KWDataPreparation/KWStat.cpp
+++ b/src/Learning/KWDataPreparation/KWStat.cpp
@@ -218,8 +218,6 @@ double KWStat::InvStandardNormal(double dProb)
 	const double dMax = 1e20;
 	double dLowerX;
 	double dUpperX;
-	double dLowerXVal;
-	double dUpperXVal;
 	double dNewX;
 	double dNewXVal;
 
@@ -227,9 +225,7 @@ double KWStat::InvStandardNormal(double dProb)
 
 	// Initialisation des bornes de l'intervalle de recherche
 	dLowerX = -dMax;
-	dLowerXVal = 0;
 	dUpperX = dMax;
-	dUpperXVal = 1;
 
 	// Recherche par dichotomie de la valeur la plus proche
 	while ((dUpperX - dLowerX) > dTolerance * (fabs(dLowerX) + fabs(dUpperX)))
@@ -242,12 +238,10 @@ double KWStat::InvStandardNormal(double dProb)
 		if (dNewXVal < dProb)
 		{
 			dLowerX = dNewX;
-			dLowerXVal = dNewXVal;
 		}
 		else
 		{
 			dUpperX = dNewX;
-			dUpperXVal = dNewXVal;
 		}
 	}
 	return dLowerX;
@@ -337,8 +331,6 @@ double KWStat::InvStudent(double dProb, int ndf)
 	const double dMax = 1e20;
 	double dLowerX;
 	double dUpperX;
-	double dLowerXVal;
-	double dUpperXVal;
 	double dNewX;
 	double dNewXVal;
 
@@ -353,9 +345,7 @@ double KWStat::InvStudent(double dProb, int ndf)
 
 	// Initialisation des bornes de l'intervalle de recherche
 	dLowerX = 0;
-	dLowerXVal = 0;
 	dUpperX = dMax;
-	dUpperXVal = 1;
 
 	// Recherche par dichotomie de la valeur la plus proche
 	while ((dUpperX - dLowerX) > dTolerance * (fabs(dLowerX) + fabs(dUpperX)))
@@ -368,12 +358,10 @@ double KWStat::InvStudent(double dProb, int ndf)
 		if (dNewXVal > dProb)
 		{
 			dLowerX = dNewX;
-			dLowerXVal = dNewXVal;
 		}
 		else
 		{
 			dUpperX = dNewX;
-			dUpperXVal = dNewXVal;
 		}
 	}
 	return dLowerX;
@@ -850,8 +838,6 @@ double KWStat::InvChi2(double dProb, int ndf)
 	const double dMax = 1e20;
 	double dLowerX;
 	double dUpperX;
-	double dLowerXVal;
-	double dUpperXVal;
 	double dNewX;
 	double dNewXVal;
 	double dLnProb;
@@ -865,9 +851,7 @@ double KWStat::InvChi2(double dProb, int ndf)
 
 	// Initialisation des bornes de l'intervalle de recherche
 	dLowerX = 0;
-	dLowerXVal = 0;
 	dUpperX = dMax;
-	dUpperXVal = 1;
 
 	// Recherche par dichotomie de la valeur la plus proche
 	dLnProb = log(dProb);
@@ -881,12 +865,10 @@ double KWStat::InvChi2(double dProb, int ndf)
 		if (dNewXVal > dLnProb)
 		{
 			dLowerX = dNewX;
-			dLowerXVal = dNewXVal;
 		}
 		else
 		{
 			dUpperX = dNewX;
-			dUpperXVal = dNewXVal;
 		}
 	}
 	return dLowerX;

--- a/src/Learning/KWDataUtils/KWDatabaseTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTask.cpp
@@ -268,7 +268,6 @@ boolean KWDatabaseTask::ComputeAllDataTableIndexation()
 {
 	boolean bOk = true;
 	boolean bDisplay = false;
-	PLDatabaseTextFile* sourceDatabase;
 	RMTaskResourceGrant grantedResources;
 	KWFileIndexerTask fileIndexerTask;
 	int nSlaveNumber;
@@ -281,12 +280,9 @@ boolean KWDatabaseTask::ComputeAllDataTableIndexation()
 	/////////////////////////////////////////////////////////////////////////////////////////
 	// Collectes d'informations prealables sur les tables a traiter en lecture ou en ecriture
 
-	// Acces a la base source
-	sourceDatabase = shared_sourceDatabase.GetPLDatabase();
-	timer.Start();
-
 	// Calcul d'informations lie a l'ouverture des bases
 	bOk = bOk and ComputeDatabaseOpenInformation();
+	timer.Start();
 
 	// Appel prealable pour evaluer les ressources allouees, de facon a piloter les taches d'indexation
 	if (bOk)

--- a/src/Learning/KWDataUtils/KWDatabaseTransferTask.cpp
+++ b/src/Learning/KWDataUtils/KWDatabaseTransferTask.cpp
@@ -597,13 +597,9 @@ boolean KWDatabaseTransferTask::SlaveInitializePrepareDatabase()
 {
 	boolean bOk = true;
 	ALString sClassName;
-	PLDatabaseTextFile* targetDatabase;
 
 	// Appel de la methode ancetre
 	bOk = KWDatabaseTask::SlaveInitializePrepareDatabase();
-
-	// Acces aux bases
-	targetDatabase = shared_targetDatabase.GetPLDatabase();
 
 	// Cas specifique au multi-tables
 	if (bOk and shared_targetDatabase.GetDatabase()->IsMultiTableTechnology())

--- a/src/Learning/KWDataUtils/KWKeyPositionFinderTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeyPositionFinderTask.cpp
@@ -1001,7 +1001,6 @@ boolean KWKeyPositionFinderTask::SlaveProcess()
 	longint lNextLinePos;
 	boolean bLineTooLong;
 	int nCumulatedLineNumber;
-	boolean bIsLineOK;
 	ALString sTmp;
 	ALString sObjectLabel;
 	ALString sOtherObjectLabel;
@@ -1107,7 +1106,7 @@ boolean KWKeyPositionFinderTask::SlaveProcess()
 				}
 
 				// Extraction de la cle
-				bIsLineOK = keyExtractor.ParseNextKey(key, NULL);
+				keyExtractor.ParseNextKey(key, NULL);
 
 				// Memorisation de la premiere cle de l'esclave, que la la ligne soit valide ou non
 				if (output_SlaveFirstKeyPosition.GetKeyPosition()->GetLineIndex() == 0)

--- a/src/Learning/KWDataUtils/KWKeyPositionSampleExtractorTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeyPositionSampleExtractorTask.cpp
@@ -587,7 +587,6 @@ boolean KWKeyPositionSampleExtractorTask::SlaveProcess()
 	longint lNextLinePos;
 	boolean bLineTooLong;
 	int nCumulatedLineNumber;
-	boolean bIsLineOK;
 	ALString sTmp;
 	ALString sObjectLabel;
 	ALString sOtherObjectLabel;
@@ -668,7 +667,7 @@ boolean KWKeyPositionSampleExtractorTask::SlaveProcess()
 			{
 				// Extraction de la cle, que la ligne soit valide ou non
 				recordKeyPosition = new KWKeyPosition;
-				bIsLineOK = keyExtractor.ParseNextKey(recordKeyPosition->GetKey(), NULL);
+				keyExtractor.ParseNextKey(recordKeyPosition->GetKey(), NULL);
 
 				// Memorisation du numero de ligne pour la cle
 				recordKeyPosition->SetLineIndex((longint)nCumulatedLineNumber +

--- a/src/Learning/KWDataUtils/KWKeySampleExtractorTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeySampleExtractorTask.cpp
@@ -707,7 +707,6 @@ boolean KWKeySampleExtractorTask::SlaveProcess()
 	longint lMaxEndPos;
 	longint lNextLinePos;
 	boolean bLineTooLong;
-	boolean bIsLineOk;
 
 	inputFile.SetBufferSize(shared_nBufferSize);
 
@@ -772,7 +771,7 @@ boolean KWKeySampleExtractorTask::SlaveProcess()
 			{
 				// Extraction de la cle, que la ligne soti valdie ou non
 				recordKey = new KWKey;
-				bIsLineOk = keyExtractor.ParseNextKey(recordKey, NULL);
+				keyExtractor.ParseNextKey(recordKey, NULL);
 
 				// Memorisation de la cle et de sa memoire utilisee
 				output_oaSampledKeys->GetObjectArray()->Add(recordKey);

--- a/src/Learning/KWDataUtils/KWKeySizeEvaluatorTask.cpp
+++ b/src/Learning/KWDataUtils/KWKeySizeEvaluatorTask.cpp
@@ -286,7 +286,6 @@ boolean KWKeySizeEvaluatorTask::SlaveProcess()
 	longint lBeginPos;
 	longint lBeginLinePos;
 	longint lMaxEndPos;
-	boolean bIsLineOk;
 
 	require(inputFile.IsOpened());
 
@@ -319,7 +318,7 @@ boolean KWKeySizeEvaluatorTask::SlaveProcess()
 		// Extraction des clefs du fichier, que les lignes soit valides ou non
 		while (not inputFile.IsBufferEnd())
 		{
-			bIsLineOk = keyExtractor.ParseNextKey(&recordKey, NULL);
+			keyExtractor.ParseNextKey(&recordKey, NULL);
 			output_nTotalKeySize += (int)(sizeof(KWKey*) + recordKey.GetUsedMemory());
 		}
 	}

--- a/src/Learning/KWLearningProblem/CMakeLists.txt
+++ b/src/Learning/KWLearningProblem/CMakeLists.txt
@@ -16,7 +16,6 @@ target_link_libraries(
          DTForest
          KIInterpretation
          KWDRRuleLibrary
-         KWDataPreparation
          KWUserInterface
          SNBPredictor
          MHHistograms)

--- a/src/Learning/KWLearningProblem/KWLearningProject.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProject.cpp
@@ -19,6 +19,15 @@ void KWLearningProject::Start(int argc, char** argv)
 	// Et avant l'ouverture du fichier du MemoryStatsManager
 	SystemFileDriverCreator::RegisterExternalDrivers();
 
+	// Parametrage du mode d'interface graphique en fonction des drivers de fichiers enregistres
+	SetLearningDefaultRawGuiModeMode(SystemFileDriverCreator::GetExternalDriverNumber());
+
+	// Parametrage si necessaire d'un mode de fonctionnement basique des boites de dialogue de type FileChooser
+	if (GetLearningRawGuiModeMode())
+	{
+		UIFileChooserCard::SetDefaultStyle("");
+	}
+
 	// Parametrage des logs memoires depuis les variables d'environnement
 	//   KhiopsMemStatsLogFileName, KhiopsMemStatsLogFrequency, KhiopsMemStatsLogToCollect
 	// On ne tente d'ouvrir le fichier que si ces trois variables sont presentes et valides
@@ -28,10 +37,6 @@ void KWLearningProject::Start(int argc, char** argv)
 	if (GetIOTraceMode())
 		FileService::SetIOStatsActive(true);
 	MemoryStatsManager::OpenLogFileFromEnvVars(true);
-
-	// Parametrage si necessaire d'un mode de fonctionnement basique des boites de dialogue de type FileChooser
-	if (GetLearningRawGuiModeMode())
-		UIFileChooserCard::SetDefaultStyle("");
 
 	// Parametrage de la gestion des traces paralleles
 	if (GetParallelTraceMode() >= 1)
@@ -60,9 +65,6 @@ void KWLearningProject::Start(int argc, char** argv)
 	// Parametrage du repertoire applicatif des fichiers temporaires
 	// (le LearningApplicationName peut avoir ete modifie dans une sous classe)
 	FileService::SetApplicationName(GetLearningApplicationName());
-
-	// Parametrage du mode d'interface graphique en fonction des drivers de fichiers enregistres
-	SetLearningDefaultRawGuiModeMode(SystemFileDriverCreator::GetExternalDriverNumber());
 
 	// Seul endroit ou on capture les exceptions, pour le lancement du projet principal
 	try

--- a/src/Learning/KWLearningProblem/KWLearningProject.cpp
+++ b/src/Learning/KWLearningProblem/KWLearningProject.cpp
@@ -20,7 +20,7 @@ void KWLearningProject::Start(int argc, char** argv)
 	SystemFileDriverCreator::RegisterExternalDrivers();
 
 	// Parametrage du mode d'interface graphique en fonction des drivers de fichiers enregistres
-	SetLearningDefaultRawGuiModeMode(SystemFileDriverCreator::GetExternalDriverNumber());
+	SetLearningDefaultRawGuiModeMode(SystemFileDriverCreator::GetExternalDriverNumber() > 0);
 
 	// Parametrage si necessaire d'un mode de fonctionnement basique des boites de dialogue de type FileChooser
 	if (GetLearningRawGuiModeMode())

--- a/src/Learning/KWLearningProblem/KWModelingSpecView.cpp
+++ b/src/Learning/KWLearningProblem/KWModelingSpecView.cpp
@@ -41,6 +41,7 @@ void KWModelingSpecView::EventUpdate(Object* object)
 	require(object != NULL);
 
 	editedObject = cast(KWModelingSpec*, object);
+	(void)editedObject; // Evite un warning si on n'utilise pas l'objet dans cette methode
 }
 
 void KWModelingSpecView::EventRefresh(Object* object)
@@ -50,6 +51,7 @@ void KWModelingSpecView::EventRefresh(Object* object)
 	require(object != NULL);
 
 	editedObject = cast(KWModelingSpec*, object);
+	(void)editedObject; // Evite un warning si on n'utilise pas l'objet dans cette methode
 }
 
 const ALString KWModelingSpecView::GetClassLabel() const

--- a/src/Learning/KWModeling/KWLearningBenchmark.cpp
+++ b/src/Learning/KWModeling/KWLearningBenchmark.cpp
@@ -139,7 +139,6 @@ void KWLearningBenchmark::Evaluate()
 	IntVector ivPhysicalRecordIndexes;
 	int nValidation;
 	int nFold;
-	KWLearningSpec* learningSpec;
 	IntVector ivSelectedInstances;
 	ALString sTmp;
 
@@ -173,8 +172,6 @@ void KWLearningBenchmark::Evaluate()
 		// Exploitation si elles sont valides
 		if (benchmarkSpec->IsLearningSpecValid())
 		{
-			learningSpec = benchmarkSpec->GetLearningSpec();
-
 			// Calcul des statistiques sur le benchmark
 			Global::SetSilentMode(false);
 			benchmarkSpec->ComputeBenchmarkStats();

--- a/src/Learning/KWModeling/KWPredictorEvaluationTask.cpp
+++ b/src/Learning/KWModeling/KWPredictorEvaluationTask.cpp
@@ -216,9 +216,7 @@ boolean KWClassifierEvaluationTask::MasterInitialize()
 	boolean bOk;
 	int nTargetValue;
 	longint lMasterGrantedMemory;
-	longint lMasterSelfMemory;
 	longint lSlaveGrantedMemory;
-	longint lSlaveSelfMemory;
 	ALString sTmp;
 
 	require(masterConfMatrixEvaluation == NULL);
@@ -269,9 +267,6 @@ boolean KWClassifierEvaluationTask::MasterInitialize()
 
 	// Dimensionnement de la capacite de l'echantillonneur du maitre et du esclave
 	lMasterGrantedMemory = GetMasterResourceGrant()->GetMemory();
-	lMasterSelfMemory =
-	    ComputeTaskSelfMemory(lMasterGrantedMemory, GetResourceRequirements()->GetMasterRequirement()->GetMemory(),
-				  &databaseTaskMasterMemoryRequirement);
 	masterInstanceEvaluationSampler->SetCapacity(
 	    ComputeSamplerCapacity(lMasterGrantedMemory, shared_nTargetValueNumber));
 
@@ -281,9 +276,6 @@ boolean KWClassifierEvaluationTask::MasterInitialize()
 	if (GetTaskResourceGrant()->GetSlaveNumber() > 1)
 	{
 		lSlaveGrantedMemory = GetTaskResourceGrant()->GetSlaveMemory();
-		lSlaveSelfMemory = ComputeTaskSelfMemory(lSlaveGrantedMemory,
-							 GetResourceRequirements()->GetSlaveRequirement()->GetMemory(),
-							 &databaseTaskSlaveMemoryRequirement);
 		shared_nSlaveInstanceEvaluationCapacity =
 		    ComputeSamplerCapacity(lSlaveGrantedMemory, shared_nTargetValueNumber);
 	}

--- a/src/Learning/KWModeling/KWPredictorNaiveBayes.cpp
+++ b/src/Learning/KWModeling/KWPredictorNaiveBayes.cpp
@@ -182,7 +182,6 @@ KWAttribute* KWPredictorNaiveBayes::AddClassifierAttribute(KWDataPreparationClas
 							   ObjectArray* oaUsedDataPreparationAttributes,
 							   ContinuousVector* cvAttributeWeights)
 {
-	KWClass* classifierClass;
 	KWDRContinuousVector* weightRule;
 	KWDerivationRuleOperand* operand;
 	KWDRNBClassifier* classifierRule;
@@ -194,9 +193,6 @@ KWAttribute* KWPredictorNaiveBayes::AddClassifierAttribute(KWDataPreparationClas
 	require(oaUsedDataPreparationAttributes != NULL);
 	require(cvAttributeWeights == NULL or
 		cvAttributeWeights->GetSize() >= oaUsedDataPreparationAttributes->GetSize());
-
-	// Acces a la classe du classifieur (pour la lisibilite)
-	classifierClass = dataPreparationClass->GetDataPreparationClass();
 
 	// Creation d'une regle de ponderation des grilles
 	weightRule = NULL;
@@ -684,7 +680,6 @@ void KWPredictorNaiveBayes::AddPredictorDataGridStatsAndBlockOperands(KWDerivati
 	Object* oElement;
 	KWDerivationRuleOperand* operand;
 	KWAttribute* dataGridBlockAttribute;
-	KWAttributeBlock* nativeAttributeBlock;
 	KWDRDataGridStatsBlock* dataGridStatsBlockRule;
 	int nCurrentWeightIndex;
 
@@ -751,8 +746,6 @@ void KWPredictorNaiveBayes::AddPredictorDataGridStatsAndBlockOperands(KWDerivati
 	while (position != NULL)
 	{
 		odDataPreparationAttributesByBlock.GetNextAssoc(position, sAttributeBlockName, oElement);
-		nativeAttributeBlock =
-		    dataPreparationClass->GetDataPreparationClass()->LookupAttributeBlock(sAttributeBlockName);
 		oaDataGridStatsBlockDataPreparationAttributes = cast(ObjectArray*, oElement);
 
 		dataGridBlockAttribute =

--- a/src/Learning/KWTest/CreateLargeFiles.cpp
+++ b/src/Learning/KWTest/CreateLargeFiles.cpp
@@ -229,7 +229,6 @@ void CopyFileTwiceThenConcatenate(const ALString& sPathName, boolean bFast)
 	longint lPosition;
 	const int nBufferLength = MemSegmentByteSize;
 	char sBuffer[nBufferLength];
-	int nByteReadNumber;
 	FILE* fFile;
 	FILE* fCopy1;
 	FILE* fCopy2;
@@ -285,14 +284,14 @@ void CopyFileTwiceThenConcatenate(const ALString& sPathName, boolean bFast)
 	{
 		if (lPosition + nBufferLength < lFileSize)
 		{
-			nByteReadNumber = (int)fread(sBuffer, sizeof(char), nBufferLength, fFile);
+			fread(sBuffer, sizeof(char), nBufferLength, fFile);
 			fwrite(sBuffer, sizeof(char), nBufferLength, fCopy1);
 			fwrite(sBuffer, sizeof(char), nBufferLength, fCopy2);
 			lPosition += nBufferLength;
 		}
 		else
 		{
-			nByteReadNumber = (int)fread(sBuffer, sizeof(char), int(lFileSize - lPosition), fFile);
+			fread(sBuffer, sizeof(char), int(lFileSize - lPosition), fFile);
 			fwrite(sBuffer, sizeof(char), int(lFileSize - lPosition), fCopy1);
 			fwrite(sBuffer, sizeof(char), int(lFileSize - lPosition), fCopy2);
 			lPosition = lFileSize;
@@ -338,13 +337,13 @@ void CopyFileTwiceThenConcatenate(const ALString& sPathName, boolean bFast)
 	{
 		if (lPosition + nBufferLength < lFileSize)
 		{
-			nByteReadNumber = (int)fread(sBuffer, sizeof(char), nBufferLength, fCopy1);
+			fread(sBuffer, sizeof(char), nBufferLength, fCopy1);
 			fwrite(sBuffer, sizeof(char), nBufferLength, fConcat);
 			lPosition += nBufferLength;
 		}
 		else
 		{
-			nByteReadNumber = (int)fread(sBuffer, sizeof(char), int(lFileSize - lPosition), fCopy1);
+			fread(sBuffer, sizeof(char), int(lFileSize - lPosition), fCopy1);
 			fwrite(sBuffer, sizeof(char), int(lFileSize - lPosition), fConcat);
 			lPosition = lFileSize;
 		}
@@ -358,13 +357,13 @@ void CopyFileTwiceThenConcatenate(const ALString& sPathName, boolean bFast)
 	{
 		if (lPosition + nBufferLength < lFileSize)
 		{
-			nByteReadNumber = (int)fread(sBuffer, sizeof(char), nBufferLength, fCopy2);
+			fread(sBuffer, sizeof(char), nBufferLength, fCopy2);
 			fwrite(sBuffer, sizeof(char), nBufferLength, fConcat);
 			lPosition += nBufferLength;
 		}
 		else
 		{
-			nByteReadNumber = (int)fread(sBuffer, sizeof(char), int(lFileSize - lPosition), fCopy2);
+			fread(sBuffer, sizeof(char), int(lFileSize - lPosition), fCopy2);
 			fwrite(sBuffer, sizeof(char), int(lFileSize - lPosition), fConcat);
 			lPosition = lFileSize;
 		}

--- a/src/Learning/KWUserInterface/KWBenchmarkSpecArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWBenchmarkSpecArrayView.cpp
@@ -42,11 +42,13 @@ Object* KWBenchmarkSpecArrayView::EventNew()
 
 void KWBenchmarkSpecArrayView::EventUpdate(Object* object)
 {
+
 	KWBenchmarkSpec* editedObject;
 
 	require(object != NULL);
 
 	editedObject = cast(KWBenchmarkSpec*, object);
+	(void)editedObject; // Evite un warning si on n'utilise pas l'objet dans cette methode
 
 	// ## Custom update
 

--- a/src/Learning/KWUserInterface/KWBenchmarkSpecArrayView.cpp
+++ b/src/Learning/KWUserInterface/KWBenchmarkSpecArrayView.cpp
@@ -42,13 +42,7 @@ Object* KWBenchmarkSpecArrayView::EventNew()
 
 void KWBenchmarkSpecArrayView::EventUpdate(Object* object)
 {
-
-	KWBenchmarkSpec* editedObject;
-
 	require(object != NULL);
-
-	editedObject = cast(KWBenchmarkSpec*, object);
-	(void)editedObject; // Evite un warning si on n'utilise pas l'objet dans cette methode
 
 	// ## Custom update
 

--- a/src/Learning/KWUserInterface/KWBenchmarkSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWBenchmarkSpecView.cpp
@@ -65,13 +65,12 @@ KWBenchmarkSpec* KWBenchmarkSpecView::GetKWBenchmarkSpec()
 
 void KWBenchmarkSpecView::EventUpdate(Object* object)
 {
-	KWBenchmarkSpec* editedObject;
-
 	require(object != NULL);
 
-	editedObject = cast(KWBenchmarkSpec*, object);
-
 	// ## Custom update
+
+	KWBenchmarkSpec* editedObject;
+	editedObject = cast(KWBenchmarkSpec*, object);
 
 	// Lecture des classes du benchmark si la fenetre est ouverte
 	// Une mise a jour du fichier des classes (depuis KWBenchmarkClassSpec) rend en effet

--- a/src/Learning/KWUserInterface/KWDatabaseTransferView.cpp
+++ b/src/Learning/KWUserInterface/KWDatabaseTransferView.cpp
@@ -425,7 +425,6 @@ void KWDatabaseTransferView::BuildTransferredClass()
 	FileSpec specTransferredDictionaryFile;
 	ALString sTransferredClassFileName;
 	KWClassDomain transferredClassDomain;
-	KWClass* transferredClass;
 	KWResultFilePathBuilder resultFilePathBuilder;
 
 	// Memorisation des donnees modifies (non geres par les View)
@@ -525,7 +524,7 @@ void KWDatabaseTransferView::BuildTransferredClass()
 		if (bOk and sTransferredClassFileName != "")
 		{
 			AddSimpleMessage("Write deployed dictionary file " + sTransferredClassFileName);
-			transferredClass = InternalBuildTransferredClass(&transferredClassDomain, transferClass);
+			InternalBuildTransferredClass(&transferredClassDomain, transferClass);
 
 			// Ecriture du dictionnaire
 			transferredClassDomain.WriteFile(sTransferredClassFileName);

--- a/src/Learning/KWUserInterface/KWPreprocessingSpecView.cpp
+++ b/src/Learning/KWUserInterface/KWPreprocessingSpecView.cpp
@@ -177,12 +177,7 @@ void KWPreprocessingSpecView::InspectDataGridOptimizerParameters()
 
 void KWPreprocessingSpecView::SetObject(Object* object)
 {
-	KWPreprocessingSpec* preprocessingSpec;
-
 	require(object != NULL);
-
-	// Acces a l'objet edite
-	preprocessingSpec = cast(KWPreprocessingSpec*, object);
 
 	// Memorisation de l'objet pour la fiche courante
 	UIObjectView::SetObject(object);

--- a/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.cpp
+++ b/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.cpp
@@ -466,7 +466,7 @@ static void KNIInternalDeleteStream(int hStream)
 
 	// Destruction de la classe
 	kwcClass = kniStream->GetClass();
-	kwcdLoadedDomain = kniStream->GetClass()->GetDomain();
+	kwcdLoadedDomain = kwcClass->GetDomain();
 	delete kwcdLoadedDomain;
 
 	// Destruction du stream
@@ -1225,7 +1225,6 @@ KNI_API int KNISetExternalTable(int hStream, const char* sDataRoot, const char* 
 KNI_API int KNIFinishOpeningStream(int hStream)
 {
 	int nRetCode;
-	KWClass* kwcClass;
 	KNIStream* kniStream;
 	KWMTDatabaseMapping* mapping;
 	int i;
@@ -1244,7 +1243,6 @@ KNI_API int KNIFinishOpeningStream(int hStream)
 		nRetCode = KNI_ErrorStreamHandle;
 
 	// Test si stream non deja ouvert
-	kwcClass = NULL;
 	kniStream = NULL;
 	if (nRetCode == KNI_OK)
 	{
@@ -1252,7 +1250,6 @@ KNI_API int KNIFinishOpeningStream(int hStream)
 
 		// Recherche du stream et de sa classe
 		kniStream = KNIGetOpenedStreamAt(hStream);
-		kwcClass = kniStream->GetClass();
 
 		// Erreur si stream deja ouvert
 		if (kniStream->GetInputStream()->IsOpenedForRead())

--- a/src/Learning/MHHistograms/MHFloatingPointFrequencyTableBuilder.cpp
+++ b/src/Learning/MHHistograms/MHFloatingPointFrequencyTableBuilder.cpp
@@ -19,7 +19,6 @@ void MHFloatingPointFrequencyTableBuilder::InitializeBins(const ContinuousVector
 	Continuous cBinLowerValue;
 	Continuous cBinUpperValue;
 	int nBinFrequency;
-	Continuous cMantissa;
 
 	require(cvSourceBinUpperValues != NULL);
 	require(cvSourceBinUpperValues->GetSize() > 0);
@@ -119,7 +118,7 @@ void MHFloatingPointFrequencyTableBuilder::InitializeBins(const ContinuousVector
 		// Cas d'une valeur non nulle
 		else
 		{
-			cMantissa = ExtractMantissa(cMaxValue, nMaxValueExponent);
+			ExtractMantissa(cMaxValue, nMaxValueExponent);
 			nMinValueExponent = nMaxValueExponent;
 			nMinCentralBinExponent = nMaxValueExponent;
 		}
@@ -128,16 +127,16 @@ void MHFloatingPointFrequencyTableBuilder::InitializeBins(const ContinuousVector
 	else if (cMinValue >= 0)
 	{
 		// Exposant max
-		cMantissa = ExtractMantissa(cMaxValue, nMaxValueExponent);
+		ExtractMantissa(cMaxValue, nMaxValueExponent);
 
 		// Exposant min si valeurs strictement positives
 		if (cMinValue > 0)
-			cMantissa = ExtractMantissa(cMinValue, nMinValueExponent);
+			ExtractMantissa(cMinValue, nMinValueExponent);
 		// Cas d'un central bin
 		else
 		{
 			assert(cMinPositiveValue > 0);
-			cMantissa = ExtractMantissa(cMinPositiveValue, nMinValueExponent);
+			ExtractMantissa(cMinPositiveValue, nMinValueExponent);
 		}
 
 		// Exposant minimum du central bin
@@ -147,16 +146,16 @@ void MHFloatingPointFrequencyTableBuilder::InitializeBins(const ContinuousVector
 	else if (cMaxValue <= 0)
 	{
 		// Exposant min
-		cMantissa = ExtractMantissa(cMinValue, nMinValueExponent);
+		ExtractMantissa(cMinValue, nMinValueExponent);
 
 		// Exposant max si valeurs strictement negatives
 		if (cMaxValue < 0)
-			cMantissa = ExtractMantissa(cMaxValue, nMaxValueExponent);
+			ExtractMantissa(cMaxValue, nMaxValueExponent);
 		// Cas d'un central bin
 		else
 		{
 			assert(cMaxNegativeValue < 0);
-			cMantissa = ExtractMantissa(cMaxNegativeValue, nMaxValueExponent);
+			ExtractMantissa(cMaxNegativeValue, nMaxValueExponent);
 		}
 
 		// Exposant minimum du central bin
@@ -171,16 +170,16 @@ void MHFloatingPointFrequencyTableBuilder::InitializeBins(const ContinuousVector
 		assert(cMinPositiveValue > 0);
 
 		// Exposant min
-		cMantissa = ExtractMantissa(cMinValue, nMinValueExponent);
+		ExtractMantissa(cMinValue, nMinValueExponent);
 
 		// Exposant max
-		cMantissa = ExtractMantissa(cMaxValue, nMaxValueExponent);
+		ExtractMantissa(cMaxValue, nMaxValueExponent);
 
 		// Exposant du bin central
 		if (-cMaxNegativeValue < cMinPositiveValue)
-			cMantissa = ExtractMantissa(cMaxNegativeValue, nMinCentralBinExponent);
+			ExtractMantissa(cMaxNegativeValue, nMinCentralBinExponent);
 		else
-			cMantissa = ExtractMantissa(cMinPositiveValue, nMinCentralBinExponent);
+			ExtractMantissa(cMinPositiveValue, nMinCentralBinExponent);
 	}
 
 	// Memorisation de la valeur initiale du CentralBinExponent
@@ -1768,7 +1767,6 @@ boolean MHFloatingPointFrequencyTableBuilder::Check() const
 	boolean bOk = true;
 	Continuous cLowerBound;
 	Continuous cUpperBound;
-	Continuous cPreviousLowerBound;
 	Continuous cPreviousUpperBound;
 	int nMainBinIndex;
 	int nIndex;
@@ -1793,7 +1791,6 @@ boolean MHFloatingPointFrequencyTableBuilder::Check() const
 		assert(bOk);
 
 		// Verification des main bins
-		cPreviousLowerBound = 0;
 		cPreviousUpperBound = 0;
 		for (nMainBinIndex = 0; nMainBinIndex < GetMainBinNumber(); nMainBinIndex++)
 		{
@@ -1864,7 +1861,6 @@ boolean MHFloatingPointFrequencyTableBuilder::Check() const
 			assert(bOk);
 
 			// Memorisation du bin precedent
-			cPreviousLowerBound = cLowerBound;
 			cPreviousUpperBound = cUpperBound;
 		}
 	}

--- a/src/Learning/MHHistograms/MHTruncationFloatingPointFrequencyTableBuilder.cpp
+++ b/src/Learning/MHHistograms/MHTruncationFloatingPointFrequencyTableBuilder.cpp
@@ -312,13 +312,13 @@ void MHTruncationFloatingPointFrequencyTableBuilder::ExtractFloatingPointBinBoun
 	assert(cIntervalLength < dTruncationBinaryEpsilon or
 	       (longint)(cIntervalLength / dTruncationBinaryEpsilon) == cIntervalLength / dTruncationBinaryEpsilon or
 	       nHierarchyBitNumber < GetMainBinHierarchyRootLevel() or
-	       cIntervalLength / dTruncationBinaryEpsilon >= LONG_MAX or
+	       cIntervalLength / dTruncationBinaryEpsilon >= (double)LONG_MAX or
 	       cIntervalLength == KWContinuous::GetEpsilonValue());
 	if (cIntervalLength < dTruncationBinaryEpsilon)
 	{
 		assert((longint)(dTruncationBinaryEpsilon / cIntervalLength) ==
 			   dTruncationBinaryEpsilon / cIntervalLength or
-		       dTruncationBinaryEpsilon / cIntervalLength >= LLONG_MAX or
+		       dTruncationBinaryEpsilon / cIntervalLength >= (double)LLONG_MAX or
 		       cIntervalLength <= KWContinuous::GetEpsilonValue());
 
 		// On ne traite que le cas d'un intervalle plus grand que le epsilon de la singularite en 0

--- a/src/Learning/MODL/CMakeLists.txt
+++ b/src/Learning/MODL/CMakeLists.txt
@@ -1,7 +1,7 @@
 file(GLOB cppfiles ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(MODL ${cppfiles} MODL.rc)
-target_link_libraries(MODL PUBLIC DTForest KWLearningProblem)
+target_link_libraries(MODL PUBLIC KWLearningProblem)
 set_khiops_options(MODL)
 
 # on fedora, binaries built with mpi must ended by _mpich or _openmpi suffix
@@ -14,7 +14,7 @@ if(MPI)
 endif()
 
 add_library(MODL_DLL SHARED ${cppfiles})
-target_link_libraries(MODL_DLL PUBLIC DTForest KWLearningProblem)
+target_link_libraries(MODL_DLL PUBLIC KWLearningProblem)
 if(MPI)
   target_link_libraries(MODL_DLL PUBLIC PLMPI)
 endif()

--- a/src/Learning/SNBPredictor/CMakeLists.txt
+++ b/src/Learning/SNBPredictor/CMakeLists.txt
@@ -11,8 +11,4 @@ target_link_libraries(
          KWDRRuleLibrary
          KWModeling
          KWUtils
-         KWDataUtils
-         KWDRRuleLibrary
-         KWModeling
-         KWUserInterface
-         KWUtils)
+         KWUserInterface)

--- a/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.cpp
+++ b/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.cpp
@@ -1271,7 +1271,6 @@ void SNBDataTableBinarySliceSetChunkPhysicalLayout::FinishInitialization()
 	longint lBlockOffset;
 	int nSlice;
 	longint lBlockSize;
-	longint lAttributeDataRelativeOffset;
 	int nSliceAttribute;
 	int nAttribute;
 
@@ -1286,13 +1285,11 @@ void SNBDataTableBinarySliceSetChunkPhysicalLayout::FinishInitialization()
 	for (nSlice = 0; nSlice < layout->GetSliceNumber(); nSlice++)
 	{
 		lBlockSize = 0;
-		lAttributeDataRelativeOffset = 0;
 		for (nSliceAttribute = 0; nSliceAttribute < layout->GetAttributeNumberAtSlice(nSlice);
 		     nSliceAttribute++)
 		{
 			nAttribute = layout->GetAttributeOffsetAtSlice(nSlice) + nSliceAttribute;
 			lBlockSize += (longint)ivAttributeDataSizes.GetAt(nAttribute);
-			lAttributeDataRelativeOffset += (longint)ivAttributeDataSizes.GetAt(nAttribute);
 		}
 		lvBlockSizes.SetAt(nSlice, lBlockSize);
 		lvBlockOffsets.SetAt(nSlice, lBlockOffset);
@@ -1517,7 +1514,6 @@ boolean SNBDataTableBinarySliceSetChunkBuffer::InitializeDataFileFromSliceSetAt(
 	int nRequestedBufferSize;
 	int* buffer;
 	int nIntBufferSize;
-	int nChunkInstanceNumber;
 	int nSlice;
 	int nSliceAttributeNumber;
 	int nBuffer;
@@ -1544,7 +1540,6 @@ boolean SNBDataTableBinarySliceSetChunkBuffer::InitializeDataFileFromSliceSetAt(
 
 		// Boucle sur les slices pour ecriture du fichier de chunk
 		Global::ActivateErrorFlowControl();
-		nChunkInstanceNumber = layout->GetInstanceNumberAtChunk(nChunkIndex);
 		for (nSlice = 0; nSlice < layout->GetSliceNumber(); nSlice++)
 		{
 			// Chargmement en memoire de la slice du binary slice set depuis le slice set
@@ -2781,7 +2776,6 @@ void SNBDataTableBinarySliceSet::WriteContentsAsTSV(ostream& ost)
 {
 	const int nMaxInstanceNumber = 200;
 	int nDisplayedInstanceNumber;
-	boolean bOk = true;
 	int nSlice;
 	int nInstance;
 	int nAttribute;
@@ -2832,7 +2826,7 @@ void SNBDataTableBinarySliceSet::WriteContentsAsTSV(ostream& ost)
 						      layout.GetAttributeNumberAtSlice(nSlice);
 				     nAttribute++)
 				{
-					bOk = GetAttributeColumnView(GetAttributeAt(nAttribute), column);
+					GetAttributeColumnView(GetAttributeAt(nAttribute), column);
 					if (column->GetSparseMode())
 					{
 						ost << "\t";

--- a/src/Learning/SNBPredictor/SNBPredictorSelectionDataCostCalculator.cpp
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectionDataCostCalculator.cpp
@@ -2105,15 +2105,11 @@ void SNBGeneralizedClassifierSelectionDataCostCalculator::UpdateTargetPartitionW
 	POSITION position;
 	SNBGroupTargetPart* groupTargetPart;
 	SNBGroupTargetPart* newTargetPartScore;
-	int nRemovedAttributeSignatureIndex;
 	ObjectArray oaPartsToDelete;
 	int nTargetPart;
 
 	require(Check());
 	require(signatureSchema.Contains(attribute));
-
-	// Acces a l'removedAttributeIndex de l'attribut a supprimer dans la signature cible
-	nRemovedAttributeSignatureIndex = signatureSchema.GetSignatureIndexAt(attribute);
 
 	// Retaillage initiale de la partition cible
 	oaTargetParts.SetSize(0);

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.cpp
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.cpp
@@ -548,7 +548,6 @@ longint SNBPredictorSelectiveNaiveBayesTrainingTask::ComputeGlobalSlaveBinarySli
 	int nInstanceNumber;
 	int nAttributeNumber;
 	int nSparseAttributeNumber;
-	longint lSparseMissingValueNumber;
 	double dSparseMemoryFactor;
 	longint lNecessaryMemory;
 	IntVector* ivTrainingSparseMissingValueNumberPerAttribute;
@@ -557,7 +556,6 @@ longint SNBPredictorSelectiveNaiveBayesTrainingTask::ComputeGlobalSlaveBinarySli
 	nInstanceNumber = masterSnbPredictor->GetInstanceNumber();
 	nAttributeNumber = masterSnbPredictor->ComputeTrainingAttributeNumber();
 	nSparseAttributeNumber = masterSnbPredictor->ComputeTrainingSparseAttributeNumber();
-	lSparseMissingValueNumber = masterSnbPredictor->ComputeTrainingAttributesSparseMissingValueNumber();
 
 	dSparseMemoryFactor = masterSnbPredictor->ComputeSparseMemoryFactor();
 	ivTrainingSparseMissingValueNumberPerAttribute =
@@ -603,7 +601,7 @@ longint SNBPredictorSelectiveNaiveBayesTrainingTask::ComputeSlaveNecessaryMemory
 	lSelectionScorerMemory = ComputeSlaveScorerNecessaryMemory();
 
 	// La memoire de l'esclave est celle des
-	lSlaveMemory = lLayoutMemory + lTargetValuesMemory + lBinarySliceSetSelfMemory;
+	lSlaveMemory = lLayoutMemory + lTargetValuesMemory + lBinarySliceSetSelfMemory + lSelectionScorerMemory;
 
 	// Trace de deboggage
 	if (bDisplay)
@@ -903,11 +901,9 @@ boolean SNBPredictorSelectiveNaiveBayesTrainingTask::MasterInitializeDataTableBi
 	int nMaxSliceNumber;
 	longint lSlaveGrantedMemory;
 	longint lSlaveNecessaryMemory;
-	longint lSlaveShareOfGlobalNecessaryMemory;
 	longint lSlaveExtraMemory;
 	longint lDataTableSliceSetTotalReadBufferMemory;
 	longint lOneSliceExecutionExtraNecessaryMemory;
-	int nDataTableSliceSetSliceNumber;
 	int nDenseAttributeNumber;
 	longint lNonBufferSlaveGlobalMemory;
 	longint lSlaveDenseValuesMemoryPerBlock;
@@ -923,11 +919,9 @@ boolean SNBPredictorSelectiveNaiveBayesTrainingTask::MasterInitializeDataTableBi
 	lSlaveGrantedMemory = GetTaskResourceGrant()->GetSlaveMemory();
 	nMaxSliceNumber = ComputeMaxSliceNumber();
 	lSlaveNecessaryMemory = 0;
-	lSlaveShareOfGlobalNecessaryMemory = 0;
 	lSlaveExtraMemory = -1;
 	lDataTableSliceSetTotalReadBufferMemory = 0;
 	lOneSliceExecutionExtraNecessaryMemory = 0;
-	nDataTableSliceSetSliceNumber = 0;
 	recoderClass = NULL;
 
 	// Recherche d'un nombre de slices qui permet d'executer la tache
@@ -982,7 +976,6 @@ boolean SNBPredictorSelectiveNaiveBayesTrainingTask::MasterInitializeDataTableBi
 		//   - l'excedant entre la memoire necessaire avec un buffer de taille par defaut et celle avec un de taille minimale
 		//   - l'excedant entre la memoire attribuee et la memoire necessaire avec un buffer de taille minimale
 		//
-		nDataTableSliceSetSliceNumber = shared_dataTableSliceSet.GetDataTableSliceSet()->GetSliceNumber();
 		lDataTableSliceSetTotalReadBufferMemory =
 		    ComputeSliceSetTotalReadBufferNecessaryMemory(MemSegmentByteSize) +
 		    min(lSlaveExtraMemory,

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesView.cpp
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesView.cpp
@@ -37,6 +37,7 @@ void SNBPredictorSelectiveNaiveBayesView::EventUpdate(Object* object)
 	require(object != NULL);
 
 	editedObject = cast(SNBPredictorSelectiveNaiveBayes*, object);
+	(void)editedObject; // Evite un warning si on n'utilise pas l'objet dans cette methode
 }
 
 void SNBPredictorSelectiveNaiveBayesView::EventRefresh(Object* object)
@@ -46,6 +47,7 @@ void SNBPredictorSelectiveNaiveBayesView::EventRefresh(Object* object)
 	require(object != NULL);
 
 	editedObject = cast(SNBPredictorSelectiveNaiveBayes*, object);
+	(void)editedObject; // Evite un warning si on n'utilise pas l'objet dans cette methode
 }
 
 void SNBPredictorSelectiveNaiveBayesView::SetObject(Object* object)

--- a/src/Learning/genum/GenumCommandLine.cpp
+++ b/src/Learning/genum/GenumCommandLine.cpp
@@ -100,10 +100,8 @@ boolean GenumCommandLine::ReadValues(ContinuousVector*& cvValues)
 	longint lFilePos;
 	boolean bLineTooLong;
 	longint lRecordIndex;
-	longint lLineNumber;
 	boolean bEndOfLine;
 	int nField;
-	int nFieldError;
 	longint lCumulatedFrequency;
 	Continuous cValue;
 	ObjectArray oaBins;
@@ -126,7 +124,6 @@ boolean GenumCommandLine::ReadValues(ContinuousVector*& cvValues)
 	if (bOk)
 	{
 		lFilePos = 0;
-		lLineNumber = 0;
 		lRecordIndex = 0;
 		cValue = KWContinuous::GetMissingValue();
 
@@ -152,7 +149,6 @@ boolean GenumCommandLine::ReadValues(ContinuousVector*& cvValues)
 				// Lecture des champs de la ligne
 				bEndOfLine = false;
 				nField = 0;
-				nFieldError = inputFile.FieldNoError;
 				lRecordIndex++;
 				while (bOk and not bEndOfLine)
 				{

--- a/src/Learning/genum/MHDiscretizerGenumHistogram.cpp
+++ b/src/Learning/genum/MHDiscretizerGenumHistogram.cpp
@@ -422,7 +422,6 @@ void MHDiscretizerGenumHistogram::GranularizedDiscretizeValues(
 	double dCost;
 	int nIntervalNumber;
 	double dPartitionCost;
-	int nHierarchyLevel;
 	int nPartileNumber;
 	int nTotalBinNumber;
 	int nMaxPartileNumber;
@@ -465,7 +464,6 @@ void MHDiscretizerGenumHistogram::GranularizedDiscretizeValues(
 	// Optimisation de la granularite
 	// On s'arrete quand on depasse un nombre max d'essais consecutifs sans amelioration
 	dBestCost = DBL_MAX;
-	nHierarchyLevel = 0;
 	nPartileNumber = 1;
 	nLastActualPartileNumber = 1;
 	optimizedHistogramFrequencyTable = NULL;
@@ -476,8 +474,6 @@ void MHDiscretizerGenumHistogram::GranularizedDiscretizeValues(
 	dPreviousCost = DBL_MAX;
 	while (nPartileNumber <= nMaxPartileNumber)
 	{
-		nHierarchyLevel++;
-
 		// Construction d'une version granularisee de la table, apres avoir parametree correctement le nombre de
 		// partiles
 		BuildGranularizedFrequencyTable(initialHistogramFrequencyTable, nPartileNumber,

--- a/src/Learning/khisto/KhistoCommandLine.cpp
+++ b/src/Learning/khisto/KhistoCommandLine.cpp
@@ -472,10 +472,8 @@ boolean KhistoCommandLine::ReadBins(ContinuousVector*& cvLowerValues, Continuous
 	longint lFilePos;
 	boolean bLineTooLong;
 	longint lRecordIndex;
-	longint lLineNumber;
 	boolean bEndOfLine;
 	int nField;
-	int nFieldError;
 	longint lCumulatedFrequency;
 	int nFrequency;
 	Continuous cLowerValue;
@@ -519,7 +517,6 @@ boolean KhistoCommandLine::ReadBins(ContinuousVector*& cvLowerValues, Continuous
 	if (bOk)
 	{
 		lFilePos = 0;
-		lLineNumber = 0;
 		lRecordIndex = 0;
 		nFrequency = 0;
 		cLowerValue = KWContinuous::GetMissingValue();
@@ -547,7 +544,6 @@ boolean KhistoCommandLine::ReadBins(ContinuousVector*& cvLowerValues, Continuous
 				// Lecture des champs de la ligne
 				bEndOfLine = false;
 				nField = 0;
-				nFieldError = inputFile.FieldNoError;
 				lRecordIndex++;
 				while (bOk and not bEndOfLine)
 				{
@@ -893,10 +889,8 @@ boolean KhistoCommandLine::ReadValues(ContinuousVector*& cvValues)
 	longint lFilePos;
 	boolean bLineTooLong;
 	longint lRecordIndex;
-	longint lLineNumber;
 	boolean bEndOfLine;
 	int nField;
-	int nFieldError;
 	longint lCumulatedFrequency;
 	Continuous cValue;
 	ObjectArray oaBins;
@@ -919,7 +913,6 @@ boolean KhistoCommandLine::ReadValues(ContinuousVector*& cvValues)
 	if (bOk)
 	{
 		lFilePos = 0;
-		lLineNumber = 0;
 		lRecordIndex = 0;
 		cValue = KWContinuous::GetMissingValue();
 
@@ -945,7 +938,6 @@ boolean KhistoCommandLine::ReadValues(ContinuousVector*& cvValues)
 				// Lecture des champs de la ligne
 				bEndOfLine = false;
 				nField = 0;
-				nFieldError = inputFile.FieldNoError;
 				lRecordIndex++;
 				while (bOk and not bEndOfLine)
 				{

--- a/src/Learning/samples/sample3/MYLearningProblemView.cpp
+++ b/src/Learning/samples/sample3/MYLearningProblemView.cpp
@@ -110,20 +110,12 @@ MYLearningProblemExtendedActionView::~MYLearningProblemExtendedActionView() {}
 
 void MYLearningProblemExtendedActionView::EventUpdate(Object* object)
 {
-	MYLearningProblem* editedObject;
-
 	require(object != NULL);
-
-	editedObject = cast(MYLearningProblem*, object);
 }
 
 void MYLearningProblemExtendedActionView::EventRefresh(Object* object)
 {
-	MYLearningProblem* editedObject;
-
 	require(object != NULL);
-
-	editedObject = cast(MYLearningProblem*, object);
 }
 
 void MYLearningProblemExtendedActionView::ClassifierBenchmark()

--- a/src/Norm/_khiopslauncher/KhiopsLauncher.cpp
+++ b/src/Norm/_khiopslauncher/KhiopsLauncher.cpp
@@ -12,6 +12,8 @@
 
 int main(int argc, char** argv)
 {
+	(void)argc;
+	(void)argv;
 	printf("This program is used by Khiops, only on Windows.\n");
 	return EXIT_FAILURE;
 }

--- a/src/Norm/base/CharVector.cpp
+++ b/src/Norm/base/CharVector.cpp
@@ -367,6 +367,7 @@ boolean CharVector::TestCopyAt(int nSizeDest, int nSizeSource, int nIndexDest, i
 	int nErrorNumber;
 	int i;
 	boolean bOk;
+	const boolean bTrace = false;
 
 	assert(nIndexDest + nCopySize < nSizeDest);
 	assert(nIndexSource + nCopySize <= nSizeSource);
@@ -404,6 +405,14 @@ boolean CharVector::TestCopyAt(int nSizeDest, int nSizeSource, int nIndexDest, i
 		default:
 			nErrorNumber++;
 		}
+	}
+	if (bTrace)
+	{
+		cout << "TestCopyAt: nSizeDest=" << nSizeDest << ", nSizeSource=" << nSizeSource
+		     << ", nIndexDest=" << nIndexDest << ", nIndexSource=" << nIndexSource
+		     << ", nCopySize=" << nCopySize << endl;
+		cout << "nCharSourceNumber=" << nCharSourceNumber << ", nCharDestNumber=" << nCharDestNumber
+		     << ", nErrorNumber=" << nErrorNumber << endl;
 	}
 
 	// Test si les resultats sont OK

--- a/src/Norm/base/CommandFile.cpp
+++ b/src/Norm/base/CommandFile.cpp
@@ -127,7 +127,7 @@ const ALString& CommandFile::GetInputParameterFileName() const
 
 boolean CommandFile::Check() const
 {
-	boolean bOk;
+	boolean bOk = true;
 
 	// Le parametrage des search/replace ne peut pas etre utilise s'il n'y a pas de fichier de commande en entree
 	if (GetInputSearchReplaceValueNumber() > 0 and GetInputCommandFileName() == "")
@@ -141,7 +141,7 @@ boolean CommandFile::Check() const
 	if (GetInputParameterFileName() != "" and GetInputSearchReplaceValueNumber() > 0)
 		bOk = false;
 
-	return true;
+	return bOk;
 }
 
 boolean CommandFile::OpenInputCommandFile()

--- a/src/Norm/base/MemoryBufferedFile.cpp
+++ b/src/Norm/base/MemoryBufferedFile.cpp
@@ -27,7 +27,6 @@ boolean MemoryInputBufferedFile::FillBuffer(const CharVector* cvInputRecord)
 {
 	boolean bOk;
 	int nInitialCurrentBufferSize;
-	int nInitialBufferLineNumber;
 	char c;
 	int i;
 
@@ -35,7 +34,6 @@ boolean MemoryInputBufferedFile::FillBuffer(const CharVector* cvInputRecord)
 
 	// Retaillage si necessaire du buffer
 	nInitialCurrentBufferSize = nCurrentBufferSize;
-	nInitialBufferLineNumber = nBufferLineNumber;
 	bOk = AllocateBuffer();
 
 	// Recopie de la chaine de caracteres dans le buffer

--- a/src/Norm/base/SystemResource.cpp
+++ b/src/Norm/base/SystemResource.cpp
@@ -898,7 +898,6 @@ static size_t get(const char* name)
 	size_t len = sizeof(nValue);
 	if (sysctlbyname(name, &nValue, &len, NULL, 0) < 0)
 	{
-	std:
 		cerr << "error when acces " << name << std::endl;
 		nValue = -1;
 	}
@@ -910,21 +909,13 @@ longint MemGetFreePhysicalMemory()
 {
 #ifdef __APPLE__
 	size_t pagesize = get("vm.pagesize");
-	size_t pages = get("vm.pages");
 
 	// Memoire disponible
 	size_t pagefree = get("vm.page_free_count");
 
 	// Memoire disponible apres purge
 	size_t pagepurge = get("vm.page_pageable_external_count");
-	// size_t pagepurge2=get("vm.page_pageable_internal_count");
 
-	// std::cout << "free: " << pagesize * pagefree / 10000000 << " Mo" << endl;
-	// std::cout << "purge: " << pagesize * pagepurge / 10000000 << " Mo" << endl;
-	// std::cout << "purge2: " << pagesize * pagepurge2 / 10000000 << " Mo" << endl;
-	// std::cout << "mem: " << pagesize * pages / 10000000 << " Mo" << endl;
-	// std::cout << "available? : " << pagesize * (pagepurge+pagefree) / 10000000 << " Mo" << endl;
-	// std::cout << "used? : " << pagesize * (pages -pagepurge - pagefree) / 10000000 << " Mo" << endl;
 	if (pagesize == -1 or pagepurge == -1 or pagefree == -1)
 		return 0;
 	return pagesize * (pagepurge + pagefree);
@@ -1357,20 +1348,34 @@ int GetMaxOpenedFileNumber()
 	return lim.rlim_cur;
 }
 
+#ifdef __APPLE__
 const char* GetSystemInfos()
 {
-	FILE* file = NULL;
-	int i = 0;
-	int nLineCount;
 	char* sInfo = StandardGetBuffer();
 	int nPos;
-	char c;
 	struct utsname buffer;
-	bool bOk;
 
 	sInfo[0] = '\0';
 
-#ifndef __APPLE__
+	// Ajout de l'architecture (fonctionne sur Linux et macOS)
+	if (uname(&buffer) >= 0)
+	{
+		nPos = (int)strlen(sInfo);
+		snprintf(&sInfo[nPos], BUFFER_LENGTH - nPos, "system=%s\nrelease=%s\nversion=%s\n", buffer.sysname,
+			 buffer.release, buffer.version);
+	}
+	return sInfo;
+}
+#else // __APPLE__
+
+const char* GetSystemInfos()
+{
+	char* sInfo = StandardGetBuffer();
+	FILE* file = NULL;
+	char c;
+	int i = 0;
+	int nLineCount;
+
 	// Parcours du fichier os-release
 	file = p_fopen("/etc/os-release", "rb");
 	if (file == NULL)
@@ -1393,19 +1398,10 @@ const char* GetSystemInfos()
 		sInfo[i] = '\0';
 		fclose(file);
 	}
-#endif // __APPLE__
-
-	// Ajout de l'architecture (fonctionne sur Linux et macOS)
-	if (uname(&buffer) >= 0)
-	{
-		bOk = true;
-		nPos = (int)strlen(sInfo);
-		snprintf(&sInfo[nPos], BUFFER_LENGTH - nPos, "system=%s\nrelease=%s\nversion=%s\n", buffer.sysname,
-			 buffer.release, buffer.version);
-	}
 	return sInfo;
 }
 
+#endif // __APPLE__
 #endif // __linux_or_apple__
 
 void TestSystemResource()

--- a/src/Norm/base/TextService.cpp
+++ b/src/Norm/base/TextService.cpp
@@ -390,7 +390,6 @@ boolean TextService::JsonToCString(const char* sJsonString, ALString& sCString)
 	boolean bOk = true;
 	const unsigned char* sInputString;
 	int nAnsiCode;
-	boolean bContainsAnsiChars;
 	unsigned int nCode;
 	unsigned int nPotentialCode;
 	int nBegin;
@@ -418,7 +417,6 @@ boolean TextService::JsonToCString(const char* sJsonString, ALString& sCString)
 	nBegin = 0;
 	nEnd = 0;
 	sCharsToAdd = "?";
-	bContainsAnsiChars = false;
 	while (nEnd < nLength)
 	{
 		if (sInputString[nEnd] == '\\')
@@ -484,7 +482,6 @@ boolean TextService::JsonToCString(const char* sJsonString, ALString& sCString)
 					nAnsiCode = UnicodeHexToWindows1252(sUnicodeChars);
 					if (nAnsiCode != -1)
 					{
-						bContainsAnsiChars = true;
 						nEnd += 3;
 						nCharNumber = 1;
 						sUtf8Chars[0] = (char)nAnsiCode;

--- a/src/Norm/genere/GenereAttArrayViewC.cpp
+++ b/src/Norm/genere/GenereAttArrayViewC.cpp
@@ -8,6 +8,18 @@ void TableGenerator::GenerateAttributeArrayViewC(ostream& ost) const
 {
 	int nCurrent;
 	Attribute* att;
+	int nVisibleFieldNumber = 0;
+
+	// Calcul du nombre de champs visibles (non derives)
+	for (nCurrent = 0; nCurrent < GetFieldNumber(); nCurrent++)
+	{
+		att = GetFieldAt(nCurrent);
+
+		if (att->GetVisible() and not att->GetDerived())
+		{
+			nVisibleFieldNumber++;
+		}
+	}
 
 	GenerateCopyrightHeader(ost);
 	GenerateFileHeader(ost);
@@ -100,28 +112,34 @@ void TableGenerator::GenerateAttributeArrayViewC(ostream& ost) const
 	    << "\n";
 	ost << "{"
 	    << "\n";
-	ost << "\t" << GetModelClassName() << "* editedObject;"
-	    << "\n";
-	ost << ""
-	    << "\n";
+	if (nVisibleFieldNumber > 0)
+	{
+		ost << "\t" << GetModelClassName() << "* editedObject;"
+		    << "\n";
+		ost << ""
+		    << "\n";
+	}
 	ost << "\trequire(object != NULL);"
 	    << "\n";
 	ost << ""
 	    << "\n";
 	if (GetSuperClassName() != "")
 		ost << "\t" << GetArrayViewSuperClassName() << "::EventUpdate(object);\n";
-	ost << "\teditedObject = cast(" << GetModelClassName() << "*, object);"
-	    << "\n";
-	for (nCurrent = 0; nCurrent < GetFieldNumber(); nCurrent++)
+	if (nVisibleFieldNumber > 0)
 	{
-		att = GetFieldAt(nCurrent);
-
-		if (att->GetVisible() and not att->GetDerived())
+		ost << "\teditedObject = cast(" << GetModelClassName() << "*, object);"
+		    << "\n";
+		for (nCurrent = 0; nCurrent < GetFieldNumber(); nCurrent++)
 		{
-			ost << "\teditedObject->Set" << att->GetName() << "("
-			    << "Get" << att->GetFieldType() << "ValueAt(\"" << att->GetName() << "\")"
-			    << ");"
-			    << "\n";
+			att = GetFieldAt(nCurrent);
+
+			if (att->GetVisible() and not att->GetDerived())
+			{
+				ost << "\teditedObject->Set" << att->GetName() << "("
+				    << "Get" << att->GetFieldType() << "ValueAt(\"" << att->GetName() << "\")"
+				    << ");"
+				    << "\n";
+			}
 		}
 	}
 

--- a/src/Norm/genere/GenereAttViewC.cpp
+++ b/src/Norm/genere/GenereAttViewC.cpp
@@ -8,6 +8,18 @@ void TableGenerator::GenerateAttributeViewC(ostream& ost) const
 {
 	int nCurrent;
 	Attribute* att;
+	int nVisibleFieldNumber = 0;
+
+	// Calcul du nombre de champs visibles (non derives)
+	for (nCurrent = 0; nCurrent < GetFieldNumber(); nCurrent++)
+	{
+		att = GetFieldAt(nCurrent);
+
+		if (att->GetVisible() and not att->GetDerived())
+		{
+			nVisibleFieldNumber++;
+		}
+	}
 
 	GenerateCopyrightHeader(ost);
 	GenerateFileHeader(ost);
@@ -91,28 +103,34 @@ void TableGenerator::GenerateAttributeViewC(ostream& ost) const
 	    << "\n";
 	ost << "{"
 	    << "\n";
-	ost << "\t" << GetModelClassName() << "* editedObject;"
-	    << "\n";
-	ost << ""
-	    << "\n";
+	if (nVisibleFieldNumber > 0)
+	{
+		ost << "\t" << GetModelClassName() << "* editedObject;"
+		    << "\n";
+		ost << ""
+		    << "\n";
+	}
 	ost << "\trequire(object != NULL);"
 	    << "\n";
 	ost << ""
 	    << "\n";
 	if (GetSuperClassName() != "")
 		ost << "\t" << GetViewSuperClassName() << "::EventUpdate(object);\n";
-	ost << "\teditedObject = cast(" << GetModelClassName() << "*, object);"
-	    << "\n";
-	for (nCurrent = 0; nCurrent < GetFieldNumber(); nCurrent++)
+	if (nVisibleFieldNumber > 0)
 	{
-		att = GetFieldAt(nCurrent);
-
-		if (att->GetVisible() and not att->GetDerived())
+		ost << "\teditedObject = cast(" << GetModelClassName() << "*, object);"
+		    << "\n";
+		for (nCurrent = 0; nCurrent < GetFieldNumber(); nCurrent++)
 		{
-			ost << "\teditedObject->Set" << att->GetName() << "("
-			    << "Get" << att->GetFieldType() << "ValueAt(\"" << att->GetName() << "\")"
-			    << ");"
-			    << "\n";
+			att = GetFieldAt(nCurrent);
+
+			if (att->GetVisible() and not att->GetDerived())
+			{
+				ost << "\teditedObject->Set" << att->GetName() << "("
+				    << "Get" << att->GetFieldType() << "ValueAt(\"" << att->GetName() << "\")"
+				    << ");"
+				    << "\n";
+			}
 		}
 	}
 

--- a/src/Norm/genere/TableGenerator.cpp
+++ b/src/Norm/genere/TableGenerator.cpp
@@ -532,7 +532,7 @@ void TableGenerator::GenerateCopyrightHeader(ostream& ost) const
 	nCurrentYear = dateCurrent->tm_year + 1900;
 
 	// Notice de copyright
-	ost << "// Copyright (c) 2023-" << nCurrentYear << " Orange. All rights reserved.\n ";
+	ost << "// Copyright (c) 2023-" << nCurrentYear << " Orange. All rights reserved.\n";
 	ost << "// This software is distributed under the BSD 3-Clause-clear License, the text of which is available\n";
 	ost << "// at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the \"LICENSE\" file for more "
 	       "details.\n";

--- a/src/Parallel/PLMPI/PLMPISlave.cpp
+++ b/src/Parallel/PLMPI/PLMPISlave.cpp
@@ -11,7 +11,6 @@ DisplayErrorFunction PLMPISlave::currentDisplayErrorFunction = NULL;
 
 PLMPISlave::PLMPISlave(PLParallelTask* t)
 {
-	int color;
 	ALString sNewFileName;
 	PLShared_TaskResourceGrant shared_rg;
 	PLMPIMsgContext context;
@@ -20,7 +19,6 @@ PLMPISlave::PLMPISlave(PLParallelTask* t)
 
 	bBoostedMode = false;
 	bIsWorking = false;
-	color = MPI_UNDEFINED;
 	task = t;
 	assert(task->oaUserMessages == NULL);
 	task->oaUserMessages = new ObjectArray;

--- a/src/Parallel/PLParallelTask/RMParallelResourceManager.cpp
+++ b/src/Parallel/PLParallelTask/RMParallelResourceManager.cpp
@@ -699,7 +699,6 @@ void RMParallelResourceManager::GreedySolve(PLSolution* solution)
 	int nProcNumber;
 	int i;
 	int nProcMax;
-	int nProcCount;
 	const boolean bSequential = false;
 
 	if (PLParallelTask::GetTracerResources() == 3)
@@ -724,7 +723,6 @@ void RMParallelResourceManager::GreedySolve(PLSolution* solution)
 	// Algorithme glouton : a chaque iteration, on ajoute un processus.
 	solution->Evaluate(bSequential);
 	currentSolution = solution->Clone();
-	nProcCount = 0;
 
 	while (currentSolution->GetUsedProcessNumber() < nProcMax)
 	{
@@ -1510,8 +1508,6 @@ PLSolutionResources* PLHostClass::SaturateResource(const RMTaskResourceRequireme
 	longint lHostResource;       // Ressources physiques disponibles sur cette machine
 	longint lHostUsableResource; // Ressources Physiques disponibles en prenant en compte les exigences max
 	longint lHostExtraResource;  // Ressources a distribuer apres avoir alloue le min
-	longint lResourceFull; // Ressources maximales qu'on peut allouer en prenant en compte les resources diponibles
-	longint lResourceBounded; // Ressources maximales qu'on peut allouer en prenant en compte les exigences max
 	int nSlaveNumberOnCluster;
 	int nSlaveNumberOnHost;
 	int nMasterNumberOnHost;
@@ -1623,8 +1619,6 @@ PLSolutionResources* PLHostClass::SaturateResource(const RMTaskResourceRequireme
 			{
 				lHostExtraResource = lHostUsableResource - lHostOverallMin;
 				assert(lHostExtraResource >= 0);
-				lResourceFull = (lGlobalMin + lHostExtraResource) / nSlaveNumberOnHost;
-				lResourceBounded = lGlobalMax / nSlaveNumberOnCluster;
 
 				resources->SetGlobalResource(nRT,
 							     min((lGlobalMin + lHostExtraResource) / nSlaveNumberOnHost,
@@ -2333,7 +2327,6 @@ boolean PLSolution::FitMinimalRequirements(int nRT, longint& lMissingResource, b
 	int nProcNumber;
 	IntVector ivResourcesMissingForProcNumber;
 	LongintVector lvResourceMissing;
-	boolean bResourceOkForMaster;
 	longint lLocalMissingResource;
 	longint lUsedResource;
 	longint lHostUsableResource;
@@ -2352,7 +2345,6 @@ boolean PLSolution::FitMinimalRequirements(int nRT, longint& lMissingResource, b
 	// ressources manquantes (peut etre le nom de la machine)
 	lMissingResource = LLONG_MAX;
 	bResourceIsMissing = false;
-	bResourceOkForMaster = false;
 	lvResourceMissing.SetSize(0);
 
 	// Cas sequentiel : il n'y a qu'une classe de machines

--- a/src/Parallel/PLParallelTask/RMTaskResourceGrant.cpp
+++ b/src/Parallel/PLParallelTask/RMTaskResourceGrant.cpp
@@ -230,13 +230,11 @@ ALString RMTaskResourceGrant::GetMissingResourceMessage()
 	ALString sTmp;
 	ALString sMissingResource;
 	boolean bMissingMemory;
-	boolean bMissingDisk;
 
 	require(GetMissingMemory() > 0 or GetMissingDisk() > 0);
 	require(IsEmpty());
 
 	bMissingMemory = GetMissingMemory() > 0;
-	bMissingDisk = GetMissingDisk() > 0;
 
 	if (bMissingMemory)
 	{

--- a/src/Parallel/PLSamples/PEFileSearchTask.cpp
+++ b/src/Parallel/PLSamples/PEFileSearchTask.cpp
@@ -179,7 +179,6 @@ boolean PEFileSearchTask::SlaveProcess()
 	ALString sTmp;
 	boolean bIsOpen;
 	boolean bTrace = false;
-	longint lLinePosition;
 	longint lBeginPos;
 	longint lMaxEndPos;
 	longint lNextLinePos;
@@ -231,7 +230,6 @@ boolean PEFileSearchTask::SlaveProcess()
 
 	// Remplissage du buffer avec des lignes entieres dans la limite de la taille du buffer
 	// On reitere tant que l'on a pas atteint la derniere position pour lire toutes les ligne, y compris la derniere
-	lLinePosition = -1;
 	while (bOk and lBeginPos < lMaxEndPos)
 	{
 		bOk = inputBuffer.FillOuterLinesUntil(lBeginPos, lMaxEndPos, bLineTooLong);
@@ -258,8 +256,6 @@ boolean PEFileSearchTask::SlaveProcess()
 		// Parcours du buffer d'entree
 		while (bOk and not inputBuffer.IsBufferEnd())
 		{
-			lLinePosition = inputBuffer.GetPositionInFile();
-
 			// Gestion de la progresssion
 			lDisplayFreshness++;
 			if (TaskProgression::IsRefreshNecessary(lDisplayFreshness))

--- a/src/Parallel/PLSamples/PESerializerTestTask.cpp
+++ b/src/Parallel/PLSamples/PESerializerTestTask.cpp
@@ -143,7 +143,6 @@ boolean PESerializerTestTask::SlaveProcess()
 	ALString sLargeString;
 	ALString sSimpleString;
 	CharVector* cvCharVector;
-	const IntVector* ivIntvector;
 	boolean bOk;
 	int i;
 	int nCount;
@@ -252,7 +251,6 @@ boolean PESerializerTestTask::SlaveProcess()
 	}
 	if (bOk)
 	{
-		ivIntvector = input_ivIntVector.GetConstIntVector();
 		bOk = input_ivIntVector.GetConstIntVector()->GetSize() == 100000;
 		assert(bOk);
 		for (i = 0; i < 100000; i++)

--- a/test/UnitTests/Utils/TestServices.cpp
+++ b/test/UnitTests/Utils/TestServices.cpp
@@ -63,8 +63,6 @@ boolean FileCompareForTest(const ALString& sFileNameReference, const ALString& s
 {
 	FILE* fileRef;
 	FILE* fileTest;
-	boolean bOk1;
-	boolean bOk2;
 	boolean bSame = true;
 	boolean bDifferentLineNumber = false;
 	const char sSys[] = "SYS";
@@ -80,8 +78,6 @@ boolean FileCompareForTest(const ALString& sFileNameReference, const ALString& s
 	int nPos;
 
 	// Initialisations
-	bOk1 = false;
-	bOk2 = false;
 	fileRef = NULL;
 	fileTest = NULL;
 


### PR DESCRIPTION
- fix #989 
- Silence warnings with clang/macOS compiler
  - implicit conversion from 'long' to 'double'
  - Set but not used [-Wunused-but-set-parameter]
  - first argument in call to 'memset' is a pointer to non-trivially copyable type 'Symbol'
- Pending warnings in files:
      - ~~KWDerivationRule.cpp: Affectations with NULL commented with "Pour eviter le warning" produce a warning.~~
      - ~~MHFloatingPointFrequencyTableBuilder::InitializeBins: variable 'cMantissa' set but not used. Weird...~~
      - KWGrouperMODLOptimization.cpp: in method EMPostOptimizeGroupsWithGarbage, variable nStart is not used but initialized with RandomInt. It could change the references in LearningTest 
      - KWDataPreparation/* to avoid difficult conflicts
      - KWTest/*
- modification of the view generation in order to silence warnings
> [!IMPORTANT] 
>  LearningTest full passed