### PR TITLE
Fix compiler warning on Windows

### DIFF
--- a/src/Learning/DTForest/DTGrouperMODL.cpp
+++ b/src/Learning/DTForest/DTGrouperMODL.cpp
@@ -2311,11 +2311,12 @@ IntVector* DTGrouperMODL::OptimizeGroupsWithGarbageSearch(int nExactGroupNumber,
 		for (i = 0; i < oaInitialGroups->GetSize(); i++)
 			cout << *cast(KWMODLGroup*, oaInitialGroups->GetAt(i));
 	}
-
-	if (bTraceGarbage and nExactGroupNumber == 0)
-		cout << "Nbre optimal de groupes avant degradation (avec ou sans poub) \tSANS poubelle\t"
-		     << nOptimumGroupNumber << "\t AVEC poubelle \t" << nOptimumGroupNumberWithGarbage << endl;
-
+	if (bTraceGarbage)
+	{
+		if (nExactGroupNumber == 0)
+			cout << "Nbre optimal de groupes avant degradation (avec ou sans poub) \tSANS poubelle\t"
+			     << nOptimumGroupNumber << "\t AVEC poubelle \t" << nOptimumGroupNumberWithGarbage << endl;
+	}
 	ensure(nExactGroupNumber == 0 or nExactGroupNumber == nGroupNumber);
 
 	// Memorisation du vecteur des tailles optimales des partitions avec et sans poubelle

--- a/src/Learning/DTForest/DTGrouperMODLInternal.cpp
+++ b/src/Learning/DTForest/DTGrouperMODLInternal.cpp
@@ -763,7 +763,7 @@ KWMODLLine* DTGrouperMODLTwoClasses::IntervalListOptimizationWithGarbage(
 		cout << kwftSource->GetTotalFrequency() << "\t" << kwftSource->GetFrequencyVectorNumber() << "\t"
 		     << nMergeNumber << "\t" << nExtraMergeNumber << "\t" << nSplitNumber << "\t" << nExtraSplitNumber
 		     << "\t" << nMergeSplitNumber << "\t" << nMergeMergeSplitNumber << "\t"
-		     << GetIntervalListSize(headInterval);
+		     << GetIntervalListSize(headInterval) << endl;
 	}
 
 	// Affichage des resultats
@@ -787,13 +787,11 @@ KWMODLLine* DTGrouperMODLTwoClasses::IntervalListOptimizationWithGarbage(
 		// Effectifs des intervalles
 		for (nInterval = 0; nInterval < kwftTarget->GetFrequencyVectorNumber(); nInterval++)
 			cout << "\t" << kwftTarget->GetFrequencyVectorAt(nInterval)->ComputeTotalFrequency();
+		cout << endl;
 
 		// Nettoyage
 		delete kwftTarget;
 	}
-
-	if (bTraceOptimisationStatistics or bTraceResults)
-		cout << endl;
 
 	// Nettoyage
 	CleanWorkingData();
