### PR TITLE
Add deployment for instances x variables coclustering

### DIFF
--- a/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
@@ -267,7 +267,7 @@ boolean CCDeploymentSpec::PrepareVarPartCoclusteringDeployment(const CCHierarchi
 	require(coclusteringDataGrid->IsVarPartDataGrid());
 	require(deploymentDomain == NULL);
 
-	// Test d'integrite pour le deploiement, en fonction des specifications et de la grille de coclustering : a adapter
+	// Test d'integrite pour le deploiement, en fonction des specifications et de la grille de coclustering
 	if (bOk)
 		bOk = CheckDeploymentSpec(coclusteringDataGrid);
 
@@ -391,6 +391,9 @@ boolean CCDeploymentSpec::CheckDeploymentSpec(const CCHierarchicalDataGrid* cocl
 	boolean bOk = true;
 	KWClass* kwcDeploymentClass;
 	KWAttribute* kwaDistributionAttribute;
+	KWAttribute* innerAttribute;
+	int nAttributeIndex;
+	ALString sInnerAttributeName;
 
 	require(coclusteringDataGrid != NULL);
 
@@ -494,6 +497,24 @@ boolean CCDeploymentSpec::CheckDeploymentSpec(const CCHierarchicalDataGrid* cocl
 			AddWarning("Coclustering deployment variable is required only for variable x variable "
 				   "coclustering. The name " +
 				   GetDeployedAttributeName() + " will be ignored and deleted.");
+
+		// Verification de la compatibilite entre les noms innerAttributes du coclustering et du dictionnaire
+		for (nAttributeIndex = 0;
+		     nAttributeIndex < coclusteringDataGrid->GetInnerAttributes()->GetInnerAttributeNumber();
+		     nAttributeIndex++)
+		{
+			sInnerAttributeName = coclusteringDataGrid->GetInnerAttributes()
+						  ->GetInnerAttributeAt(nAttributeIndex)
+						  ->GetAttributeName();
+			innerAttribute = kwcDeploymentClass->LookupAttribute(sInnerAttributeName);
+			GetInputClassName();
+			if (bOk and innerAttribute == NULL)
+			{
+				bOk = false;
+				AddError("Inner attribute " + sInnerAttributeName + " not found in dictionary " +
+					 kwcDeploymentClass->GetName());
+			}
+		}
 	}
 	return bOk;
 }

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
@@ -37,13 +37,13 @@ void CCDeploymentSpec::CopyFrom(const CCDeploymentSpec* aSource)
 {
 	require(aSource != NULL);
 
-	sInputClassName = aSource->sInputClassName;
-	sInputObjectArrayAttributeName = aSource->sInputObjectArrayAttributeName;
-	sDeployedAttributeName = aSource->sDeployedAttributeName;
 	bBuildPredictedClusterAttribute = aSource->bBuildPredictedClusterAttribute;
 	bBuildClusterDistanceAttributes = aSource->bBuildClusterDistanceAttributes;
 	bBuildFrequencyRecodingAttributes = aSource->bBuildFrequencyRecodingAttributes;
 	sOutputAttributesPrefix = aSource->sOutputAttributesPrefix;
+	sInputClassName = aSource->sInputClassName;
+	sInputObjectArrayAttributeName = aSource->sInputObjectArrayAttributeName;
+	sDeployedAttributeName = aSource->sDeployedAttributeName;
 
 	// ## Custom copyfrom
 
@@ -65,15 +65,14 @@ CCDeploymentSpec* CCDeploymentSpec::Clone() const
 
 void CCDeploymentSpec::Write(ostream& ost) const
 {
-	ost << "Input dictionary\t" << GetInputClassName() << "\n";
-	if (GetInputObjectArrayAttributeName() != "")
-		ost << "Input table variable\t" << GetInputObjectArrayAttributeName() << "\n";
-	ost << "Coclustering deployed variable\t" << GetDeployedAttributeName() << "\n";
 	ost << "Build predicted cluster variable\t" << BooleanToString(GetBuildPredictedClusterAttribute()) << "\n";
 	ost << "Build inter-cluster distance variables\t" << BooleanToString(GetBuildClusterDistanceAttributes())
 	    << "\n";
 	ost << "Build frequency recoding variables\t" << BooleanToString(GetBuildFrequencyRecodingAttributes()) << "\n";
 	ost << "Output variables prefix\t" << GetOutputAttributesPrefix() << "\n";
+	ost << "Input dictionary\t" << GetInputClassName() << "\n";
+	ost << "Input table variable\t" << GetInputObjectArrayAttributeName() << "\n";
+	ost << "Coclustering deployed variable\t" << GetDeployedAttributeName() << "\n";
 }
 
 const ALString CCDeploymentSpec::GetClassLabel() const
@@ -133,7 +132,7 @@ boolean CCDeploymentSpec::PrepareCoclusteringDeployment(const CCHierarchicalData
 		    cast(CCHDGAttribute*, coclusteringDataGrid->SearchAttribute(GetDeployedAttributeName()));
 
 		//////////////////////////////////////////////////////////////////////////////////////
-		// Creation du domaine de dploiement et identification des classe et attributs utiles
+		// Creation du domaine de deploiement et identification des classes et attributs utiles
 
 		// Creation du domaine de deploiement a partir de la classe de deploiement
 		kwcInputClass = KWClassDomain::GetCurrentDomain()->LookupClass(GetInputClassName());
@@ -240,6 +239,7 @@ boolean CCDeploymentSpec::PrepareVarPartCoclusteringDeployment(const CCHierarchi
 {
 	boolean bOk = true;
 	int nAttribute;
+	CCHDGAttribute* hdgAttribute;
 	CCHDGAttribute* hdgDeploymentAttribute;
 	KWClass* kwcInputClass;
 	KWClass* kwcDeploymentClass;
@@ -352,6 +352,29 @@ boolean CCDeploymentSpec::PrepareVarPartCoclusteringDeployment(const CCHierarchi
 		    AddPartLabelAttribute(kwcDeploymentClass, predictedPartIndexAttribute, labelVectorAttribute,
 					  hdgDeploymentAttribute, "Predicted");
 		assert(predictedPartLabelAttribute != NULL); // Pour eviter un warning
+
+		// Creation d'attributs de distance pour l'attribut de deploiement
+		if (GetBuildClusterDistanceAttributes())
+		{
+			AddPredictedPartDistancesAttributes(kwcDeploymentClass, dataGridDeploymentAttribute,
+							    hdgDeploymentAttribute);
+		}
+
+		// Creation d'attributs d'effectif pour les attributs de distribution
+		if (GetBuildFrequencyRecodingAttributes())
+		{
+			for (nAttribute = 0; nAttribute < coclusteringDataGrid->GetAttributeNumber(); nAttribute++)
+			{
+				hdgAttribute = cast(CCHDGAttribute*, coclusteringDataGrid->GetAttributeAt(nAttribute));
+
+				// Si attribut different de l'attribut de deploiement
+				if (hdgAttribute != hdgDeploymentAttribute)
+				{
+					AddPredictedPartFrequenciesAttributesAt(
+					    kwcDeploymentClass, dataGridDeploymentAttribute, hdgAttribute);
+				}
+			}
+		}
 
 		// Completion des infos
 		deploymentDomain->CompleteTypeInfo();
@@ -686,6 +709,12 @@ void CCDeploymentSpec::FillInputClassAndAttributeNames(CCPostProcessingSpec* pos
 			}
 		}
 	}
+}
+
+const ALString& CCDeploymentSpec::GetInnerVariableMetaDataKey()
+{
+	static const ALString sMetaDataKey = "InnerVariable";
+	return sMetaDataKey;
 }
 
 KWAttribute* CCDeploymentSpec::AddDataGridAttribute(KWClass* kwcDeploymentClass,
@@ -1276,6 +1305,7 @@ KWAttribute* CCDeploymentSpec::AddInnerAttributePartitionLabelAttribute(KWClass*
 	KWAttribute* dgAttribute;
 	KWDerivationRuleOperand* partIndexOperand1;
 	KWDerivationRuleOperand* partIndexOperand2;
+	ALString sInnerAttributeName;
 
 	require(GetVarPartDeploymentMode());
 	require(kwcDeploymentClass != NULL);
@@ -1303,7 +1333,18 @@ KWAttribute* CCDeploymentSpec::AddInnerAttributePartitionLabelAttribute(KWClass*
 	partIndexOperand2->SetAttributeName(ivIndexAttribute->GetName());
 	varPartRule->AddOperand(partIndexOperand2);
 
+	// Extraction du nom de l'inner variable pour construire le label
+	sInnerAttributeName = ivIndexAttribute->GetName();
+	sInnerAttributeName = sInnerAttributeName.Left(sInnerAttributeName.Find("PartitionIndex"));
+	sInnerAttributeName =
+	    sInnerAttributeName.Right(sInnerAttributeName.GetLength() - GetOutputAttributesPrefix().GetLength());
+
+	// Creation des meta-donnees permettant de retrouver automatiquement l'attribut
 	dgAttribute->SetUsed(false);
+	dgAttribute->GetMetaData()->SetStringValueAt(GetInnerVariableMetaDataKey(), sInnerAttributeName);
+	dgAttribute->GetMetaData()->SetNoValueAt("PartLabel");
+
+	// Insertion de l'attribut
 	kwcDeploymentClass->InsertAttribute(dgAttribute);
 	return dgAttribute;
 }

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
@@ -438,6 +438,7 @@ boolean CCDeploymentSpec::CheckDeploymentSpec(const CCHierarchicalDataGrid* cocl
 		AddError("No deployment variable must be built");
 	}
 
+	// Cas d'un coclustering variable * variable
 	if (not coclusteringDataGrid->IsVarPartDataGrid())
 	{
 		// L'attribut de deploiement doit exister s'il est specifie
@@ -474,6 +475,25 @@ boolean CCDeploymentSpec::CheckDeploymentSpec(const CCHierarchicalDataGrid* cocl
 					 " is not consistent with the coclustering variables");
 			}
 		}
+	}
+
+	// Sinon : cas d'un coclustering individus * variable
+	else
+	{
+		// Warnings si des parametres dedies au cas variable x variable sont specifies
+		// Pas d'impact sur le deploiement qui se deroule normalement
+		if (GetInputClassName() != "")
+			AddWarning(
+			    "Name of the dictionary is required only for variable x variable coclustering. The name " +
+			    GetInputClassName() + " will be ignored and deleted.");
+		if (GetInputObjectArrayAttributeName() != "")
+			AddWarning(
+			    "Input table variable is required only for variable x variable coclustering. The name " +
+			    GetInputObjectArrayAttributeName() + " will be ignored and deleted.");
+		if (GetDeployedAttributeName() != "")
+			AddWarning("Coclustering deployment variable is required only for variable x variable "
+				   "coclustering. The name " +
+				   GetDeployedAttributeName() + " will be ignored and deleted.");
 	}
 	return bOk;
 }

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpec.cpp
@@ -394,6 +394,7 @@ boolean CCDeploymentSpec::CheckDeploymentSpec(const CCHierarchicalDataGrid* cocl
 	KWAttribute* innerAttribute;
 	int nAttributeIndex;
 	ALString sInnerAttributeName;
+	int nInnerAttributeType;
 
 	require(coclusteringDataGrid != NULL);
 
@@ -488,15 +489,15 @@ boolean CCDeploymentSpec::CheckDeploymentSpec(const CCHierarchicalDataGrid* cocl
 		if (GetInputClassName() != "")
 			AddWarning(
 			    "Name of the dictionary is required only for variable x variable coclustering. The name " +
-			    GetInputClassName() + " will be ignored and deleted.");
+			    GetInputClassName() + " will be ignored.");
 		if (GetInputObjectArrayAttributeName() != "")
 			AddWarning(
 			    "Input table variable is required only for variable x variable coclustering. The name " +
-			    GetInputObjectArrayAttributeName() + " will be ignored and deleted.");
+			    GetInputObjectArrayAttributeName() + " will be ignored.");
 		if (GetDeployedAttributeName() != "")
 			AddWarning("Coclustering deployment variable is required only for variable x variable "
 				   "coclustering. The name " +
-				   GetDeployedAttributeName() + " will be ignored and deleted.");
+				   GetDeployedAttributeName() + " will be ignored.");
 
 		// Verification de la compatibilite entre les noms innerAttributes du coclustering et du dictionnaire
 		for (nAttributeIndex = 0;
@@ -513,6 +514,21 @@ boolean CCDeploymentSpec::CheckDeploymentSpec(const CCHierarchicalDataGrid* cocl
 				bOk = false;
 				AddError("Inner attribute " + sInnerAttributeName + " not found in dictionary " +
 					 kwcDeploymentClass->GetName());
+			}
+			// Verification de la compatibilite des types
+			else
+			{
+				nInnerAttributeType = coclusteringDataGrid->GetInnerAttributes()
+							  ->GetInnerAttributeAt(nAttributeIndex)
+							  ->GetAttributeType();
+				if (bOk and innerAttribute->GetType() != nInnerAttributeType)
+				{
+					bOk = false;
+					AddError("Inner attribute " + sInnerAttributeName + " found in dictionary " +
+						 kwcDeploymentClass->GetName() + " with type " +
+						 KWType::ToString(innerAttribute->GetType()) +
+						 " instead of expected type " + KWType::ToString(nInnerAttributeType));
+				}
 			}
 		}
 	}

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpec.dd
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpec.dd
@@ -1,8 +1,8 @@
 Rank;Name;Type;Style;Label
