### PR TITLE
1028 optimisation isues with ngram tokenization of very large text datasets

### DIFF
--- a/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.cpp
+++ b/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.cpp
@@ -172,6 +172,9 @@ boolean KDTextTokenSampleCollectionTask::InternalCollectTokenSamples(const KWDat
 	////////////////////////////////////////////////////////////////////////////////////////////////
 	// Premiere passe de collecte d'un echantillon de tokens
 
+	// Personnalisation du libelle de la tache
+	SetTaskUserLabel(GetTaskName() + " (first pass)");
+
 	// Debut de la collecte des indicateurs de performance
 	StartCollectPerformanceIndicators(bTracePerformanceStats);
 
@@ -219,6 +222,9 @@ boolean KDTextTokenSampleCollectionTask::InternalCollectTokenSamples(const KWDat
 
 	//////////////////////////////////////////////////////////////////////////////////////////////
 	// Deuxieme passe de collecte des effectifs exact par tokens
+
+	// Personnalisation du libelle de la tache
+	SetTaskUserLabel(GetTaskName() + " (second pass)");
 
 	// Collecte uniquement si necessaire
 	if (bOk)
@@ -268,6 +274,7 @@ boolean KDTextTokenSampleCollectionTask::InternalCollectTokenSamples(const KWDat
 	}
 
 	// Nettoyage
+	SetTaskUserLabel("");
 	oaMasterTextTokenizers.DeleteAll();
 	assert(oaSlaveTextTokenizers.GetSize() == 0);
 

--- a/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.cpp
+++ b/src/Learning/KDDomainKnowledge/KDTextTokenSampleCollectionTask.cpp
@@ -217,11 +217,15 @@ boolean KDTextTokenSampleCollectionTask::InternalCollectTokenSamples(const KWDat
 
 			// Parametrage des tokens specifiques pour les tokenizers des esclaves
 			shared_oaSecondPassSpecificTokens->GetObjectArray()->SetAt(nAttribute, oaCollectedTokens);
+			DisplayPerformanceIndicators(sTmp + "Specify specific tokens (var " +
+							 IntToString(nAttribute + 1) + ")",
+						     &oaMasterTextTokenizers);
 		}
+		DisplayPerformanceIndicators("End of specifying specific tokens", &oaMasterTextTokenizers);
 	}
 
 	//////////////////////////////////////////////////////////////////////////////////////////////
-	// Deuxieme passe de collecte des effectifs exact par tokens
+	// Deuxieme passe de collecte des effectifs exacts par tokens
 
 	// Personnalisation du libelle de la tache
 	SetTaskUserLabel(GetTaskName() + " (second pass)");
@@ -271,6 +275,7 @@ boolean KDTextTokenSampleCollectionTask::InternalCollectTokenSamples(const KWDat
 							 IntToString(nAttribute + 1) + ")",
 						     &oaMasterTextTokenizers);
 		}
+		DisplayPerformanceIndicators("End of token extraction and sort", &oaMasterTextTokenizers);
 	}
 
 	// Nettoyage
@@ -294,6 +299,7 @@ boolean KDTextTokenSampleCollectionTask::InternalCollectTokenSamples(const KWDat
 	shared_oaSecondPassSpecificTokens->Clean();
 
 	// Fin de la collecte des indicateurs de performance
+	DisplayPerformanceIndicators("Clean and end", &oaMasterTextTokenizers);
 	StopCollectPerformanceIndicators();
 	return bOk;
 }
@@ -350,7 +356,7 @@ void KDTextTokenSampleCollectionTask::DisplayPerformanceIndicators(const ALStrin
 
 	require(oaTokenizers != NULL);
 
-	// Affichage des performance si elles sont collectees
+	// Affichage des performances si elles sont collectees
 	if (lPerformanceInitialHeapMemory > 0)
 	{
 		// Calcul du nombre total de token collectes
@@ -544,20 +550,21 @@ boolean KDTextTokenSampleCollectionTask::MasterAggregateResults()
 {
 	boolean bOk;
 	const boolean bTrace = false;
+	const boolean bTraceTokens = false;
 	KWTextTokenizer* textTokenizer;
 	ObjectArray* oaCollectedTokens;
 	KWClass* kwcClass;
 	int nAttribute;
+	Timer traceTimer;
+	longint lTraceHeapMemory;
 
 	// Affichage
 	if (bTrace)
 	{
-		cout << GetTaskLabel() << "\t";
-		if (shared_bIsFirstPass)
-			cout << "First pass\n";
-		else
-			cout << "Second pass\n";
-		cout << "MasterAggregateResults\t" << GetTaskIndex() << "\n";
+		cout << GetTaskUserLabel() << "\tMasterAggregateResults\t" << GetTaskIndex() << "\t" << GetProcessId()
+		     << "\n";
+		traceTimer.Start();
+		lTraceHeapMemory = MemGetHeapMemory();
 	}
 
 	// Appel de la methode ancetre
@@ -585,15 +592,22 @@ boolean KDTextTokenSampleCollectionTask::MasterAggregateResults()
 			// Affichage
 			if (bTrace)
 			{
-				cout << kwcClass->GetUsedAttributeAt(nAttribute)->GetName() << "\t"
-				     << oaCollectedTokens->GetSize() << "\n";
-				KWTextTokenizer::DisplayHeadTokenArray(oaCollectedTokens, 10, cout);
+				cout << "- " << kwcClass->GetUsedAttributeAt(nAttribute)->GetName() << " tokens\t"
+				     << oaCollectedTokens->GetSize() << "\t" << textTokenizer->GetCollectedTokenNumber()
+				     << "\n";
+				if (bTraceTokens)
+					KWTextTokenizer::DisplayHeadTokenArray(oaCollectedTokens, 10, cout);
 			}
 
 			// Nettoyage
 			oaCollectedTokens->DeleteAll();
 		}
 		output_oaTokens->GetObjectArray()->DeleteAll();
+	}
+	if (bTrace)
+	{
+		cout << "- aggregation\t" << traceTimer.GetElapsedTime() << "\t"
+		     << LongintToHumanReadableString(MemGetHeapMemory() - lTraceHeapMemory) << "\n";
 	}
 	return bOk;
 }
