### PR TITLE
fix: improve MPI detection in conda environments

### DIFF
--- a/.github/workflows/run-standard-tests.yml
+++ b/.github/workflows/run-standard-tests.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         build-setup:
-          - {os: windows-2022, cmake-preset: windows-msvc}
+          - {os: windows-2025-vs2026, cmake-preset: windows-msvc}
           - {os: ubuntu-latest, cmake-preset: linux-gcc}
           - {os: ubuntu-24.04-arm, cmake-preset: linux-gcc}
           - {os: macos-14, cmake-preset: macos-clang}
@@ -92,7 +92,7 @@ jobs:
       fail-fast: false
       matrix:
         build-setup:
-          - {os: windows-2022, cmake-preset: windows-msvc}
+          - {os: windows-2025-vs2026, cmake-preset: windows-msvc}
           - {os: ubuntu-latest, cmake-preset: linux-gcc}
           - {os: ubuntu-24.04-arm, cmake-preset: linux-gcc}
           - {os: macos-14, cmake-preset: macos-clang}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         build-setup:
-          - {os: windows-2022, cmake-preset: windows-msvc-debug}
+          - {os: windows-2025-vs2026, cmake-preset: windows-msvc-debug}
           - {os: ubuntu-latest, cmake-preset: linux-gcc-debug}
           - {os: macos-latest, cmake-preset: macos-clang-debug}
     runs-on: ${{ matrix.build-setup.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,13 +111,6 @@ if(DEFINED ENV{CONDA_PREFIX} AND NOT "$ENV{CONDA_PREFIX}" STREQUAL "")
   message(STATUS "Auto-detected conda environment")
 endif()
 
-if(IS_CONDA AND MPI)
-  if(NOT DEFINED ENV{mpi})
-    message(
-      WARNING "You are building in a conda environment without using `conda build`. find_mpi may not work as expected.")
-  endif()
-endif()
-
 if(IS_PIP AND IS_CONDA)
   message(FATAL_ERROR "Building in a conda environment and using scikit-build-core")
 endif()

--- a/scripts/get_mpi_implementation.cmake
+++ b/scripts/get_mpi_implementation.cmake
@@ -18,6 +18,12 @@ function(get_mpi_implementation)
         COMMAND grep mpi
         OUTPUT_VARIABLE VAR_MPI_INFO)
     endif()
+    if(VAR_MPI_INFO STREQUAL "")
+      message(
+        FATAL_ERROR
+          "No MPI implementation found in conda environment. Please make sure to install an MPI implementation (e.g. `conda install openmpi`)"
+      )
+    endif()
   elseif(IS_PIP)
     set(DETECTION_MESSAGE "from pip environment")
 
@@ -39,10 +45,12 @@ function(get_mpi_implementation)
     set(VAR_MPI_INFO "${MPI_LIBRARIES}")
   endif(IS_CONDA)
 
-  # ERROR if VAR_MPI_INFO is not defined, it means either: - in standard environment find_mpi provides no MPI path (MPI
-  # is not installed) - or in conda build, the 'mpi' variable is missing and find_mpi may find the system wide mpi, this
-  # is not not what we want. - or in conda, outside of the build process, the mpi package is not installed and find_mpi
-  # may find the system wide mpi.
+  # cmake-format: off
+  # ERROR if VAR_MPI_INFO is not defined, it means either: 
+  # - in standard environment find_mpi provides no MPI path (MPI is not installed) 
+  # - or in conda build, the 'mpi' variable is missing and find_mpi may find the system wide mpi, this is not not what we want. 
+  # - or in conda, outside of the build process, the mpi package is not installed and find_mpi may find the system wide mpi.
+  # cmake-format: on
   if(NOT DEFINED VAR_MPI_INFO OR "${VAR_MPI_INFO}" STREQUAL "")
     message(FATAL_ERROR "Missing information to discover the MPI implementation")
   endif()


### PR DESCRIPTION
- Remove early warning about missing `mpi` env var in conda builds; rely on explicit detection instead
- Add FATAL_ERROR in `get_mpi_implementation` when no MPI package is found in a conda environment, with a clear remediation message (`conda install openmpi`)
- Use `windows-2025-vs2026` instead of `windows2022` in `run-standard-test` and `run-unit-tests`