-1;InputClassName                  ;ALString;   ;Input dictionary
-2;InputObjectArrayAttributeName   ;ALString;   ;Input table variable
-3;DeployedAttributeName           ;ALString;   ;Coclustering deployed variable
-4;BuildPredictedClusterAttribute  ;Boolean ;   ;Build predicted cluster variable
-5;BuildClusterDistanceAttributes  ;Boolean ;   ;Build inter-cluster distance variables
-6;BuildFrequencyRecodingAttributes;Boolean ;   ;Build frequency recoding variables
-7;OutputAttributesPrefix          ;ALString;   ;Output variables prefix
+1;BuildPredictedClusterAttribute  ;Boolean ;   ;Build predicted cluster variable
+2;BuildClusterDistanceAttributes  ;Boolean ;   ;Build inter-cluster distance variables
+3;BuildFrequencyRecodingAttributes;Boolean ;   ;Build frequency recoding variables
+4;OutputAttributesPrefix          ;ALString;   ;Output variables prefix
+5;InputClassName                  ;ALString;   ;Input dictionary
+6;InputObjectArrayAttributeName   ;ALString;   ;Input table variable
+7;DeployedAttributeName           ;ALString;   ;Coclustering deployed variable

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpec.h
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpec.h
@@ -116,9 +116,10 @@ public:
 	// de distribution valides
 	void FillInputClassAndAttributeNames(CCPostProcessingSpec* postProcessingSpec);
 