@@ -1749,18 +1747,21 @@ void DTGrouperMODLTwoClasses::IntervalListMergeOptimizationWithGarbagePartitionC
 		    (GetMaxIntervalNumber() > 0 and nIntervalNumber > GetMaxIntervalNumber()))
 		{
 			// Affichage de la meilleure partition avec poubelle avant mise a jour
-			if (bTraceResults and dDiscretizationWithGarbageDeltaCost > 0)
+			if (bTraceResults)
 			{
-				KWMODLLineOptimization* intervalTemp;
-				cout << "Meilleure table avec poubelle " << endl;
-				intervalTemp = headInterval;
-				while (intervalTemp != NULL)
+				if (dDiscretizationWithGarbageDeltaCost > 0)
 				{
-					// Affichage de la ligne courante
-					cast(KWMODLLineOptimization*, intervalTemp)->Write(cout);
+					KWMODLLineOptimization* intervalTemp;
+					cout << "Meilleure table avec poubelle " << endl;
+					intervalTemp = headInterval;
+					while (intervalTemp != NULL)
+					{
+						// Affichage de la ligne courante
+						cast(KWMODLLineOptimization*, intervalTemp)->Write(cout);
 
-					// Intervalle suivant
-					intervalTemp = cast(KWMODLLineOptimization*, intervalTemp->GetNext());
+						// Intervalle suivant
+						intervalTemp = cast(KWMODLLineOptimization*, intervalTemp->GetNext());
+					}
 				}
 			}
 
@@ -1770,19 +1771,22 @@ void DTGrouperMODLTwoClasses::IntervalListMergeOptimizationWithGarbagePartitionC
 			nIntervalNumber--;
 			nMergeNumber++;
 
-			if (bTraceResults and nIntervalNumber == 3)
+			if (bTraceResults)
 			{
-				// Affichage de la partition obtenue pour I=3 i.e. derniere partition avec groupe
-				// poubelle
-				// cout << "Table courante " << endl;
-				interval = headInterval;
-				while (interval != NULL)
+				if (nIntervalNumber == 3)
 				{
-					// Affichage de la ligne courante
-					cast(KWMODLLineOptimization*, interval)->Write(cout);
+					// Affichage de la partition obtenue pour I=3 i.e. derniere partition avec groupe
+					// poubelle
+					// cout << "Table courante " << endl;
+					interval = headInterval;
+					while (interval != NULL)
+					{
+						// Affichage de la ligne courante
+						cast(KWMODLLineOptimization*, interval)->Write(cout);
 
-					// Intervalle suivant
-					interval = cast(KWMODLLineOptimization*, interval->GetNext());
+						// Intervalle suivant
+						interval = cast(KWMODLLineOptimization*, interval->GetNext());
+					}
 				}
 			}
 		}

--- a/src/Learning/DTForest/DTGrouperMODLOptimization.cpp
+++ b/src/Learning/DTForest/DTGrouperMODLOptimization.cpp
@@ -1783,20 +1783,25 @@ void DTGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 					// Evaluation de la variation globale du cout
 					dDeltaCost = dOutDeltaCost + dInDeltaCost + dPartitionDeltaCost;
 
-					if (bTraceDeltaCosts and dDeltaCost < dBestDeltaCost - dEpsilon)
+					if (bTraceDeltaCosts)
 					{
-						cout << "Modality\t" << nModality << "\tOutGroup\t" << nOutGroup
-						     << "\tInGroup\t" << nInGroup << "\tGroupNumber\t" << nGroupNumber
-						     << "\tTrueGroupNumber\t " << nTrueGroupNumber << "\t Garbage \t"
-						     << (kwftTarget->GetGarbageModalityNumber() > 0)
-						     << "\tGarbageNumber\t" << nGarbageModalityNumber
-						     << "\tNewGarbageNumber\t" << nNewGarbageModalityNumber << endl;
-						cout << "BestDeltaCost\t" << dBestDeltaCost << "\t DeltaCost \t"
-						     << dDeltaCost << "\tOutDeltaCost\t" << dOutDeltaCost
-						     << "\tInDeltaCost\t" << dInDeltaCost << "\tPartitionDeltaCost\t"
-						     << dPartitionDeltaCost << endl;
-						cout << "Table avant deplacement " << endl;
-						cout << *kwftTarget << endl;
+						if (dDeltaCost < dBestDeltaCost - dEpsilon)
+						{
+							cout << "Modality\t" << nModality << "\tOutGroup\t" << nOutGroup
+							     << "\tInGroup\t" << nInGroup << "\tGroupNumber\t"
+							     << nGroupNumber << "\tTrueGroupNumber\t "
+							     << nTrueGroupNumber << "\t Garbage \t"
+							     << (kwftTarget->GetGarbageModalityNumber() > 0)
+							     << "\tGarbageNumber\t" << nGarbageModalityNumber
+							     << "\tNewGarbageNumber\t" << nNewGarbageModalityNumber
+							     << endl;
+							cout << "BestDeltaCost\t" << dBestDeltaCost << "\t DeltaCost \t"
+							     << dDeltaCost << "\tOutDeltaCost\t" << dOutDeltaCost
+							     << "\tInDeltaCost\t" << dInDeltaCost
+							     << "\tPartitionDeltaCost\t" << dPartitionDeltaCost << endl;
+							cout << "Table avant deplacement " << endl;
+							cout << *kwftTarget << endl;
+						}
 					}
 
 					// Memorisation si amelioration

