### PR TITLE
Use KNI with external data and dictionary on the cloud

### DIFF
--- a/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.cpp
+++ b/src/Learning/KhiopsNativeInterface/KhiopsNativeInterface.cpp
@@ -572,7 +572,7 @@ KNI_API int KNIOpenStream(const char* sDictionaryFileName, const char* sDictiona
 		else if (not KNICheckString(sDictionaryName, KNI_MaxDictionaryNameLength))
 			nRetCode = KNI_ErrorDictionaryName;
 		// Erreur si fichier dictionnaire inexistant
-		else if (not FileService::FileExists(sDictionaryFileName))
+		else if (not PLRemoteFileService::FileExists(sDictionaryFileName))
 			nRetCode = KNI_ErrorDictionaryMissingFile;
 		// Erreur si pas de header line
 		else if (not KNICheckString(sStreamHeaderLine, KNI_MaxRecordLength))
@@ -586,7 +586,7 @@ KNI_API int KNIOpenStream(const char* sDictionaryFileName, const char* sDictiona
 	lKNIStreamMaxActualMemory = nKNIStreamMaxMemory * lMB;
 	if (nRetCode == KNI_OK)
 	{
-		lFileSize = FileService::GetFileSize(sDictionaryFileName);
+		lFileSize = PLRemoteFileService::GetFileSize(sDictionaryFileName);
 		if (lFileSize > lKNIStreamMaxActualMemory)
 		{
 			KNIAddInternalError(sDictionaryName,


### PR DESCRIPTION
Summary
- Use PLRemoteFileService to access dictionaries on cloud storage through FileSize and FileExists.
- Reading the dictionary from cloud storage already works.
- Reading the external table from cloud storage already works.
- Tested with KNIRecodeMTFiles with command:
```bash
KNIRecodeMTFiles \
  -d gs://AIDS/AIDSMolecule.kdic Molecule \
  -i /Users/bob/LearningTest/MTdatasets/AIDS/AIDSMolecules.txt 1 \
  -s Atoms /Users/bob/LearningTest/MTdatasets/AIDS/AIDSAtoms.txt 1 2 \
  -s Bonds /Users/bob/LearningTest/MTdatasets/AIDS/AIDSBonds.txt 1 2 3 \
  -x MoleculeLabel "" gs://AIDS/AIDSLabels.txt
```
>[!NOTE]
> - I recommend releasing this feature after #975. In the current state, dictionaries on cloud storage are first copied to a local temporary directory (not explicitly configured in KNI) and then read. With #975, dictionaries will be read directly on cloud storage.
>-  KNITransfer is not cloud ready. It will be easy to to it after #975 (need PLRemoteFileservice::OpenInputBinaryFile)