-	// ##
 	// Cles de meta-donnees pour les dictionnaires de deploiement d'un coclustering
 	static const ALString& GetInnerVariableMetaDataKey();
+
+	// ##
 
 	////////////////////////////////////////////////////////
 	///// Implementation

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpec.h
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpec.h
@@ -38,18 +38,6 @@ public:
 	///////////////////////////////////////////////////////////
 	// Acces aux attributs
 
-	// Input dictionary
-	const ALString& GetInputClassName() const;
-	void SetInputClassName(const ALString& sValue);
-
-	// Input table variable
-	const ALString& GetInputObjectArrayAttributeName() const;
-	void SetInputObjectArrayAttributeName(const ALString& sValue);
-
-	// Coclustering deployed variable
-	const ALString& GetDeployedAttributeName() const;
-	void SetDeployedAttributeName(const ALString& sValue);
-
 	// Build predicted cluster variable
 	boolean GetBuildPredictedClusterAttribute() const;
 	void SetBuildPredictedClusterAttribute(boolean bValue);
@@ -65,6 +53,18 @@ public:
 	// Output variables prefix
 	const ALString& GetOutputAttributesPrefix() const;
 	void SetOutputAttributesPrefix(const ALString& sValue);
+
+	// Input dictionary
+	const ALString& GetInputClassName() const;
+	void SetInputClassName(const ALString& sValue);
+
+	// Input table variable
+	const ALString& GetInputObjectArrayAttributeName() const;
+	void SetInputObjectArrayAttributeName(const ALString& sValue);
+
+	// Coclustering deployed variable
+	const ALString& GetDeployedAttributeName() const;
+	void SetDeployedAttributeName(const ALString& sValue);
 
 	///////////////////////////////////////////////////////////
 	// Divers