@@ -660,12 +674,28 @@ boolean KDTextTokenSampleCollectionTask::SlaveInitialize()
 boolean KDTextTokenSampleCollectionTask::SlaveProcess()
 {
 	boolean bOk;
+	const boolean bTrace = false;
 	KWTextTokenizer* textTokenizer;
 	ObjectArray* oaCollectedTokens;
 	int nAttribute;
+	Timer traceTimer;
+	longint lTraceHeapMemory;
+
+	// Affichage
+	if (bTrace)
+	{
+		cout << GetTaskUserLabel() << "\tSlaveProcess\t" << GetTaskIndex() << "\t" << GetProcessId() << "\n";
+		traceTimer.Start();
+		lTraceHeapMemory = MemGetHeapMemory();
+	}
 
 	// Appel de la methode ancetre
 	bOk = KWDatabaseTask::SlaveProcess();
+	if (bTrace)
+	{
+		cout << "- tokenization\t" << traceTimer.GetElapsedTime() << "\t"
+		     << LongintToHumanReadableString(MemGetHeapMemory() - lTraceHeapMemory) << "\n";
+	}
 
 	// Collecte des tokens a renvoyer par l'esclave
 	if (bOk)
@@ -680,11 +710,19 @@ boolean KDTextTokenSampleCollectionTask::SlaveProcess()
 			oaCollectedTokens = new ObjectArray;
 			textTokenizer->ExportTokens(oaCollectedTokens);
 			output_oaTokens->GetObjectArray()->SetAt(nAttribute, oaCollectedTokens);
+			if (bTrace)
+				cout << "- variable " << nAttribute + 1 << " tokens\t" << oaCollectedTokens->GetSize()
+				     << "\n";
 
 			// Nettoyage du tokenizer : si l'esclave est appele plus d'une fois, alors
 			// il ne cumulera pas les tokens des appels precedents
 			textTokenizer->CleanCollectedTokens();
 		}
+	}
+	if (bTrace)
+	{
+		cout << "- token collection\t" << traceTimer.GetElapsedTime() << "\t"
+		     << LongintToHumanReadableString(MemGetHeapMemory() - lTraceHeapMemory) << "\n";
 	}
 	return bOk;
 }

--- a/src/Learning/KWData/KWTextTokenizer.cpp
+++ b/src/Learning/KWData/KWTextTokenizer.cpp
@@ -141,11 +141,66 @@ void KWTextTokenizer::CumulateTokenFrequencies(const ObjectArray* oaTokens)
 
 void KWTextTokenizer::ExportTokens(ObjectArray* oaTokenFrequencies) const
 {
+	const boolean bTrace = false;
+	POSITION position;
+	ALString sToken;
+	longint lValue;
+	int nSpecificTokenIndex;
+	KWTokenFrequency* token;
+	int nIndex;
+	Timer traceTimer;
+
 	require(not IsDeploymentMode());
+	require(gdCollectedTokens != NULL);
+	require(not gdCollectedTokens->IsObjectValue());
 	require(oaTokenFrequencies != NULL);
 	require(oaTokenFrequencies->GetSize() == 0);
 
-	ExportFrequentTokens(oaTokenFrequencies, GetCollectedTokenNumber());
+	// Debut de la trace
+	if (bTrace)
+	{
+		cout << "ExportTokens\n";
+		cout << "- MaxCollectedTokenNumber\t" << GetMaxCollectedTokenNumber() << "\n";
+		cout << "- collected tokens\t" << gdCollectedTokens->GetCount() << "\t"
+		     << LongintToHumanReadableString(gdCollectedTokens->GetOverallUsedMemory()) << "\n";
+		if (gdSpecificTokens != NULL)
+			cout << "- specific tokens\t" << gdSpecificTokens->GetCount() << "\t"
+			     << LongintToHumanReadableString(gdSpecificTokens->GetOverallUsedMemory()) << "\n";
+		traceTimer.Start();
+	}
+
+	// Cas sans tokens specifiques
+	if (gdSpecificTokens == NULL)
+	{
+		// Parcours des cles pour creer l'ensemble des tokens
+		oaTokenFrequencies->SetSize(gdCollectedTokens->GetCount());
+		nIndex = 0;
+		position = GetStartTokenPosition(gdCollectedTokens);
+		while (position != NULL)
+		{
+			GetNextToken(gdCollectedTokens, position, sToken, lValue);
+
+			// Creation et memorisation du token
+			token = new KWTokenFrequency;
+			token->SetToken(sToken);
+			token->SetFrequency(lValue);
+			oaTokenFrequencies->SetAt(nIndex, token);
+			nIndex++;
+		}
+		assert(nIndex == gdCollectedTokens->GetCount());
+	}
+	// Cas avec tokens specifiques
+	else
+		ExportSpecificTokens(oaTokenFrequencies);
+	if (bTrace)
+	{
+		traceTimer.Stop();
+		cout << "- exported tokens\t" << oaTokenFrequencies->GetSize() << "\t"
+		     << LongintToHumanReadableString(oaTokenFrequencies->GetOverallUsedMemory()) << "\n";
+		cout << "- export time\t" << traceTimer.GetElapsedTime() << "\n";
+		traceTimer.Reset();
+		traceTimer.Start();
+	}
 }
 
 void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int nMaxTokenNumber) const
@@ -174,6 +229,7 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 	if (bTrace)
 	{
 		cout << "ExportFrequentTokens\n";
+		cout << "- MaxCollectedTokenNumber\t" << GetMaxCollectedTokenNumber() << "\n";
 		cout << "- max tokens\t" << nMaxTokenNumber << "\n";
 		cout << "- collected tokens\t" << gdCollectedTokens->GetCount() << "\t"
 		     << LongintToHumanReadableString(gdCollectedTokens->GetOverallUsedMemory()) << "\n";
@@ -234,32 +290,7 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 	}
 	// Cas avec tokens specifiques
 	else