--- a/src/Learning/KDDomainKnowledge/KDSelectionOperandSamplingTask.cpp
+++ b/src/Learning/KDDomainKnowledge/KDSelectionOperandSamplingTask.cpp
@@ -97,7 +97,6 @@ PLParallelTask* KDSelectionOperandSamplingTask::Create() const
 boolean KDSelectionOperandSamplingTask::ComputeResourceRequirements()
 {
 	boolean bOk;
-	const boolean bTrace = false;
 	const SortedList slSample;
 	const NumericKeyDictionary nkdSample;
 	longint lSelectionOperandDataSamplerSpecUsedMemory;

--- a/src/Learning/KWData/KWTextTokenizer.cpp
+++ b/src/Learning/KWData/KWTextTokenizer.cpp
@@ -145,7 +145,6 @@ void KWTextTokenizer::ExportTokens(ObjectArray* oaTokenFrequencies) const
 	POSITION position;
 	ALString sToken;
 	longint lValue;
-	int nSpecificTokenIndex;
 	KWTokenFrequency* token;
 	int nIndex;
 	Timer traceTimer;
@@ -213,7 +212,6 @@ void KWTextTokenizer::ExportFrequentTokens(ObjectArray* oaTokenFrequencies, int 
 	IntVector ivNumbersOfTokensPerFrequency;
 	int nMinFrequency;
 	int nCollectedTokenNumber;
-	int nSpecificTokenIndex;
 	KWTokenFrequency* token;
 	int nIndex;
 	Timer traceTimer;

--- a/src/Learning/KWData/Profiler.cpp
+++ b/src/Learning/KWData/Profiler.cpp
@@ -252,7 +252,7 @@ void Profiler::WriteKeyBoolean(const ALString& sKey, boolean bValue)
 	}
 }
 
-int Profiler::GetMethodStartNumber(const ALString& sMethodName) const
+longint Profiler::GetMethodStartNumber(const ALString& sMethodName) const
 {
 	Timer* methodTimer;
 

--- a/src/Learning/KWData/Profiler.h
+++ b/src/Learning/KWData/Profiler.h
@@ -52,7 +52,7 @@ public:
 	void WriteKeyBoolean(const ALString& sKey, boolean bValue);
 
 	// Recherche du nombre de lancement d'une methode donnee pour un profiling en cours
-	int GetMethodStartNumber(const ALString& sMethodName) const;
+	longint GetMethodStartNumber(const ALString& sMethodName) const;
 
 	// Parametrage avance pour exporter toute la trace de profiling (defaut: false)
 	// Dans ce cas, un fichier de trace complet est ecrit au format json, de nom

--- a/src/Learning/KWDataPreparation/KWDiscretizerMODL.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizerMODL.cpp
@@ -1283,7 +1283,7 @@ KWMODLLine* KWDiscretizerMODL::IntervalListOptimization(const KWFrequencyTable* 
 		cout << kwftSource->GetTotalFrequency() << "\t" << kwftSource->GetFrequencyVectorNumber() << "\t"
 		     << nMergeNumber << "\t" << nExtraMergeNumber << "\t" << nSplitNumber << "\t" << nExtraSplitNumber
 		     << "\t" << nMergeSplitNumber << "\t" << nMergeMergeSplitNumber << "\t"
-		     << GetIntervalListSize(headInterval);
+		     << GetIntervalListSize(headInterval) << endl;
 	}
 
 	// Affichage des resultats
@@ -1307,13 +1307,11 @@ KWMODLLine* KWDiscretizerMODL::IntervalListOptimization(const KWFrequencyTable* 
 		// Effectifs des intervalles
 		for (nInterval = 0; nInterval < kwftTarget->GetFrequencyVectorNumber(); nInterval++)
 			cout << "\t" << kwftTarget->GetFrequencyVectorAt(nInterval)->ComputeTotalFrequency();
+		cout << endl;
 
 		// Nettoyage
 		delete kwftTarget;
 	}
-
-	if (bTraceOptimisationStatistics or bTraceResults)
-		cout << endl;
 
 	// Nettoyage
 	CleanWorkingData();

--- a/src/Learning/KWDataPreparation/KWDiscretizerUnsupervised.cpp
+++ b/src/Learning/KWDataPreparation/KWDiscretizerUnsupervised.cpp
@@ -539,8 +539,11 @@ void KWDiscretizerMODLEqualBins::MODLEqualBinsDiscretizeValues(boolean bIsEqualF
 			if (bAreCostPositive and dDiscretizationCost >= dBestDiscretizationCost)
 			{
 				// Pas d'optimsaition des calculs si affichage des details
-				if (not bTraceDiscretizationTables and not bTraceDiscretizationCosts)
-					break;
+				if (not bTraceDiscretizationTables)
+				{
+					if (not bTraceDiscretizationCosts)
+						break;
+				}
 			}
 		}
 

--- a/src/Learning/KWDataPreparation/KWGrouperMODL.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperMODL.cpp
@@ -2410,16 +2410,17 @@ IntVector* KWGrouperMODL::OptimizeGroupsWithGarbageSearch(int nExactGroupNumber,
 		for (i = 0; i < oaInitialGroups->GetSize(); i++)
 			cout << *cast(KWMODLGroup*, oaInitialGroups->GetAt(i));
 	}
-
-	if (bTrace and nExactGroupNumber == 0)
-		cout << "Nbre optimal de groupes avant degradation (avec ou sans poub) \tSANS poubelle\t"
-		     << nOptimumGroupNumber << "\t AVEC poubelle \t" << nOptimumGroupNumberWithGarbage << endl;
-
-	ensure(nExactGroupNumber == 0 or nExactGroupNumber == nGroupNumber);
+	if (bTrace)
+	{
+		if (nExactGroupNumber == 0)
+			cout << "Nbre optimal de groupes avant degradation (avec ou sans poub) \tSANS poubelle\t"
+			     << nOptimumGroupNumber << "\t AVEC poubelle \t" << nOptimumGroupNumberWithGarbage << endl;
+	}
 
 	// Memorisation du vecteur des tailles optimales des partitions avec et sans poubelle
 	ivOptimumNumbers = new IntVector;
 	ivOptimumNumbers->Add(nOptimumGroupNumber);
 	ivOptimumNumbers->Add(nOptimumGroupNumberWithGarbage);
+	ensure(nExactGroupNumber == 0 or nExactGroupNumber == nGroupNumber);
 	return ivOptimumNumbers;
 }