@@ -117,18 +117,20 @@ public:
 	void FillInputClassAndAttributeNames(CCPostProcessingSpec* postProcessingSpec);
 
 	// ##
+	// Cles de meta-donnees pour les dictionnaires de deploiement d'un coclustering
+	static const ALString& GetInnerVariableMetaDataKey();
 
 	////////////////////////////////////////////////////////
 	///// Implementation
 protected:
 	// Attributs de la classe
-	ALString sInputClassName;
-	ALString sInputObjectArrayAttributeName;
-	ALString sDeployedAttributeName;
 	boolean bBuildPredictedClusterAttribute;
 	boolean bBuildClusterDistanceAttributes;
 	boolean bBuildFrequencyRecodingAttributes;
 	ALString sOutputAttributesPrefix;
+	ALString sInputClassName;
+	ALString sInputObjectArrayAttributeName;
+	ALString sDeployedAttributeName;
 
 	// ## Custom implementation
 
@@ -200,36 +202,6 @@ protected:
 ////////////////////////////////////////////////////////////
 // Implementations inline
 
-inline const ALString& CCDeploymentSpec::GetInputClassName() const
-{
-	return sInputClassName;
-}
-
-inline void CCDeploymentSpec::SetInputClassName(const ALString& sValue)
-{
-	sInputClassName = sValue;
-}
-
-inline const ALString& CCDeploymentSpec::GetInputObjectArrayAttributeName() const
-{
-	return sInputObjectArrayAttributeName;
-}
-
-inline void CCDeploymentSpec::SetInputObjectArrayAttributeName(const ALString& sValue)
-{
-	sInputObjectArrayAttributeName = sValue;
-}
-
-inline const ALString& CCDeploymentSpec::GetDeployedAttributeName() const
-{
-	return sDeployedAttributeName;
-}
-
-inline void CCDeploymentSpec::SetDeployedAttributeName(const ALString& sValue)
-{
-	sDeployedAttributeName = sValue;
-}
-
 inline boolean CCDeploymentSpec::GetBuildPredictedClusterAttribute() const
 {
 	return bBuildPredictedClusterAttribute;
@@ -268,6 +240,36 @@ inline const ALString& CCDeploymentSpec::GetOutputAttributesPrefix() const
 inline void CCDeploymentSpec::SetOutputAttributesPrefix(const ALString& sValue)
 {
 	sOutputAttributesPrefix = sValue;
+}
+
+inline const ALString& CCDeploymentSpec::GetInputClassName() const
+{
+	return sInputClassName;
+}
+
+inline void CCDeploymentSpec::SetInputClassName(const ALString& sValue)
+{
+	sInputClassName = sValue;
+}
+
+inline const ALString& CCDeploymentSpec::GetInputObjectArrayAttributeName() const
+{
+	return sInputObjectArrayAttributeName;
+}
+
+inline void CCDeploymentSpec::SetInputObjectArrayAttributeName(const ALString& sValue)
+{
+	sInputObjectArrayAttributeName = sValue;
+}
+
+inline const ALString& CCDeploymentSpec::GetDeployedAttributeName() const
+{
+	return sDeployedAttributeName;
+}
+
+inline void CCDeploymentSpec::SetDeployedAttributeName(const ALString& sValue)
+{
+	sDeployedAttributeName = sValue;
 }
 
 // ## Custom inlines

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpecView.cpp
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpecView.cpp
@@ -23,18 +23,6 @@ CCDeploymentSpecView::CCDeploymentSpecView()
 	// ## Custom constructor
 
 	// Info-bulles
-	GetFieldAt("InputClassName")
-	    ->SetHelpText("Name of the dictionary that corresponds to the deployment database"
-			  "\n that contains the instances of interest. Only needed for "
-			  "variable x variable coclustering.");
-	GetFieldAt("InputObjectArrayAttributeName")
-	    ->SetHelpText("Name of the table variable in the input dictionary"
-			  "\n that contains the detailed record for each instance of interest. Only needed for "
-			  "variable x variable coclustering.");
-	GetFieldAt("DeployedAttributeName")
-	    ->SetHelpText("Name of the deployed variable, i.e. one of the coclustering variables,"
-			  "\n which represents the entity of interest. Only needed for "
-			  "variable x variable coclustering.");
 	GetFieldAt("BuildPredictedClusterAttribute")
 	    ->SetHelpText("Indicate that the deployment model must generate a new variable"
 			  "\n containing the label of the cluster of the entity of interest.");
@@ -44,6 +32,20 @@ CCDeploymentSpecView::CCDeploymentSpecView()
 	GetFieldAt("BuildFrequencyRecodingAttributes")
 	    ->SetHelpText("Indicates that the deployment model must generate new variables"
 			  "\n representing the frequency per cluster of the other coclustering variables.");
+	GetFieldAt("OutputAttributesPrefix")
+	    ->SetHelpText("Prefix added to the deployment variables in the deployment dictionary.");
+	GetFieldAt("InputClassName")
+	    ->SetHelpText("Name of the dictionary that corresponds to the deployment database"
+			  "\n that contains the instances of interest."
+			  "\n Required only for variable x variable coclustering.");
+	GetFieldAt("InputObjectArrayAttributeName")
+	    ->SetHelpText("Name of the table variable in the input dictionary"
+			  "\n that contains the detailed record for each instance of interest."
+			  "\n Required only for variable x variable coclustering.");
+	GetFieldAt("DeployedAttributeName")
+	    ->SetHelpText("Name of the deployed variable, i.e. one of the coclustering variables,"
+			  "\n which represents the entity of interest."
+			  "\n Required only for variable x variable coclustering.");
 
 	// ##
 }