-	{
-		assert(gdCollectedTokens->GetCount() == 0);
-
-		// Initialisation du nombre de tokens a collecter sans contrainte d'effectif minimum
-		nCollectedTokenNumber = ivUsedSpecificTokenIndexes.GetSize();
-
-		// Parcours des tokens specifiques pour retrouver leur index et donc leur effectif
-		oaTokenFrequencies->SetSize(nCollectedTokenNumber);
-		nIndex = 0;
-		position = GetStartTokenPosition(gdSpecificTokens);
-		while (position != NULL)
-		{
-			GetNextToken(gdSpecificTokens, position, sToken, lValue);
-			nSpecificTokenIndex = (int)lValue;
-
-			// Creation et memorisation du token selon la contrainte d'effectif minimum
-			if (lvSpecificTokenFrequencies.GetAt(nSpecificTokenIndex) > 0)
-			{
-				token = new KWTokenFrequency;
-				token->SetToken(sToken);
-				token->SetFrequency(lvSpecificTokenFrequencies.GetAt(nSpecificTokenIndex));
-				oaTokenFrequencies->SetAt(nIndex, token);
-				nIndex++;
-			}
-		}
-	}
+		ExportSpecificTokens(oaTokenFrequencies);
 	if (bTrace)
 	{
 		traceTimer.Stop();
@@ -910,6 +941,39 @@ longint KWTextTokenizer::ComputeTotalTokenFrequency() const
 		lTotalTokenFrequency += lvSpecificTokenFrequencies.GetAt(nTokenIndex);
 	}
 	return lTotalTokenFrequency;
+}
+
+void KWTextTokenizer::ExportSpecificTokens(ObjectArray* oaTokenFrequencies) const
+{
+	int nIndex;
+	POSITION position;
+	ALString sToken;
+	longint lValue;
+	int nSpecificTokenIndex;
+	KWTokenFrequency* token;
+
+	require(gdSpecificTokens != NULL);
+	require(gdCollectedTokens->GetCount() == 0);
+
+	// Parcours des tokens specifiques pour retrouver leur index et donc leur effectif
+	oaTokenFrequencies->SetSize(ivUsedSpecificTokenIndexes.GetSize());
+	nIndex = 0;
+	position = GetStartTokenPosition(gdSpecificTokens);
+	while (position != NULL)
+	{
+		GetNextToken(gdSpecificTokens, position, sToken, lValue);
+		nSpecificTokenIndex = (int)lValue;
+
+		// Creation et memorisation du token selon la contrainte d'effectif minimum
+		if (lvSpecificTokenFrequencies.GetAt(nSpecificTokenIndex) > 0)
+		{
+			token = new KWTokenFrequency;
+			token->SetToken(sToken);
+			token->SetFrequency(lvSpecificTokenFrequencies.GetAt(nSpecificTokenIndex));
+			oaTokenFrequencies->SetAt(nIndex, token);
+			nIndex++;
+		}
+	}
 }
 
 POSITION KWTextTokenizer::GetStartTokenPosition(const GenericDictionary* gdDictionary) const

--- a/src/Learning/KWData/KWTextTokenizer.cpp
+++ b/src/Learning/KWData/KWTextTokenizer.cpp
@@ -121,6 +121,7 @@ void KWTextTokenizer::CumulateTokenFrequencies(const ObjectArray* oaTokens)
 	require(not IsDeploymentMode());
 	require(CheckParameters());
 	require(oaTokens != NULL);
+	require(gdCollectedTokens->GetCount() <= GetMaxCollectedTokenNumber());
 
 	// Prise en compte des effectifs des tokens
 	for (nToken = 0; nToken < oaTokens->GetSize(); nToken++)
@@ -130,6 +131,12 @@ void KWTextTokenizer::CumulateTokenFrequencies(const ObjectArray* oaTokens)
 		// Ajout de l'effectif du token
 		UpgradeTokenFrequency(token->GetToken(), token->GetFrequency());
 	}
+
+	// Nettoyage du dictionnaire de collecte pour ne garder que les tokens les plus frequents
+	// dans le cas sans tokens specifiques
+	if (gdSpecificTokens == NULL)
+		StreamCleanTokenDictionary(gdCollectedTokens, GetMaxCollectedTokenNumber());
+	ensure(gdCollectedTokens->GetCount() <= GetMaxCollectedTokenNumber());
 }
 
 void KWTextTokenizer::ExportTokens(ObjectArray* oaTokenFrequencies) const
@@ -1114,6 +1121,7 @@ void KWTextNgramTokenizer::CumulateTokenFrequencies(const ObjectArray* oaTokens)
 
 	require(CheckParameters());
 	require(oaTokens != NULL);
+	require(gdCollectedTokens->GetCount() <= GetMaxCollectedTokenNumber());
 
 	// Prise en compte des effectifs des tokens
 	for (nToken = 0; nToken < oaTokens->GetSize(); nToken++)
@@ -1124,6 +1132,12 @@ void KWTextNgramTokenizer::CumulateTokenFrequencies(const ObjectArray* oaTokens)
 		lEncodedNgram = NgramToLongint(token->GetToken());
 		UpgradeNgramTokenFrequency(lEncodedNgram, token->GetFrequency());
 	}
+
+	// Nettoyage du dictionnaire de collecte pour ne garder que les tokens les plus frequents
+	// dans le cas sans tokens specifiques
+	if (gdSpecificTokens == NULL)
+		StreamCleanTokenDictionary(gdCollectedTokens, GetMaxCollectedTokenNumber());
+	ensure(gdCollectedTokens->GetCount() <= GetMaxCollectedTokenNumber());
 }
 
 void KWTextNgramTokenizer::SetDeploymentTokens(const StringVector* svDeploymentTokens)

--- a/src/Learning/KWData/KWTextTokenizer.cpp
+++ b/src/Learning/KWData/KWTextTokenizer.cpp
@@ -152,10 +152,8 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 {
 	const boolean bTrace = false;
 	const int nMaxCollectedFrequency = 1000;
-	const LongintDictionary* ldCollectedTokens;
-	const LongintDictionary* ldSpecificTokens;
 	POSITION position;
-	ALString sKey;
+	ALString sToken;
 	longint lValue;
 	IntVector ivNumbersOfTokensPerFrequency;
 	int nMinFrequency;
@@ -167,7 +165,6 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 
 	require(not IsDeploymentMode());
 	require(gdCollectedTokens != NULL);
-	require(gdCollectedTokens->IsStringKey());
 	require(not gdCollectedTokens->IsObjectValue());
 	require(nMaxTokenNumber >= 0);
 	require(oaTokenFrequencies != NULL);
@@ -186,12 +183,8 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 		traceTimer.Start();
 	}
 
-	// Choix du type de dictionnaire selon le type de cle
-	ldCollectedTokens = cast(const LongintDictionary*, gdCollectedTokens);
-	ldSpecificTokens = cast(const LongintDictionary*, gdSpecificTokens);
-
 	// Cas sans tokens specifiques
-	if (ldSpecificTokens == NULL)
+	if (gdSpecificTokens == NULL)
 	{
 		// Initialisation du nombre de tokens a collecter sans contrainte d'effectif minimum
 		nCollectedTokenNumber = gdCollectedTokens->GetCount();
@@ -217,21 +210,21 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 				   nMaxTokenNumber);
 		}
 