--- a/src/Learning/KWDataPreparation/KWGrouperMODLInternal.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperMODLInternal.cpp
@@ -778,7 +778,7 @@ KWMODLLine* KWGrouperMODLTwoClasses::IntervalListOptimizationWithGarbage(
 		cout << kwftSource->GetTotalFrequency() << "\t" << kwftSource->GetFrequencyVectorNumber() << "\t"
 		     << nMergeNumber << "\t" << nExtraMergeNumber << "\t" << nSplitNumber << "\t" << nExtraSplitNumber
 		     << "\t" << nMergeSplitNumber << "\t" << nMergeMergeSplitNumber << "\t"
-		     << GetIntervalListSize(headInterval);
+		     << GetIntervalListSize(headInterval) << endl;
 	}
 
 	// Affichage des resultats
@@ -802,13 +802,11 @@ KWMODLLine* KWGrouperMODLTwoClasses::IntervalListOptimizationWithGarbage(
 		// Effectifs des intervalles
 		for (nInterval = 0; nInterval < kwftTarget->GetFrequencyVectorNumber(); nInterval++)
 			cout << "\t" << kwftTarget->GetFrequencyVectorAt(nInterval)->ComputeTotalFrequency();
+		cout << endl;
 
 		// Nettoyage
 		delete kwftTarget;
 	}
-
-	if (bTraceOptimisationStatistics or bTraceResults)
-		cout << endl;
 
 	// Nettoyage
 	CleanWorkingData();