--- a/src/Learning/MODL_Coclustering/CCDeploymentSpecView.cpp
+++ b/src/Learning/MODL_Coclustering/CCDeploymentSpecView.cpp
@@ -12,26 +12,29 @@ CCDeploymentSpecView::CCDeploymentSpecView()
 {
 	SetIdentifier("CCDeploymentSpec");
 	SetLabel("Deployment parameters");
-	AddStringField("InputClassName", "Input dictionary", "");
-	AddStringField("InputObjectArrayAttributeName", "Input table variable", "");
-	AddStringField("DeployedAttributeName", "Coclustering deployed variable", "");
 	AddBooleanField("BuildPredictedClusterAttribute", "Build predicted cluster variable", false);
 	AddBooleanField("BuildClusterDistanceAttributes", "Build inter-cluster distance variables", false);
 	AddBooleanField("BuildFrequencyRecodingAttributes", "Build frequency recoding variables", false);
 	AddStringField("OutputAttributesPrefix", "Output variables prefix", "");
+	AddStringField("InputClassName", "Input dictionary", "");
+	AddStringField("InputObjectArrayAttributeName", "Input table variable", "");
+	AddStringField("DeployedAttributeName", "Coclustering deployed variable", "");
 
 	// ## Custom constructor
 
 	// Info-bulles
 	GetFieldAt("InputClassName")
 	    ->SetHelpText("Name of the dictionary that corresponds to the deployment database"
-			  "\n that contains the instances of interest.");
+			  "\n that contains the instances of interest. Only needed for "
+			  "variable x variable coclustering.");
 	GetFieldAt("InputObjectArrayAttributeName")
 	    ->SetHelpText("Name of the table variable in the input dictionary"
-			  "\n that contains the detailed record for each instance of interest.");
+			  "\n that contains the detailed record for each instance of interest. Only needed for "
+			  "variable x variable coclustering.");
 	GetFieldAt("DeployedAttributeName")
 	    ->SetHelpText("Name of the deployed variable, i.e. one of the coclustering variables,"
-			  "\n which represents the entity of interest.");
+			  "\n which represents the entity of interest. Only needed for "
+			  "variable x variable coclustering.");
 	GetFieldAt("BuildPredictedClusterAttribute")
 	    ->SetHelpText("Indicate that the deployment model must generate a new variable"
 			  "\n containing the label of the cluster of the entity of interest.");