-		// Parcours des cles pour creer l'ensemble des tokens, en ne gardant que ceux ayant un effectif minimum
-		// suffisant
+		// Parcours des cles pour creer l'ensemble des tokens, en ne gardant que ceux
+		// ayant un effectif minimum suffisant
 		assert(nMinFrequency > 0 or nCollectedTokenNumber == gdCollectedTokens->GetCount());
 		oaTokenFrequencies->SetSize(nCollectedTokenNumber);
 		nIndex = 0;
-		position = ldCollectedTokens->GetStartPosition();
+		position = GetStartTokenPosition(gdCollectedTokens);
 		while (position != NULL)
 		{
-			ldCollectedTokens->GetNextAssoc(position, sKey, lValue);
+			GetNextToken(gdCollectedTokens, position, sToken, lValue);
 
 			// Creation et memorisation du token selon la contrainte d'effectif minimum
 			if (lValue >= nMinFrequency)
 			{
 				token = new KWTokenFrequency;
-				token->SetToken(sKey);
+				token->SetToken(sToken);
 				token->SetFrequency(lValue);
 				oaTokenFrequencies->SetAt(nIndex, token);
 				nIndex++;
@@ -250,17 +243,17 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 		// Parcours des tokens specifiques pour retrouver leur index et donc leur effectif
 		oaTokenFrequencies->SetSize(nCollectedTokenNumber);
 		nIndex = 0;
-		position = ldSpecificTokens->GetStartPosition();
+		position = GetStartTokenPosition(gdSpecificTokens);
 		while (position != NULL)
 		{
-			ldSpecificTokens->GetNextAssoc(position, sKey, lValue);
+			GetNextToken(gdSpecificTokens, position, sToken, lValue);
 			nSpecificTokenIndex = (int)lValue;
 
 			// Creation et memorisation du token selon la contrainte d'effectif minimum
 			if (lvSpecificTokenFrequencies.GetAt(nSpecificTokenIndex) > 0)
 			{
 				token = new KWTokenFrequency;
-				token->SetToken(sKey);
+				token->SetToken(sToken);
 				token->SetFrequency(lvSpecificTokenFrequencies.GetAt(nSpecificTokenIndex));
 				oaTokenFrequencies->SetAt(nIndex, token);
 				nIndex++;
@@ -919,6 +912,23 @@ longint KWTextTokenizer::ComputeTotalTokenFrequency() const
 	return lTotalTokenFrequency;
 }
 
+POSITION KWTextTokenizer::GetStartTokenPosition(const GenericDictionary* gdDictionary) const
+{
+	require(gdDictionary != NULL);
+	require(gdDictionary->IsStringKey());
+	require(not gdDictionary->IsObjectValue());
+	return cast(const LongintDictionary*, gdDictionary)->GetStartPosition();
+}
+
+void KWTextTokenizer::GetNextToken(const GenericDictionary* gdDictionary, POSITION& rNextPosition, ALString& sToken,
+				   longint& lValue) const
+{
+	require(gdDictionary != NULL);
+	require(gdDictionary->IsStringKey());
+	require(not gdDictionary->IsObjectValue());
+	cast(const LongintDictionary*, gdDictionary)->GetNextAssoc(rNextPosition, sToken, lValue);
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 // Classe KWTextNgramTokenizer
 
@@ -971,146 +981,6 @@ void KWTextNgramTokenizer::SetSpecificTokens(const ObjectArray* oaTokens)
 		}
 		assert(gdSpecificTokens->GetCount() == oaTokens->GetSize());
 	}
-}
-
-void KWTextNgramTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int nMaxTokenNumber) const
-{
-	const boolean bTrace = false;
-	const int nMaxCollectedFrequency = 1000;
-	const LongintNumericKeyDictionary* lnkdCollectedTokens;
-	const LongintNumericKeyDictionary* lnkdSpecificTokens;
-	POSITION position;
-	NUMERIC numericKey;
-	longint lValue;
-	IntVector ivNumbersOfTokensPerFrequency;
-	int nMinFrequency;
-	int nCollectedTokenNumber;
-	int nSpecificTokenIndex;
-	KWTokenFrequency* token;
-	int nIndex;
-	Timer traceTimer;
-
-	require(gdCollectedTokens != NULL);
-	require(not gdCollectedTokens->IsStringKey());
-	require(not gdCollectedTokens->IsObjectValue());
-	require(nMaxTokenNumber >= 0);
-	require(oaTokenFrequencies != NULL);
-	require(oaTokenFrequencies->GetSize() == 0);
-
-	// Debut de la trace
-	if (bTrace)
-	{
-		cout << "ExportFrequentTokens\n";
-		cout << "- max tokens\t" << nMaxTokenNumber << "\n";
-		cout << "- collected tokens\t" << gdCollectedTokens->GetCount() << "\t"
-		     << LongintToHumanReadableString(gdCollectedTokens->GetOverallUsedMemory()) << "\n";
-		if (gdSpecificTokens != NULL)
-			cout << "- specific tokens\t" << gdSpecificTokens->GetCount() << "\t"
-			     << LongintToHumanReadableString(gdSpecificTokens->GetOverallUsedMemory()) << "\n";
-		traceTimer.Start();
-	}
-
-	// Choix du type de dictionnaire selon le type de cle
-	lnkdCollectedTokens = cast(const LongintNumericKeyDictionary*, gdCollectedTokens);
-	lnkdSpecificTokens = cast(const LongintNumericKeyDictionary*, gdSpecificTokens);
-
-	// Cas sans tokens specifiques
-	if (lnkdSpecificTokens == NULL)
-	{
-		// Initialisation du nombre de tokens a collecter sans contrainte d'effectif minimum
-		nCollectedTokenNumber = gdCollectedTokens->GetCount();
-		nMinFrequency = 0;
-
-		// Si necessaire, passe prealabale de collecte des stats sur les nombres de tokens par effectif
-		if (gdCollectedTokens->GetCount() > 2 * nMaxTokenNumber)
-		{
-			// Calcul des stats par effectif de token
-			ComputeTokenDictionaryFrequencyStats(gdCollectedTokens, nMaxCollectedFrequency,
-							     &ivNumbersOfTokensPerFrequency);
-
-			// On determine l'effectif minimum suffisant pour collecter les tokens les plus frequents
-			for (nMinFrequency = 1; nMinFrequency <= nMaxCollectedFrequency; nMinFrequency++)
-			{
-				if (nCollectedTokenNumber - ivNumbersOfTokensPerFrequency.GetAt(nMinFrequency) >=
-				    nMaxTokenNumber)
-					nCollectedTokenNumber -= ivNumbersOfTokensPerFrequency.GetAt(nMinFrequency);
-				else
-					break;
-			}
-		}
-
-		// Parcours des cles pour creer l'ensemble des tokens, en ne gardant que ceux ayant un effectif minimum
-		// suffisant
-		assert(nMinFrequency > 0 or nCollectedTokenNumber == gdCollectedTokens->GetCount());
-		oaTokenFrequencies->SetSize(nCollectedTokenNumber);
-		nIndex = 0;
-		position = lnkdCollectedTokens->GetStartPosition();
-		while (position != NULL)
-		{
-			lnkdCollectedTokens->GetNextAssoc(position, numericKey, lValue);
-
-			// Creation et memorisation du token de type ngrams selon la contrainte d'effectif minimum
-			if (lValue >= nMinFrequency)
-			{
-				token = new KWTokenFrequency;
-				token->SetToken(LongintToNgram(numericKey.ToLongint()));
-				token->SetFrequency(lValue);
-				oaTokenFrequencies->SetAt(nIndex, token);
-				nIndex++;
-			}
-		}
-	}
-	// Cas avec tokens specifiques
-	else
-	{
-		assert(gdCollectedTokens->GetCount() == 0);
-
-		// Initialisation du nombre de tokens a collecter sans contrainte d'effectif minimum
-		nCollectedTokenNumber = ivUsedSpecificTokenIndexes.GetSize();
-
-		// Parcours des tokens specifiques pour retrouver leur index et donc leur effectif
-		oaTokenFrequencies->SetSize(nCollectedTokenNumber);
-		nIndex = 0;
-		position = lnkdSpecificTokens->GetStartPosition();
-		while (position != NULL)
-		{
-			lnkdSpecificTokens->GetNextAssoc(position, numericKey, lValue);
-			nSpecificTokenIndex = (int)lValue;
-
-			// Creation et memorisation du token de type ngrams selon la contrainte d'effectif minimum
-			if (lvSpecificTokenFrequencies.GetAt(nSpecificTokenIndex) > 0)
-			{
-				token = new KWTokenFrequency;
-				token->SetToken(LongintToNgram(numericKey.ToLongint()));
-				token->SetFrequency(lvSpecificTokenFrequencies.GetAt(nSpecificTokenIndex));
-				oaTokenFrequencies->SetAt(nIndex, token);
-				nIndex++;
-			}
-		}
-	}
-	if (bTrace)
-	{
-		traceTimer.Stop();
-		cout << "- exported tokens\t" << oaTokenFrequencies->GetSize() << "\t"
-		     << LongintToHumanReadableString(oaTokenFrequencies->GetOverallUsedMemory()) << "\n";
-		cout << "- export time\t" << traceTimer.GetElapsedTime() << "\n";
-		traceTimer.Reset();
-		traceTimer.Start();
-	}
-
-	// Tri du tableau
-	SortTokenArray(oaTokenFrequencies);
-	if (bTrace)
-	{
-		cout << "- sort time\t" << traceTimer.GetElapsedTime() << "\n";
-		traceTimer.Reset();
-		traceTimer.Start();
-	}
-
-	// Filtrage de la fin du tableau apres le tri
-	FilterTokenArray(oaTokenFrequencies, nMaxTokenNumber);
-	if (bTrace)
-		cout << "- filter time\t" << traceTimer.GetElapsedTime() << "\n";
 }
 
 void KWTextNgramTokenizer::CumulateTokenFrequencies(const ObjectArray* oaTokens)