@@ -1764,18 +1762,21 @@ void KWGrouperMODLTwoClasses::IntervalListMergeOptimizationWithGarbagePartitionC
 		    (GetMaxIntervalNumber() > 0 and nIntervalNumber > GetMaxIntervalNumber()))
 		{
 			// Affichage de la meilleure partition avec poubelle avant mise a jour
-			if (bTraceResults and dDiscretizationWithGarbageDeltaCost > 0)
+			if (bTraceResults)
 			{
-				KWMODLLineOptimization* intervalTemp;
-				cout << "Meilleure table avec poubelle " << endl;
-				intervalTemp = headInterval;
-				while (intervalTemp != NULL)
+				if (dDiscretizationWithGarbageDeltaCost > 0)
 				{
-					// Affichage de la ligne courante
-					cast(KWMODLLineOptimization*, intervalTemp)->Write(cout);
+					KWMODLLineOptimization* intervalTemp;
+					cout << "Meilleure table avec poubelle " << endl;
+					intervalTemp = headInterval;
+					while (intervalTemp != NULL)
+					{
+						// Affichage de la ligne courante
+						cast(KWMODLLineOptimization*, intervalTemp)->Write(cout);
 
-					// Intervalle suivant
-					intervalTemp = cast(KWMODLLineOptimization*, intervalTemp->GetNext());
+						// Intervalle suivant
+						intervalTemp = cast(KWMODLLineOptimization*, intervalTemp->GetNext());
+					}
 				}
 			}
 
@@ -1785,19 +1786,22 @@ void KWGrouperMODLTwoClasses::IntervalListMergeOptimizationWithGarbagePartitionC
 			nIntervalNumber--;
 			nMergeNumber++;
 
-			if (bTraceResults and nIntervalNumber == 3)
+			if (bTraceResults)
 			{
-				// Affichage de la partition obtenue pour I=3 i.e. derniere partition avec groupe
-				// poubelle
-				// cout << "Table courante " << endl;
-				interval = headInterval;
-				while (interval != NULL)
+				if (nIntervalNumber == 3)
 				{
-					// Affichage de la ligne courante
-					cast(KWMODLLineOptimization*, interval)->Write(cout);
+					// Affichage de la partition obtenue pour I=3 i.e. derniere partition avec groupe
+					// poubelle
+					// cout << "Table courante " << endl;
+					interval = headInterval;
+					while (interval != NULL)
+					{
+						// Affichage de la ligne courante
+						cast(KWMODLLineOptimization*, interval)->Write(cout);
 
-					// Intervalle suivant
-					interval = cast(KWMODLLineOptimization*, interval->GetNext());
+						// Intervalle suivant
+						interval = cast(KWMODLLineOptimization*, interval->GetNext());
+					}
 				}
 			}
 		}