@@ -41,8 +44,6 @@ CCDeploymentSpecView::CCDeploymentSpecView()
 	GetFieldAt("BuildFrequencyRecodingAttributes")
 	    ->SetHelpText("Indicates that the deployment model must generate new variables"
 			  "\n representing the frequency per cluster of the other coclustering variables.");
-	GetFieldAt("OutputAttributesPrefix")
-	    ->SetHelpText("Prefix added to the deployment variables in the deployment dictionary.");
 
 	// ##
 }
@@ -67,13 +68,13 @@ void CCDeploymentSpecView::EventUpdate(Object* object)
 	require(object != NULL);
 
 	editedObject = cast(CCDeploymentSpec*, object);
-	editedObject->SetInputClassName(GetStringValueAt("InputClassName"));
-	editedObject->SetInputObjectArrayAttributeName(GetStringValueAt("InputObjectArrayAttributeName"));
-	editedObject->SetDeployedAttributeName(GetStringValueAt("DeployedAttributeName"));
 	editedObject->SetBuildPredictedClusterAttribute(GetBooleanValueAt("BuildPredictedClusterAttribute"));
 	editedObject->SetBuildClusterDistanceAttributes(GetBooleanValueAt("BuildClusterDistanceAttributes"));
 	editedObject->SetBuildFrequencyRecodingAttributes(GetBooleanValueAt("BuildFrequencyRecodingAttributes"));
 	editedObject->SetOutputAttributesPrefix(GetStringValueAt("OutputAttributesPrefix"));
+	editedObject->SetInputClassName(GetStringValueAt("InputClassName"));
+	editedObject->SetInputObjectArrayAttributeName(GetStringValueAt("InputObjectArrayAttributeName"));
+	editedObject->SetDeployedAttributeName(GetStringValueAt("DeployedAttributeName"));
 
 	// ## Custom update
 
@@ -87,13 +88,13 @@ void CCDeploymentSpecView::EventRefresh(Object* object)
 	require(object != NULL);
 
 	editedObject = cast(CCDeploymentSpec*, object);
-	SetStringValueAt("InputClassName", editedObject->GetInputClassName());
-	SetStringValueAt("InputObjectArrayAttributeName", editedObject->GetInputObjectArrayAttributeName());
-	SetStringValueAt("DeployedAttributeName", editedObject->GetDeployedAttributeName());
 	SetBooleanValueAt("BuildPredictedClusterAttribute", editedObject->GetBuildPredictedClusterAttribute());
 	SetBooleanValueAt("BuildClusterDistanceAttributes", editedObject->GetBuildClusterDistanceAttributes());
 	SetBooleanValueAt("BuildFrequencyRecodingAttributes", editedObject->GetBuildFrequencyRecodingAttributes());
 	SetStringValueAt("OutputAttributesPrefix", editedObject->GetOutputAttributesPrefix());