@@ -1373,6 +1243,26 @@ void KWTextNgramTokenizer::UpgradeNgramTokenFrequency(longint lEncodedNgram, lon
 			lvSpecificTokenFrequencies.UpgradeAt(nSpecificTokenIndex, lFrequency);
 		}
 	}
+}
+
+POSITION KWTextNgramTokenizer::GetStartTokenPosition(const GenericDictionary* gdDictionary) const
+{
+	require(gdDictionary != NULL);
+	require(not gdDictionary->IsStringKey());
+	require(not gdDictionary->IsObjectValue());
+	return cast(const LongintNumericKeyDictionary*, gdDictionary)->GetStartPosition();
+}
+
+void KWTextNgramTokenizer::GetNextToken(const GenericDictionary* gdDictionary, POSITION& rNextPosition,
+					ALString& sToken, longint& lValue) const
+{
+	NUMERIC numericKey;
+
+	require(gdDictionary != NULL);
+	require(not gdDictionary->IsStringKey());
+	require(not gdDictionary->IsObjectValue());
+	cast(const LongintNumericKeyDictionary*, gdDictionary)->GetNextAssoc(rNextPosition, numericKey, lValue);
+	sToken = LongintToNgram(numericKey.ToLongint());
 }
 
 longint KWTextNgramTokenizer::NgramToLongint(const ALString& sNgramBytes)

--- a/src/Learning/KWData/KWTextTokenizer.cpp
+++ b/src/Learning/KWData/KWTextTokenizer.cpp
@@ -143,6 +143,7 @@ void KWTextTokenizer::ExportTokens(ObjectArray* oaTokenFrequencies) const
 
 void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int nMaxTokenNumber) const
 {
+	const boolean bTrace = false;
 	const int nMaxCollectedFrequency = 1000;
 	const LongintDictionary* ldCollectedTokens;
 	const LongintDictionary* ldSpecificTokens;
@@ -155,6 +156,7 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 	int nSpecificTokenIndex;
 	KWTokenFrequency* token;
 	int nIndex;
+	Timer traceTimer;
 
 	require(not IsDeploymentMode());
 	require(gdCollectedTokens != NULL);
@@ -163,6 +165,19 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 	require(nMaxTokenNumber >= 0);
 	require(oaTokenFrequencies != NULL);
 	require(oaTokenFrequencies->GetSize() == 0);
+
+	// Debut de la trace
+	if (bTrace)
+	{
+		cout << "ExportFrequentTokens\n";
+		cout << "- max tokens\t" << nMaxTokenNumber << "\n";
+		cout << "- collected tokens\t" << gdCollectedTokens->GetCount() << "\t"
+		     << LongintToHumanReadableString(gdCollectedTokens->GetOverallUsedMemory()) << "\n";
+		if (gdSpecificTokens != NULL)
+			cout << "- specific tokens\t" << gdSpecificTokens->GetCount() << "\t"
+			     << LongintToHumanReadableString(gdSpecificTokens->GetOverallUsedMemory()) << "\n";
+		traceTimer.Start();
+	}
 
 	// Choix du type de dictionnaire selon le type de cle
 	ldCollectedTokens = cast(const LongintDictionary*, gdCollectedTokens);
@@ -245,9 +260,29 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 			}
 		}
 	}