--- a/src/Learning/KWDataPreparation/KWGrouperMODLOptimization.cpp
+++ b/src/Learning/KWDataPreparation/KWGrouperMODLOptimization.cpp
@@ -1783,20 +1783,25 @@ void KWGrouperMODL::FastPostOptimizeGroupsWithGarbage(KWFrequencyTable* kwftSour
 					// Evaluation de la variation globale du cout
 					dDeltaCost = dOutDeltaCost + dInDeltaCost + dPartitionDeltaCost;
 
-					if (bTraceDeltaCosts and dDeltaCost < dBestDeltaCost - dEpsilon)
+					if (bTraceDeltaCosts)
 					{
-						cout << "Modality\t" << nModality << "\tOutGroup\t" << nOutGroup
-						     << "\tInGroup\t" << nInGroup << "\tGroupNumber\t" << nGroupNumber
-						     << "\tTrueGroupNumber\t " << nTrueGroupNumber << "\t Garbage \t"
-						     << (kwftTarget->GetGarbageModalityNumber() > 0)
-						     << "\tGarbageNumber\t" << nGarbageModalityNumber
-						     << "\tNewGarbageNumber\t" << nNewGarbageModalityNumber << endl;
-						cout << "BestDeltaCost\t" << dBestDeltaCost << "\t DeltaCost \t"
-						     << dDeltaCost << "\tOutDeltaCost\t" << dOutDeltaCost
-						     << "\tInDeltaCost\t" << dInDeltaCost << "\tPartitionDeltaCost\t"
-						     << dPartitionDeltaCost << endl;
-						cout << "Table avant deplacement " << endl;
-						cout << *kwftTarget << endl;
+						if (dDeltaCost < dBestDeltaCost - dEpsilon)
+						{
+							cout << "Modality\t" << nModality << "\tOutGroup\t" << nOutGroup
+							     << "\tInGroup\t" << nInGroup << "\tGroupNumber\t"
+							     << nGroupNumber << "\tTrueGroupNumber\t "
+							     << nTrueGroupNumber << "\t Garbage \t"
+							     << (kwftTarget->GetGarbageModalityNumber() > 0)
+							     << "\tGarbageNumber\t" << nGarbageModalityNumber
+							     << "\tNewGarbageNumber\t" << nNewGarbageModalityNumber
+							     << endl;
+							cout << "BestDeltaCost\t" << dBestDeltaCost << "\t DeltaCost \t"
+							     << dDeltaCost << "\tOutDeltaCost\t" << dOutDeltaCost
+							     << "\tInDeltaCost\t" << dInDeltaCost
+							     << "\tPartitionDeltaCost\t" << dPartitionDeltaCost << endl;
+							cout << "Table avant deplacement " << endl;
+							cout << *kwftTarget << endl;
+						}
 					}
 
 					// Memorisation si amelioration

--- a/src/Learning/KWDataUtils/KWDataTableSliceSet.cpp
+++ b/src/Learning/KWDataUtils/KWDataTableSliceSet.cpp
@@ -2378,14 +2378,16 @@ void KWDataTableSliceSet::ComputeReadInformation(const KWClass* kwcInputClass, K
 	oaAttributesToClean.SetSize(0);
 
 	// Affichage des attributs necessaires
-	if (bTraceDetails and bOk)
+	if (bTraceDetails)
 	{
-		// Affichage des attributs necessaires
-		cout << "Needed attributes\n";
-		for (nAttribute = 0; nAttribute < oaClassNeededAttributes.GetSize(); nAttribute++)
+		if (bOk)
 		{
-			attribute = cast(KWAttribute*, oaClassNeededAttributes.GetAt(nAttribute));
-			cout << "\t" << attribute->GetName() << endl;
+			cout << "Needed attributes\n";
+			for (nAttribute = 0; nAttribute < oaClassNeededAttributes.GetSize(); nAttribute++)
+			{
+				attribute = cast(KWAttribute*, oaClassNeededAttributes.GetAt(nAttribute));
+				cout << "\t" << attribute->GetName() << endl;
+			}
 		}
 	}
 

--- a/src/Learning/KWTest/KWDiscretizerTest.cpp
+++ b/src/Learning/KWTest/KWDiscretizerTest.cpp
@@ -842,21 +842,24 @@ boolean KWContinuousSampleDiscretizerTest::ComputeStats()
 			nPartNumber = dataGridStats->GetAttributeAt(0)->GetPartNumber();
 
 		// Affichage des discretisations
-		if (bTrace and nPartNumber > 1)
+		if (bTrace)
 		{
-			int j;
-			cout << "Example\t" << nSampleSize << "\t" << nPartNumber << "\t:";
-			for (i = 0; i < dataGridStats->GetAttributeAt(0)->GetPartNumber(); i++)
+			if (nPartNumber > 1)
 			{
-				for (j = 0; j < dataGridStats->GetAttributeAt(1)->GetPartNumber(); j++)
+				int j;
+				cout << "Example\t" << nSampleSize << "\t" << nPartNumber << "\t:";
+				for (i = 0; i < dataGridStats->GetAttributeAt(0)->GetPartNumber(); i++)
 				{
-					if (j > 0)
-						cout << ".";
-					cout << dataGridStats->GetBivariateCellFrequencyAt(i, j);
+					for (j = 0; j < dataGridStats->GetAttributeAt(1)->GetPartNumber(); j++)
+					{
+						if (j > 0)
+							cout << ".";
+						cout << dataGridStats->GetBivariateCellFrequencyAt(i, j);
+					}
+					cout << ":";
 				}
-				cout << ":";
+				cout << endl;
 			}
-			cout << endl;
 		}
 
 		// Export du fichier de stats resultats


### PR DESCRIPTION
Suite aux derniers commits, notamment liss au pattern de trace, des warnings sont apparus lors des compilation avec Visual C++ sous Windows.

Principalement: 14 warnings de type warning C4127: l'expression conditionnelle est une constante

Quand on un bloc de trace, il ne faut avoir qu'une seule condition `if (bTrace)`. Si on a une autre condition, il faut la mettre dans un bloc imbrique.

Le wiki a ete mis a jour a cet effet.