+	SetStringValueAt("InputClassName", editedObject->GetInputClassName());
+	SetStringValueAt("InputObjectArrayAttributeName", editedObject->GetInputObjectArrayAttributeName());
+	SetStringValueAt("DeployedAttributeName", editedObject->GetDeployedAttributeName());
 
 	// ## Custom refresh
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
@@ -619,27 +619,49 @@ void CCLearningProblem::PrepareDeployment()
 	if (bOk)
 		bOk = coclusteringReport.ReadReport(sCoclusteringReportFileName, &coclusteringDataGrid);
 
-	// Cas d'un rapport issu d'un coclustering instances * variables : fonctionnalite non implementee
-	if (coclusteringDataGrid.IsVarPartDataGrid())
-	{
-		bOk = false;
-		if (not GetVarPartDeploymentMode())
-			AddWarning(
-			    "Deployment preparation is not yet implemented for instances * variables coclustering");
-		else
-			AddWarning(
-			    "Deployment dictionary is automatically produced during instances * variables coclustering "
-			    "training.");
-	}
-
 	// Post-traitement
 	if (bOk)
 		bOk = GetPostProcessingSpec()->PostProcessCoclustering(&coclusteringDataGrid);
 
 	// Preparation d'un dictionnaire de deploiement
 	deploymentDomain = NULL;
-	if (bOk)
-		bOk = GetDeploymentSpec()->PrepareCoclusteringDeployment(&coclusteringDataGrid, deploymentDomain);
+
+	// Cas d'un rapport issu d'un coclustering instances * variables
+	// Fonctionnalite implementee uniquement en mode expert
+	if (coclusteringDataGrid.IsVarPartDataGrid())
+	{
+		if (not GetVarPartDeploymentMode())
+		{
+			AddWarning("Deployment preparation is not yet implemented for instances * variables "
+				   "coclustering");
+			bOk = false;
+		}
+
+		else
+		{
+			// Initialisation du varPartDeploymentSpec
+			GetDeploymentSpec()->SetDeployedAttributeName(
+			    coclusteringDataGrid.GetIdentifierAttributeName());
+			GetDeploymentSpec()->SetInputClassName(GetClassName());
+
+			// Creation du dictionnaire de deploiement
+			if (bOk)
+				bOk = GetDeploymentSpec()->PrepareVarPartCoclusteringDeployment(&coclusteringDataGrid,
+												deploymentDomain);
+
+			// Nettoyage du varParDeploymentSpec
+			GetDeploymentSpec()->SetDeployedAttributeName("");
+			GetDeploymentSpec()->SetInputClassName("");
+		}
+	}
+
+	// Sinon : cas d'un coclustering variable * variable
+	else
+	{
+		if (bOk)
+			bOk =
+			    GetDeploymentSpec()->PrepareCoclusteringDeployment(&coclusteringDataGrid, deploymentDomain);
+	}
 
 	// Ecriture du fichier de dictionnaire de deploiement
 	if (bOk)

--- a/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
@@ -385,33 +385,6 @@ void CCLearningProblem::BuildCoclustering()
 					    " out of the " +
 					    IntToString(coclusteringBuilder.GetVarPartCoclusteringAttributeNumber()) +
 					    " dimensions");
-
-				if (GetVarPartDeploymentMode())
-				{
-					// Initialisation du varPartDeploymentSpec
-					ccVarPartDeploymentSpec.SetDeployedAttributeName(
-					    coclusteringBuilder.GetIdentifierAttributeName());
-					ccVarPartDeploymentSpec.SetInputClassName(GetClassName());
-
-					// Creation du dictionnaire de deploiement
-					bDeploymentOk = ccVarPartDeploymentSpec.PrepareVarPartCoclusteringDeployment(
-					    coclusteringBuilder.GetCoclusteringDataGrid(), deploymentDomain);
-
-					// Ecriture du fichier de dictionnaire de deploiement
-					if (bDeploymentOk)
-					{
-						sCoclusteringDictionaryFileName =
-						    GetResultFilePathBuilder(TaskBuildCoclustering)
-							->BuildOtherResultFilePathName("model.kdic");
-						AddSimpleMessage("Write deployment dictionary file " +
-								 sCoclusteringDictionaryFileName);
-						deploymentDomain->WriteFile(sCoclusteringDictionaryFileName);
-					}
-
-					// Nettoyage
-					if (bDeploymentOk)
-						delete deploymentDomain;
-				}
 			}
 		}
 		// Sinon : on ecrit un rapport avec les eventuels messages d'erreurs

--- a/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblem.cpp
@@ -575,6 +575,8 @@ void CCLearningProblem::PrepareDeployment()
 	ALString sCoclusteringDictionaryFileName;
 	CCHierarchicalDataGrid coclusteringDataGrid;
 	KWClassDomain* deploymentDomain;