-	// Filtrage de la fin du tableau apres tri
+	if (bTrace)
+	{
+		traceTimer.Stop();
+		cout << "- exported tokens\t" << oaTokenFrequencies->GetSize() << "\t"
+		     << LongintToHumanReadableString(oaTokenFrequencies->GetOverallUsedMemory()) << "\n";
+		cout << "- export time\t" << traceTimer.GetElapsedTime() << "\n";
+		traceTimer.Reset();
+		traceTimer.Start();
+	}
+
+	// Tri du tableau
 	SortTokenArray(oaTokenFrequencies);
+	if (bTrace)
+	{
+		cout << "- sort time\t" << traceTimer.GetElapsedTime() << "\n";
+		traceTimer.Reset();
+		traceTimer.Start();
+	}
+
+	// Filtrage de la fin du tableau apres le tri
 	FilterTokenArray(oaTokenFrequencies, nMaxTokenNumber);
+	if (bTrace)
+		cout << "- filter time\t" << traceTimer.GetElapsedTime() << "\n";
 }
 
 void KWTextTokenizer::CleanCollectedTokens()
@@ -933,6 +968,7 @@ void KWTextNgramTokenizer::SetSpecificTokens(const ObjectArray* oaTokens)
 
 void KWTextNgramTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int nMaxTokenNumber) const
 {
+	const boolean bTrace = false;
 	const int nMaxCollectedFrequency = 1000;
 	const LongintNumericKeyDictionary* lnkdCollectedTokens;
 	const LongintNumericKeyDictionary* lnkdSpecificTokens;
@@ -945,6 +981,7 @@ void KWTextNgramTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies,
 	int nSpecificTokenIndex;
 	KWTokenFrequency* token;
 	int nIndex;
+	Timer traceTimer;
 
 	require(gdCollectedTokens != NULL);
 	require(not gdCollectedTokens->IsStringKey());
@@ -952,6 +989,19 @@ void KWTextNgramTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies,
 	require(nMaxTokenNumber >= 0);
 	require(oaTokenFrequencies != NULL);
 	require(oaTokenFrequencies->GetSize() == 0);
+
+	// Debut de la trace
+	if (bTrace)
+	{
+		cout << "ExportFrequentTokens\n";
+		cout << "- max tokens\t" << nMaxTokenNumber << "\n";
+		cout << "- collected tokens\t" << gdCollectedTokens->GetCount() << "\t"
+		     << LongintToHumanReadableString(gdCollectedTokens->GetOverallUsedMemory()) << "\n";
+		if (gdSpecificTokens != NULL)
+			cout << "- specific tokens\t" << gdSpecificTokens->GetCount() << "\t"
+			     << LongintToHumanReadableString(gdSpecificTokens->GetOverallUsedMemory()) << "\n";
+		traceTimer.Start();
+	}
 
 	// Choix du type de dictionnaire selon le type de cle
 	lnkdCollectedTokens = cast(const LongintNumericKeyDictionary*, gdCollectedTokens);
@@ -1031,10 +1081,29 @@ void KWTextNgramTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies,
 			}
 		}
 	}
+	if (bTrace)
+	{
+		traceTimer.Stop();
+		cout << "- exported tokens\t" << oaTokenFrequencies->GetSize() << "\t"
+		     << LongintToHumanReadableString(oaTokenFrequencies->GetOverallUsedMemory()) << "\n";
+		cout << "- export time\t" << traceTimer.GetElapsedTime() << "\n";
+		traceTimer.Reset();
+		traceTimer.Start();
+	}
 
-	// Filtrage de la fin du tableau apres tri
+	// Tri du tableau
 	SortTokenArray(oaTokenFrequencies);
+	if (bTrace)
+	{
+		cout << "- sort time\t" << traceTimer.GetElapsedTime() << "\n";
+		traceTimer.Reset();
+		traceTimer.Start();
+	}
+
+	// Filtrage de la fin du tableau apres le tri
 	FilterTokenArray(oaTokenFrequencies, nMaxTokenNumber);
+	if (bTrace)
+		cout << "- filter time\t" << traceTimer.GetElapsedTime() << "\n";
 }
 
 void KWTextNgramTokenizer::CumulateTokenFrequencies(const ObjectArray* oaTokens)

--- a/src/Learning/KWData/KWTextTokenizer.h
+++ b/src/Learning/KWData/KWTextTokenizer.h
@@ -82,7 +82,7 @@ public:
 	void TokenizeSymbolVector(const SymbolVector* svValues);
 
 	// Prise en compte des effectifs d'un tableau de tokens pour mettre a jour les effectifs globaux des tokens
-	// collectes, tout en respectant le nombre max de token a collecter
+	// collectes, tout en respectant le nombre max de tokens a collecter
 	virtual void CumulateTokenFrequencies(const ObjectArray* oaTokens);
 
 	///////////////////////////////////////////////////////////////////////////////////////////////
@@ -92,12 +92,13 @@ public:
 	// Nombre de tokens collectes
 	int GetCollectedTokenNumber() const;
 
-	// Export de l'ensemble des tokens extraits (KWTokenFrequency)
-	// Les tokens sont extraits effectifs decroissants, puis longueur de token croissante, puis token croissant,
-	// Memoire: les tokens du tableau en sortie appartiennent a l'appelant
+	// Export de l'ensemble des tokens extraits (KWTokenFrequency), sans garantie d'ordre des tokens extraits
 	void ExportTokens(ObjectArray* oaTokenFrequencies) const;
 
 	// Variante de la methode en se limitant aux tokens les plus frequents
+	// Les tokens sont extraits effectifs decroissants, puis longueur de token croissante, puis valeur
+	// de token croissant selon un ordre lexicographique
+	// Memoire: les tokens du tableau en sortie appartiennent a l'appelant
 	void ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int nMaxTokenNumber) const;
 
 	// Nettoyage des tokens collectes