+	ALString sPreviousDeployedAttributeName;
+	ALString sPreviousClassName;
 
 	require(CheckResultFileNames(TaskPrepareDeployment));
 
@@ -612,6 +614,10 @@ void CCLearningProblem::PrepareDeployment()
 
 		else
 		{
+			// Memorisation des eventuels parametrages prealables
+			sPreviousDeployedAttributeName = GetDeploymentSpec()->GetDeployedAttributeName();
+			sPreviousClassName = GetDeploymentSpec()->GetInputClassName();
+
 			// Initialisation du varPartDeploymentSpec
 			GetDeploymentSpec()->SetDeployedAttributeName(
 			    coclusteringDataGrid.GetIdentifierAttributeName());
@@ -623,8 +629,8 @@ void CCLearningProblem::PrepareDeployment()
 												deploymentDomain);
 
 			// Nettoyage du varParDeploymentSpec
-			GetDeploymentSpec()->SetDeployedAttributeName("");
-			GetDeploymentSpec()->SetInputClassName("");
+			GetDeploymentSpec()->SetDeployedAttributeName(sPreviousDeployedAttributeName);
+			GetDeploymentSpec()->SetInputClassName(sPreviousClassName);
 		}
 	}
 

--- a/src/Learning/MODL_Coclustering/CCLearningProblemDeploymentPreparationView.cpp
+++ b/src/Learning/MODL_Coclustering/CCLearningProblemDeploymentPreparationView.cpp
@@ -19,7 +19,7 @@ CCLearningProblemDeploymentPreparationView::CCLearningProblemDeploymentPreparati
 	GetFieldAt("ClassFileName")->SetEditable(false);
 
 	// Champ du dictionnaire de deploiement en resultat
-	AddStringField("CoclusteringDictionaryFileName", "Coclustering dictionary file", "");
+	AddStringField("CoclusteringDictionaryFileName", "Deployment dictionary file", "");
 	GetFieldAt("CoclusteringDictionaryFileName")->SetStyle("FileChooser");
 
 	// Creation des sous fiches (creation generique pour les vues sur bases de donnees)

--- a/src/Learning/MODL_Coclustering/CCPostProcessingSpec.cpp
+++ b/src/Learning/MODL_Coclustering/CCPostProcessingSpec.cpp
@@ -292,7 +292,7 @@ void CCPostProcessingSpec::UpdateCoclusteringSpec(const ALString& sCoclusteringR
 		bOk = coclusteringReport.ReadReportHeader(sCoclusteringReportFileName, &coclusteringDataGrid,
 							  nInstanceNumber, nNonEmptyCellNumber);
 
-	// On rappatrie les informations du rapport
+	// On rapatrie les informations du rapport
 	if (bOk)
 	{
 		// Attribute identifiant (coclustering instances * variables)
@@ -323,7 +323,7 @@ void CCPostProcessingSpec::UpdateCoclusteringSpec(const ALString& sCoclusteringR
 		}
 	}
 
-	// On rappatrie les spec precedentes si coclustering de reference est egal au nouveau coclustering
+	// On rapatrie les spec precedentes si coclustering de reference est egal au nouveau coclustering
 	if (bOk)
 	{
 		// Evaluation si le coclustering est le meme
@@ -358,7 +358,7 @@ void CCPostProcessingSpec::UpdateCoclusteringSpec(const ALString& sCoclusteringR
 			}
 		}
 
-		// On rappartie les spec de reference en cas de matching du coclustering de reference
+		// On rapatrie les spec de reference en cas de matching du coclustering de reference
 		if (bSameCoclustering)
 			CopyFrom(&refPostProcessingSpec);
 	}


### PR DESCRIPTION
- suppression de l'appel de PreparaVarPartCoclusteringDeploymenet apres le calcul du coclustering dans CCLearningProblem::PrepareDeployment
- modification dans l'interface de l'ordre des champs dans l'onglet 'Deployment parameters' afin que les champs specifiques au coclustering Variable x variable soient à la fin
- complement de messages dans les infos bulles de l'onglet Deployment parameters pour distinguer le cas V*V du cas I*V
- ajout de l'appel de PrepareVarPartCoclusteringDeployment en mode Expert pour lancer la creation du dictionnaire de deploiement dans le cas individus * variables dans CCLearningProblem::PrepareDeployment
- ajout de MetaData pour les attributs du dictionnaire de deploiement donnant le label de la partie de variable pour chaque inner variable : <InnerVariable="NomVariable"> <PartLabel>
- Dans learningtest : ajout d'un repertoire de test dans TestCoclustering/y_DeployCoclusteringIV/DeployDistributionIrisIV