@@ -297,6 +298,9 @@ protected:
 
 	// Calcul de l'effectif total cumule des tokens
 	longint ComputeTotalTokenFrequency() const;
+
+	// Export de l'ensemble des tokens specifiques extraits (KWTokenFrequency), sans garantie d'ordre des tokens extraits
+	void ExportSpecificTokens(ObjectArray* oaTokenFrequencies) const;
 
 	// Parcours de toutes les paires (token, value) d'un dictionnaire de token
 	// Ce parcours est fait de facon generique pour tous les types de dictionnaires de token

--- a/src/Learning/KWData/KWTextTokenizer.h
+++ b/src/Learning/KWData/KWTextTokenizer.h
@@ -82,7 +82,7 @@ public:
 	void TokenizeSymbolVector(const SymbolVector* svValues);
 
 	// Prise en compte des effectifs d'un tableau de tokens pour mettre a jour les effectifs globaux des tokens
-	// collectes
+	// collectes, tout en respectant le nombre max de token a collecter
 	virtual void CumulateTokenFrequencies(const ObjectArray* oaTokens);
 
 	///////////////////////////////////////////////////////////////////////////////////////////////
@@ -305,8 +305,8 @@ protected:
 	GenericDictionary* gdSpecificTokens;
 
 	// Vecteur des effectifs par token specifique
-	// Ce vecteur sert egalement d'indicateur d'utilisation par token specifique, en testant si l'effectif est non
-	// nul
+	// Ce vecteur sert egalement d'indicateur d'utilisation par token specifique,
+	// en testant si l'effectif est non nul
 	LongintVector lvSpecificTokenFrequencies;
 
 	// Memorisation des index des tokens specifiques effectivement utilises

--- a/src/Learning/KWData/KWTextTokenizer.h
+++ b/src/Learning/KWData/KWTextTokenizer.h
@@ -98,7 +98,7 @@ public:
 	void ExportTokens(ObjectArray* oaTokenFrequencies) const;
 
 	// Variante de la methode en se limitant aux tokens les plus frequents
-	virtual void ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int nMaxTokenNumber) const;
+	void ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int nMaxTokenNumber) const;
 
 	// Nettoyage des tokens collectes
 	void CleanCollectedTokens();
@@ -298,6 +298,12 @@ protected:
 	// Calcul de l'effectif total cumule des tokens
 	longint ComputeTotalTokenFrequency() const;
 
+	// Parcours de toutes les paires (token, value) d'un dictionnaire de token
+	// Ce parcours est fait de facon generique pour tous les types de dictionnaires de token
+	virtual POSITION GetStartTokenPosition(const GenericDictionary*) const;
+	virtual void GetNextToken(const GenericDictionary*, POSITION& rNextPosition, ALString& sToken,
+				  longint& lValue) const;
+
 	// Dictionnaire generique de longint definissant les tokens specifiques a collecter avec
 	// une paire (token, index) par token a collecter
 	// Les index commencent a 1 pour se distinguer de la valeur 0, qui signifie absent du dictionnaire
@@ -336,7 +342,6 @@ public:
 
 	// Redefinition des methodes virtuelles
 	void SetSpecificTokens(const ObjectArray* oaTokens) override;
-	void ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int nMaxTokenNumber) const override;
 	void CumulateTokenFrequencies(const ObjectArray* oaTokens) override;
 	void SetDeploymentTokens(const StringVector* svDeploymentTokens) override;
 
@@ -357,6 +362,11 @@ protected:
 
 	// Mise a jour de l'effectif d'un token de type ngrams
 	void UpgradeNgramTokenFrequency(longint lEncodedNgram, longint lFrequency);
+
+	// Parcours de toutes les paires (token, frequency) d'un dictionnaire de token
+	POSITION GetStartTokenPosition(const GenericDictionary* gdDictionary) const override;
+	void GetNextToken(const GenericDictionary* gdDictionary, POSITION& rNextPosition, ALString& sToken,
+			  longint& lValue) const override;
 
 	//////////////////////////////////////////////////////////////////////////////////////////
 	// Gestion optimisee des ngrams

--- a/src/Learning/KWDataPreparation/KWDRDataGridBlock.cpp
+++ b/src/Learning/KWDataPreparation/KWDRDataGridBlock.cpp
@@ -38,6 +38,12 @@ KWDRDataGridBlock::KWDRDataGridBlock()
 	nOptimizationFreshness = 0;
 	nDataGridAttributeNumber = 0;
 	nDataGridVarKeyType = KWType::Unknown;
+
+	// Initialisation de la valeur standard correspondant a la StarValue
+	// Attention, bien que Symbol::GetStarValue() et sStandardStarValue soient
+	// toutes deux des Symbol ayant la meme valeur, il ne faut pas les confondre.
+	// Voir KWSymbolData::GetStarValue() pour plus de precision
+	sStandardStarValue = Symbol(Symbol::GetStarValue().GetValue());
 }
 
 KWDRDataGridBlock::~KWDRDataGridBlock() {}
@@ -554,8 +560,8 @@ boolean KWDRDataGridBlockRule::CheckOperandsCompleteness(const KWClass* kwcOwner
 						// Erreur si cle absente
 						if (nSourceIndex == -1)
 						{
-							AddError(sTmp + "VarKey " + sKey.GetValue() +
-								 " in data grid block first operand is missing in "
+							AddError(sTmp + "VarKey \"" + sKey.GetValue() +
+								 "\" in data grid block first operand is missing in "
 								 "value block second operand");
 							bOk = false;
 							break;
@@ -1198,10 +1204,9 @@ boolean KWDRCellIndexBlock::CheckBlockAttributesAt(const KWClass* kwcOwnerClass,
 				if (not bVarKeyFound)
 				{
 					sExternalVarKey = attributeBlock->GetStringVarKey(checkedAttribute);
-					attributeBlock->AddError("Variable " + checkedAttribute->GetName() +
-								 +" not found with its VarKey=" + sExternalVarKey +
-								 " in data grid block first operand of rule " +
-								 GetName());
+					attributeBlock->AddError(
+					    "Variable " + checkedAttribute->GetName() + " not found with its VarKey " +
+					    sExternalVarKey + " in data grid block first operand of rule " + GetName());
 					bOk = false;
 					break;
 				}

--- a/src/Learning/KWDataPreparation/KWDRDataGridBlock.h
+++ b/src/Learning/KWDataPreparation/KWDRDataGridBlock.h
@@ -117,6 +117,17 @@ protected:
 
 	// Fraicheur d'optimisation
 	int nOptimizationFreshness;
+
+	// Valeur standard correspondant a la StarValue
+	// La StarValue designe toute valeur autre qu'une valeur utilisateur provenant
+	// des donnees pour representer toutes les valeurs non vues en apprentissage.
+	// Le premier operande de type ValueSetC du DataGridBlock peut alors comporter
+	// une valeur coincidant avec la StarValue, alors que c'est la valeur utilisateur
+	// correspondante qu'il faut utiliser.
+	// On memorise cette valeur standard pour remplacer la StarValue a la volee
+	// par la valeur standard correspondant dans l'acces aux valeurs du ValueSetC
+	// Cela permet de reutiliser la regle ValueSetC avec une adaptation minimale.
+	Symbol sStandardStarValue;
 };
 
 ///////////////////////////////////////////////////////////////
@@ -392,10 +403,14 @@ inline int KWDRDataGridBlock::GetDataGridVarKeyType() const
 
 inline Symbol KWDRDataGridBlock::GetSymbolVarKeyAt(int nIndex) const
 {
+	Symbol sVarKey;
 	require(IsCompiled());
 	require(nDataGridVarKeyType == KWType::Symbol);
 	require(0 <= nIndex and nIndex < GetDataGridNumber());
-	return cast(KWDRSymbolValueSet*, GetFirstOperand()->GetDerivationRule())->GetValueAt(nIndex);
+	sVarKey = cast(KWDRSymbolValueSet*, GetFirstOperand()->GetDerivationRule())->GetValueAt(nIndex);
+	if (sVarKey == Symbol::GetStarValue())
+		sVarKey = sStandardStarValue;
+	return sVarKey;
 }
 
 inline int KWDRDataGridBlock::GetContinuousVarKeyAt(int nIndex) const
@@ -420,13 +435,19 @@ inline int KWDRDataGridBlock::GetUncheckedDataGridNumber() const
 
 inline Symbol KWDRDataGridBlock::GetUncheckedSymbolVarKeyAt(int nIndex) const
 {
+	Symbol sVarKey;
+
 	require(GetUncheckedDataGridVarKeyType() == KWType::Symbol);
 	require(0 <= nIndex and nIndex < GetUncheckedVarKeyNumber());
-	return cast(KWDRSymbolValueSet*, GetFirstOperand()->GetDerivationRule())->GetValueAt(nIndex);
+	sVarKey = cast(KWDRSymbolValueSet*, GetFirstOperand()->GetDerivationRule())->GetValueAt(nIndex);
+	if (sVarKey == Symbol::GetStarValue())
+		sVarKey = sStandardStarValue;
+	return sVarKey;
 }
 
 inline int KWDRDataGridBlock::GetUncheckedContinuousVarKeyAt(int nIndex) const
 {
+
 	require(GetUncheckedDataGridVarKeyType() == KWType::Continuous);
 	require(0 <= nIndex and nIndex < GetUncheckedVarKeyNumber());
 	return (int)cast(KWDRContinuousValueSet*, GetFirstOperand()->GetDerivationRule())->GetValueAt(nIndex);

--- a/src/Parallel/PLParallelTask/PLParallelTask.h
+++ b/src/Parallel/PLParallelTask/PLParallelTask.h
@@ -819,10 +819,10 @@ private:
 
 	// Titres de la barre de progression pendant les differentes phases de la tache parallele
 	const ALString PROGRESSION_MSG_MASTER_INITIALIZE = "Initialization";
-	const ALString PROGRESSION_MSG_MASTER_FINALIZE = "finalization";
-	const ALString PROGRESSION_MSG_SLAVE_INITIALIZE = "workers initialization";
-	const ALString PROGRESSION_MSG_SLAVE_FINALIZE = "workers finalization";
-	const ALString PROGRESSION_MSG_PROCESSING = "processing";
+	const ALString PROGRESSION_MSG_MASTER_FINALIZE = "Finalization";
+	const ALString PROGRESSION_MSG_SLAVE_INITIALIZE = "Workers initialization";
+	const ALString PROGRESSION_MSG_SLAVE_FINALIZE = "Workers finalization";
+	const ALString PROGRESSION_MSG_PROCESSING = "Processing";
 
 	// Classes et fonctions friend
 	friend class PLMaster;

--- a/test/LearningTestTool/kht_shell.cmd
+++ b/test/LearningTestTool/kht_shell.cmd
@@ -1,8 +1,14 @@
-#echo off
-REM Start dos shell with the LearningTestTool command files in the path
+@echo off
+REM Start a shell with the LearningTestTool command files in the PATH
+REM Usage: start-learningtest.cmd [starting-directory]
+REM If no directory is provided, starts in ..\LearningTest relative to the script.
 
-REM Add LearningTest script cmd dir in the path
-set path=%~dp0cmd;%path%
+REM Add the script's cmd directory to the PATH
+set "path=%~dp0cmd;%path%"
 
-REM Open a new shell with given title and starting directory
-start "%~n0" /D "%~dp0..\LearningTest"
+REM Open a new window (title = script name) and set the working directory without creating START_DIR
+if "%~1"=="" (
+  start "%~n0" /D "%~dp0..\LearningTest" cmd
+) else (
+  start "%~n0" /D "%~1" cmd
+)


### PR DESCRIPTION
Corrige le bug d'optimisation de la tokenization.
- le MasterAgregateResults se contentait d'agréger les tokens, sans ne garder que les plus fréquents

Autres points mineurs 
- spécialisation du libellé de la tâche selon la première ou deuxième passe de tokenisation
- ajout de trace dans quelques méthode
- refactoring d'une méthode pour mutualisation entre les versions token et ngram
- amélioration des performances en évitant les tri inutiles
- plus un point de commit de détail concernant kht_shell.cmd (pour éviter une PR à part

Tests massifs concluant:
- plus d'utilisation intempestive de mémoire
- performance s'améliorant avec le nombre de coeurs

Non traité dans cette PR: l'éventuel bug du dictionnaire invalide de SNB, qui sera traité dans une autre PR s'il est reproduit après les corrections

Après vérification, l'implémentation paralléle de la tokenisation résout le problème de l'issue https://github.com/KhiopsML/khiops/issues/1027, qui pourra donc être fermée