### PR TITLE
Add cloud dataset support to LearningTestTool (issue #944)

### DIFF
--- a/test/LearningTestTool/README.md
+++ b/test/LearningTestTool/README.md
@@ -316,18 +316,39 @@ This allows running the full LearningTest suite without storing the large datase
 
 #### Setup
 
+In addition to the dataset collections, cloud execution also needs test-local assets stored in test dirs
+(for example local dictionaries such as `./*.kdic` and local data files referenced from `./`).
+These files are part of the `scripts` export type.
+
+Minimal way to prepare a cloud `LearningTest` tree (example with `-f basic`):
+
+```bash
+# 1) Export dataset collections -> /tmp/LearningTest_datasets
+kht_export ../LearningTest/ /tmp/ -f basic --export-type datasets
+
+# 2) Export test scripts and local test assets -> /tmp/LearningTest_scripts
+kht_export ../LearningTest/ /tmp/ -f basic --export-type scripts
+
+# 3) Merge both exports into one single LearningTest tree
+mkdir -p /tmp/LearningTest
+cp -R /tmp/LearningTest_datasets/. /tmp/LearningTest/
+cp -R /tmp/LearningTest_scripts/. /tmp/LearningTest/
+```
+
+After this merge, upload `/tmp/LearningTest/` to your cloud bucket/container. The resulting cloud tree must
+contain both dataset collections (`datasets/`, `MTdatasets/`, `TextDatasets/`) and tool test dirs
+(`TestKhiops/`, `TestCoclustering/`, `TestKNI/`) with their `test.prm` and local files.
+
 Two copies of the LearningTest tree are maintained:
 
 | Location | What it contains |
 |---|---|
 | **Local disk** | Scenarios (`test.prm`), reference results (`results.ref/`), tool dirs and suite dirs structure — **no dataset files** |
-| **Cloud storage** | Dataset collections (`datasets/`, `MTdatasets/`, `TextDatasets/`) — the full copy needed for Khiops to run |
+| **Cloud storage** | A runnable LearningTest subset: dataset collections (`datasets/`, `MTdatasets/`, `TextDatasets/`) **and** test scripts/local assets under tool dirs (`TestKhiops/`, `TestCoclustering/`, `TestKNI/`) |
 
-Upload the dataset collections to the cloud once (example with GCS):
+If you already prepared `/tmp/LearningTest` with both exports (datasets + scripts), upload that merged tree once (example with GCS):
 ```
-gcloud storage cp -r LearningTest/datasets   gs://my-bucket/LearningTest/datasets
-gcloud storage cp -r LearningTest/MTdatasets gs://my-bucket/LearningTest/MTdatasets
-gcloud storage cp -r LearningTest/TextDatasets gs://my-bucket/LearningTest/TextDatasets
+gcloud storage cp -r /tmp/LearningTest gs://my-bucket/
 ```
 
 The same principle applies for S3 (`aws s3 cp --recursive`) or Azure (`az storage blob upload-batch`).
@@ -353,16 +374,6 @@ kht_test LearningTest/TestKhiops/Standard/Iris r --cloud-directory gs://my-bucke
 After this step each test dir's local `results/` folder contains `err.txt` and the Python-written
 diagnostic files. The console also prints the path to the local `err.txt` for each test, enabling
 a quick sanity check (fatal errors, batch mode failures) **before downloading anything from the cloud**.
-
-**Optional quick check after Step 1**
-
-Inspect the local `err.txt` files to catch obvious failures immediately:
-```bash
-kht_apply LearningTest errors    # list tests with errors in comparisonResults.log
-grep -r "Fatal error" LearningTest/TestKhiops/*/results/err.txt
-```
-
-Note: `err.txt` may contain cloud URIs in Khiops error messages; these will be normalised in Step 3.
 
 **Step 2 – Download the Khiops result files**
 

--- a/test/LearningTestTool/README.md
+++ b/test/LearningTestTool/README.md
@@ -338,9 +338,9 @@ The same principle applies for S3 (`aws s3 cp --recursive`) or Azure (`az storag
 
 Pass `--cloud-directory` to `kht_test`. Khiops generates a temporary scenario that replaces
 local relative paths (`../../../`) with cloud URIs, runs against the cloud datasets, and writes
-all its output files (`.khj`, `.kdic`, `.xls`, `err.txt`, …) back to the cloud.
-Only files written directly by the Python test runner (`stdout_error.log`, `stderr_error.log`,
-`return_code_error.log`, `process_timeout_error.log`, `time.log`) remain **local**.
+its Khiops output files (`.khj`, `.kdic`, `.xls`, output scenarios, task file, …) back to the cloud.
+`err.txt` and all Python diagnostic files (`stdout_error.log`, `stderr_error.log`,
+`return_code_error.log`, `process_timeout_error.log`, `time.log`) are written **locally**.
 
 ```bash
 # Full family, 4 processes, GCS example
@@ -350,8 +350,19 @@ kht_test LearningTest r --cloud-directory gs://my-bucket/LearningTest -p 4
 kht_test LearningTest/TestKhiops/Standard/Iris r --cloud-directory gs://my-bucket/LearningTest
 ```
 
-After this step each test dir's local `results/` folder contains only the Python-written files;
-the Khiops output files are on the cloud.
+After this step each test dir's local `results/` folder contains `err.txt` and the Python-written
+diagnostic files. The console also prints the path to the local `err.txt` for each test, enabling
+a quick sanity check (fatal errors, batch mode failures) **before downloading anything from the cloud**.
+
+**Optional quick check after Step 1**
+
+Inspect the local `err.txt` files to catch obvious failures immediately:
+```bash
+kht_apply LearningTest errors    # list tests with errors in comparisonResults.log
+grep -r "Fatal error" LearningTest/TestKhiops/*/results/err.txt
+```
+
+Note: `err.txt` may contain cloud URIs in Khiops error messages; these will be normalised in Step 3.
 
 **Step 2 – Download the Khiops result files**
 
@@ -407,6 +418,20 @@ kht_test LearningTest/TestKhiops/Standard check
 If errors are found, use the standard `kht_apply errors` and `kht_apply logs` instructions
 to analyse them. To update the reference results after a confirmed algorithm change,
 use `kht_apply makeref` as usual.
+
+#### Notes on locally-written files
+
+**`err.txt`** is written locally (not to the cloud) so you can inspect Khiops errors immediately
+after Step 1 without downloading anything. It may contain cloud URIs in error messages (e.g.
+`gs://…/datasets/…`); these are normalised by `transform-cloud-results` in Step 3 so that
+`kht_test check` in Step 4 compares correctly against `results.ref/err.txt`.
+
+**`time.log`** records the **wall-clock time on the machine running `kht_test`**, including
+cloud I/O latency, not pure Khiops computation time. This will differ from `results.ref/time.log`.
+The comparison engine already tolerates these differences so they do not cause false errors.
+`--min-test-time` / `--max-test-time` filters are based on the **reference** time (unaffected).
+If `kht_apply makeref` is used after a cloud run, `results.ref/time.log` will reflect
+cloud-run wall-clock times — harmless but worth being aware of for `kht_apply times` reports.
 
 ### CI/CD
 

--- a/test/LearningTestTool/README.md
+++ b/test/LearningTestTool/README.md
@@ -1,6 +1,44 @@
 # Khiops test tool: LearningTest and LearningTestTool
 
-LearningTest
+
+
+
+<!-- @import "[TOC]" {cmd="toc" depthFrom=1 depthTo=6 orderedList=false} -->
+
+<!-- code_chunk_output -->
+
+- [Khiops test tool: LearningTest and LearningTestTool](#khiops-test-tool-learningtest-and-learningtesttool)
+  - [LearningTest](#learningtest)
+    - [LearningTest directory tree](#learningtest-directory-tree)
+    - [Test dirs](#test-dirs)
+    - [Normalisation of paths in scenarios](#normalisation-of-paths-in-scenarios)
+    - [Variants of references results](#variants-of-references-results)
+  - [LearningTestTool](#learningtesttool)
+    - [Terminology](#terminology)
+  - [LearningTest commands](#learningtest-commands)
+    - [LearningTestTool directory tree](#learningtesttool-directory-tree)
+    - [Implementation of LearningTestTool](#implementation-of-learningtesttool)
+  - [Running Khiops tests](#running-khiops-tests)
+  - [Main usages](#main-usages)
+    - [Test methodology](#test-methodology)
+    - [Non-regression tests for developpement](#non-regression-tests-for-developpement)
+    - [Non-regression tests for release](#non-regression-tests-for-release)
+    - [Portability on new platform](#portability-on-new-platform)
+    - [CI/CD](#cicd)
+  - [Evolutions of LearningTest](#evolutions-of-learningtest)
+    - [New test dir](#new-test-dir)
+    - [New test suite](#new-test-suite)
+    - [Evolution of scenarios](#evolution-of-scenarios)
+    - [Evolution of reference results](#evolution-of-reference-results)
+  - [Management of LearningTest and LearningTestTool](#management-of-learningtest-and-learningtesttool)
+  - [Testing with datasets on the cloud](#testing-with-datasets-on-the-cloud)
+    - [Setup](#setup)
+    - [Full test process](#full-test-process)
+    - [Notes on locally-written files](#notes-on-locally-written-files)
+
+<!-- /code_chunk_output -->
+
+LearningTest:
 - created in March 2009
 - automated test of Khiops tools
 - versions synchronized with delivered Khiops versions
@@ -309,141 +347,6 @@ The aim is check that the new platform is supported by the tool.
 
 The tests must be run on the new platform, using the _full_ family.
 
-### Testing with datasets on the cloud
-
-Khiops supports cloud storage drivers (GCS, S3, Azure) and can read datasets directly from a cloud URI at runtime.
-This allows running the full LearningTest suite without storing the large datasets (~5 GB) on the local machine.
-
-#### Setup
-
-In addition to the dataset collections, cloud execution also needs test-local assets stored in test dirs
-(for example local dictionaries such as `./*.kdic` and local data files referenced from `./`).
-These files are part of the `scripts` export type.
-
-Minimal way to prepare a cloud `LearningTest` tree (example with `-f basic`):
-
-```bash
-# 1) Export dataset collections -> /tmp/LearningTest_datasets
-kht_export ../LearningTest/ /tmp/ -f basic --export-type datasets
-
-# 2) Export test scripts and local test assets -> /tmp/LearningTest_scripts
-kht_export ../LearningTest/ /tmp/ -f basic --export-type scripts
-
-# 3) Merge both exports into one single LearningTest tree
-mkdir -p /tmp/LearningTest
-cp -R /tmp/LearningTest_datasets/. /tmp/LearningTest/
-cp -R /tmp/LearningTest_scripts/. /tmp/LearningTest/
-```
-
-After this merge, upload `/tmp/LearningTest/` to your cloud bucket/container. The resulting cloud tree must
-contain both dataset collections (`datasets/`, `MTdatasets/`, `TextDatasets/`) and tool test dirs
-(`TestKhiops/`, `TestCoclustering/`, `TestKNI/`) with their `test.prm` and local files.
-
-Two copies of the LearningTest tree are maintained:
-
-| Location | What it contains |
-|---|---|
-| **Local disk** | Scenarios (`test.prm`), reference results (`results.ref/`), tool dirs and suite dirs structure — **no dataset files** |
-| **Cloud storage** | A runnable LearningTest subset: dataset collections (`datasets/`, `MTdatasets/`, `TextDatasets/`) **and** test scripts/local assets under tool dirs (`TestKhiops/`, `TestCoclustering/`, `TestKNI/`) |
-
-If you already prepared `/tmp/LearningTest` with both exports (datasets + scripts), upload that merged tree once (example with GCS):
-```
-gcloud storage cp -r /tmp/LearningTest gs://my-bucket/
-```
-
-The same principle applies for S3 (`aws s3 cp --recursive`) or Azure (`az storage blob upload-batch`).
-
-#### Full test process
-
-**Step 1 – Run the tests with cloud datasets**
-
-Pass `--cloud-directory` to `kht_test`. Khiops generates a temporary scenario that replaces
-local relative paths (`../../../`) with cloud URIs, runs against the cloud datasets, and writes
-its Khiops output files (`.khj`, `.kdic`, `.xls`, output scenarios, task file, …) back to the cloud.
-`err.txt` and all Python diagnostic files (`stdout_error.log`, `stderr_error.log`,
-`return_code_error.log`, `process_timeout_error.log`, `time.log`) are written **locally**.
-
-```bash
-# Full family, 4 processes, GCS example
-kht_test LearningTest r --cloud-directory gs://my-bucket/LearningTest -p 4
-
-# Or for a single test dir
-kht_test LearningTest/TestKhiops/Standard/Iris r --cloud-directory gs://my-bucket/LearningTest
-```
-
-After this step each test dir's local `results/` folder contains `err.txt` and the Python-written
-diagnostic files. The console also prints the path to the local `err.txt` for each test, enabling
-a quick sanity check (fatal errors, batch mode failures) **before downloading anything from the cloud**.
-
-**Step 2 – Download the Khiops result files**
-
-Use the cloud provider CLI to copy the result directories back to the local machine,
-merging with the already-present Python-written files:
-
-```bash
-# GCS – download results for all Khiops test dirs
-gcloud storage cp -r \
-  "gs://my-bucket/LearningTest/TestKhiops/*/results" \
-  ./LearningTest/TestKhiops/
-
-# GCS – download results for all tools
-for tool in TestKhiops TestCoclustering TestKNI; do
-  gcloud storage cp -r \
-    "gs://my-bucket/LearningTest/$tool/*/results" \
-    ./LearningTest/$tool/
-done
-```
-
-Equivalent commands for S3:
-```bash
-aws s3 cp --recursive s3://my-bucket/LearningTest/ ./LearningTest/ \
-  --exclude "*" --include "*/results/*"
-```
-
-**Step 3 – Normalize cloud paths in result files**
-
-The downloaded result files (`.khj`, …) still contain cloud URIs as data paths.
-Replace them with local relative paths before comparison:
-
-```bash
-kht_apply LearningTest transform-cloud-results \
-  --cloud-directory gs://my-bucket/LearningTest
-
-# Or for a single suite
-kht_apply LearningTest/TestKhiops/Standard transform-cloud-results \
-  --cloud-directory gs://my-bucket/LearningTest
-```
-
-This instruction also calls the version-string cleaner that `kht_test` normally runs
-after execution, so the result files are ready for comparison.
-
-**Step 4 – Compare results against references**
-
-```bash
-kht_test LearningTest check
-
-# Or targeted
-kht_test LearningTest/TestKhiops/Standard check
-```
-
-If errors are found, use the standard `kht_apply errors` and `kht_apply logs` instructions
-to analyse them. To update the reference results after a confirmed algorithm change,
-use `kht_apply makeref` as usual.
-
-#### Notes on locally-written files
-
-**`err.txt`** is written locally (not to the cloud) so you can inspect Khiops errors immediately
-after Step 1 without downloading anything. It may contain cloud URIs in error messages (e.g.
-`gs://…/datasets/…`); these are normalised by `transform-cloud-results` in Step 3 so that
-`kht_test check` in Step 4 compares correctly against `results.ref/err.txt`.
-
-**`time.log`** records the **wall-clock time on the machine running `kht_test`**, including
-cloud I/O latency, not pure Khiops computation time. This will differ from `results.ref/time.log`.
-The comparison engine already tolerates these differences so they do not cause false errors.
-`--min-test-time` / `--max-test-time` filters are based on the **reference** time (unaffected).
-If `kht_apply makeref` is used after a cloud run, `results.ref/time.log` will reflect
-cloud-run wall-clock times — harmless but worth being aware of for `kht_apply times` reports.
-
 ### CI/CD
 
 The tests can be run at different steps of the developpement process:
@@ -559,5 +462,138 @@ The full LearningTest directory tree cannot be embedded in the Khiops github rep
 - cost: storing and managing a large number of tests on dozens of platforms can be expensive in an external cloud
 
 
+## Testing with datasets on the cloud
 
+Khiops supports cloud storage drivers (GCS, S3, Azure) and can read datasets directly from a cloud URI at runtime.
+This allows running the full LearningTest suite without storing the large datasets (~5 GB) on the local machine.
+
+### Setup
+
+In addition to the dataset collections, cloud execution also needs test-local assets stored in test dirs
+(for example local dictionaries such as `./*.kdic` and local data files referenced from `./`).
+These files are part of the `scripts` export type.
+
+Minimal way to prepare a cloud `LearningTest` tree (example with `-f basic`):
+
+```bash
+# 1) Export dataset collections -> /tmp/LearningTest_datasets
+kht_export ../LearningTest/ /tmp/ -f basic --export-type datasets
+
+# 2) Export test scripts and local test assets -> /tmp/LearningTest_scripts
+kht_export ../LearningTest/ /tmp/ -f basic --export-type scripts
+
+# 3) Merge both exports into one single LearningTest tree
+mkdir -p /tmp/LearningTest
+cp -R /tmp/LearningTest_datasets/. /tmp/LearningTest/
+cp -R /tmp/LearningTest_scripts/. /tmp/LearningTest/
+```
+
+After this merge, upload `/tmp/LearningTest/` to your cloud bucket/container. The resulting cloud tree must
+contain both dataset collections (`datasets/`, `MTdatasets/`, `TextDatasets/`) and tool test dirs
+(`TestKhiops/`, `TestCoclustering/`, `TestKNI/`) with their `test.prm` and local files.
+
+Two copies of the LearningTest tree are maintained:
+
+| Location | What it contains |
+|---|---|
+| **Local disk** | Scenarios (`test.prm`), reference results (`results.ref/`), tool dirs and suite dirs structure — **no dataset files** |
+| **Cloud storage** | A runnable LearningTest subset: dataset collections (`datasets/`, `MTdatasets/`, `TextDatasets/`) **and** test scripts/local assets under tool dirs (`TestKhiops/`, `TestCoclustering/`, `TestKNI/`) |
+
+If you already prepared `/tmp/LearningTest` with both exports (datasets + scripts), upload that merged tree once (example with GCS):
+```
+gcloud storage cp -r /tmp/LearningTest gs://my-bucket/
+```
+
+The same principle applies for S3 (`aws s3 cp --recursive`) or Azure (`az storage blob upload-batch`).
+
+### Full test process
+
+**Step 1 – Run the tests with cloud datasets**
+
+Pass `--cloud-directory` to `kht_test`. Khiops generates a temporary scenario that replaces
+local relative paths (`../../../`) with cloud URIs, runs against the cloud datasets, and writes
+its Khiops output files (`.khj`, `.kdic`, `.xls`, output scenarios, task file, …) back to the cloud.
+`err.txt` and all Python diagnostic files (`stdout_error.log`, `stderr_error.log`,
+`return_code_error.log`, `process_timeout_error.log`, `time.log`) are written **locally**.
+
+```bash
+# Full family, 4 processes, GCS example
+kht_test LearningTest r --cloud-directory gs://my-bucket/LearningTest -p 4
+
+# Or for a single test dir
+kht_test LearningTest/TestKhiops/Standard/Iris r --cloud-directory gs://my-bucket/LearningTest
+```
+
+After this step each test dir's local `results/` folder contains `err.txt` and the Python-written
+diagnostic files. The console also prints the path to the local `err.txt` for each test, enabling
+a quick sanity check (fatal errors, batch mode failures) **before downloading anything from the cloud**.
+
+**Step 2 – Download the Khiops result files**
+
+Use the cloud provider CLI to copy the result directories back to the local machine,
+merging with the already-present Python-written files:
+
+```bash
+# GCS – download results for all Khiops test dirs
+gcloud storage cp -r \
+  "gs://my-bucket/LearningTest/TestKhiops/*/results" \
+  ./LearningTest/TestKhiops/
+
+# GCS – download results for all tools
+for tool in TestKhiops TestCoclustering TestKNI; do
+  gcloud storage cp -r \
+    "gs://my-bucket/LearningTest/$tool/*/results" \
+    ./LearningTest/$tool/
+done
+```
+
+Equivalent commands for S3:
+```bash
+aws s3 cp --recursive s3://my-bucket/LearningTest/ ./LearningTest/ \
+  --exclude "*" --include "*/results/*"
+```
+
+**Step 3 – Normalize cloud paths in result files**
+
+The downloaded result files (`.khj`, …) still contain cloud URIs as data paths.
+Replace them with local relative paths before comparison:
+
+```bash
+kht_apply LearningTest transform-cloud-results \
+  --cloud-directory gs://my-bucket/LearningTest
+
+# Or for a single suite
+kht_apply LearningTest/TestKhiops/Standard transform-cloud-results \
+  --cloud-directory gs://my-bucket/LearningTest
+```
+
+This instruction also calls the version-string cleaner that `kht_test` normally runs
+after execution, so the result files are ready for comparison.
+
+**Step 4 – Compare results against references**
+
+```bash
+kht_test LearningTest check
+
+# Or targeted
+kht_test LearningTest/TestKhiops/Standard check
+```
+
+If errors are found, use the standard `kht_apply errors` and `kht_apply logs` instructions
+to analyse them. To update the reference results after a confirmed algorithm change,
+use `kht_apply makeref` as usual.
+
+### Notes on locally-written files
+
+**`err.txt`** is written locally (not to the cloud) so you can inspect Khiops errors immediately
+after Step 1 without downloading anything. It may contain cloud URIs in error messages (e.g.
+`gs://…/datasets/…`); these are normalised by `transform-cloud-results` in Step 3 so that
+`kht_test check` in Step 4 compares correctly against `results.ref/err.txt`.
+
+**`time.log`** records the **wall-clock time on the machine running `kht_test`**, including
+cloud I/O latency, not pure Khiops computation time. This will differ from `results.ref/time.log`.
+The comparison engine already tolerates these differences so they do not cause false errors.
+`--min-test-time` / `--max-test-time` filters are based on the **reference** time (unaffected).
+If `kht_apply makeref` is used after a cloud run, `results.ref/time.log` will reflect
+cloud-run wall-clock times — harmless but worth being aware of for `kht_apply times` reports.
 

--- a/test/LearningTestTool/README.md
+++ b/test/LearningTestTool/README.md
@@ -309,6 +309,105 @@ The aim is check that the new platform is supported by the tool.
 
 The tests must be run on the new platform, using the _full_ family.
 
+### Testing with datasets on the cloud
+
+Khiops supports cloud storage drivers (GCS, S3, Azure) and can read datasets directly from a cloud URI at runtime.
+This allows running the full LearningTest suite without storing the large datasets (~5 GB) on the local machine.
+
+#### Setup
+
+Two copies of the LearningTest tree are maintained:
+
+| Location | What it contains |
+|---|---|
+| **Local disk** | Scenarios (`test.prm`), reference results (`results.ref/`), tool dirs and suite dirs structure — **no dataset files** |
+| **Cloud storage** | Dataset collections (`datasets/`, `MTdatasets/`, `TextDatasets/`) — the full copy needed for Khiops to run |
+
+Upload the dataset collections to the cloud once (example with GCS):
+```
+gcloud storage cp -r LearningTest/datasets   gs://my-bucket/LearningTest/datasets
+gcloud storage cp -r LearningTest/MTdatasets gs://my-bucket/LearningTest/MTdatasets
+gcloud storage cp -r LearningTest/TextDatasets gs://my-bucket/LearningTest/TextDatasets
+```
+
+The same principle applies for S3 (`aws s3 cp --recursive`) or Azure (`az storage blob upload-batch`).
+
+#### Full test process
+
+**Step 1 – Run the tests with cloud datasets**
+
+Pass `--cloud-directory` to `kht_test`. Khiops generates a temporary scenario that replaces
+local relative paths (`../../../`) with cloud URIs, runs against the cloud datasets, and writes
+all its output files (`.khj`, `.kdic`, `.xls`, `err.txt`, …) back to the cloud.
+Only files written directly by the Python test runner (`stdout_error.log`, `stderr_error.log`,
+`return_code_error.log`, `process_timeout_error.log`, `time.log`) remain **local**.
+
+```bash
+# Full family, 4 processes, GCS example
+kht_test LearningTest r --cloud-directory gs://my-bucket/LearningTest -p 4
+
+# Or for a single test dir
+kht_test LearningTest/TestKhiops/Standard/Iris r --cloud-directory gs://my-bucket/LearningTest
+```
+
+After this step each test dir's local `results/` folder contains only the Python-written files;
+the Khiops output files are on the cloud.
+
+**Step 2 – Download the Khiops result files**
+
+Use the cloud provider CLI to copy the result directories back to the local machine,
+merging with the already-present Python-written files:
+
+```bash
+# GCS – download results for all Khiops test dirs
+gcloud storage cp -r \
+  "gs://my-bucket/LearningTest/TestKhiops/*/results" \
+  ./LearningTest/TestKhiops/
+
+# GCS – download results for all tools
+for tool in TestKhiops TestCoclustering TestKNI; do
+  gcloud storage cp -r \
+    "gs://my-bucket/LearningTest/$tool/*/results" \
+    ./LearningTest/$tool/
+done
+```
+
+Equivalent commands for S3:
+```bash
+aws s3 cp --recursive s3://my-bucket/LearningTest/ ./LearningTest/ \
+  --exclude "*" --include "*/results/*"
+```
+
+**Step 3 – Normalize cloud paths in result files**
+
+The downloaded result files (`.khj`, …) still contain cloud URIs as data paths.
+Replace them with local relative paths before comparison:
+
+```bash
+kht_apply LearningTest transform-cloud-results \
+  --cloud-directory gs://my-bucket/LearningTest
+
+# Or for a single suite
+kht_apply LearningTest/TestKhiops/Standard transform-cloud-results \
+  --cloud-directory gs://my-bucket/LearningTest
+```
+
+This instruction also calls the version-string cleaner that `kht_test` normally runs
+after execution, so the result files are ready for comparison.
+
+**Step 4 – Compare results against references**
+
+```bash
+kht_test LearningTest check
+
+# Or targeted
+kht_test LearningTest/TestKhiops/Standard check
+```
+
+If errors are found, use the standard `kht_apply errors` and `kht_apply logs` instructions
+to analyse them. To update the reference results after a confirmed algorithm change,
+use `kht_apply makeref` as usual.
+
 ### CI/CD
 
 The tests can be run at different steps of the developpement process:
@@ -422,21 +521,6 @@ The full LearningTest directory tree cannot be embedded in the Khiops github rep
 - scalability issue: around ten GB are necessary to store a snapshot of one version of LearningTest
 - confidentiality: some datasets or test dir contain confidential data
 - cost: storing and managing a large number of tests on dozens of platforms can be expensive in an external cloud
-
-A solution must be defined to meet the requirements of the processes summarised in this document.
-
-A potential solution, for a start:
-- keep the developpement of LearningTest on the Khiops repo, with the `basic` sub-part of LearningTest
-- exploit a gitlab repo to store and manage LearningTest: process to specify
-  - all file except scenarios (test.prm) managed using LFS
-  - synchronisation of version between the Khiops and LearningTest repos: use the closest former version
-  - keep a full snapshot of LearningTest for past versions of Khiops
-  - for the current dev branch of Khiops:
-	- keep only a few last version of LearningTest
-	- clean the preceeding former deprecated versions of LearningTest if necessary (never used again)
-  - ...
-- exploit the system initialized by Stephane G to launch the tests on many plateforms
-- ...
 
 
 

--- a/test/LearningTestTool/py/_kht_one_shot_instructions.py
+++ b/test/LearningTestTool/py/_kht_one_shot_instructions.py
@@ -18,8 +18,8 @@ Instruction pour des usages uniques
 Peu documente et developpe rapidment sous forme de prototype
 Exemples:
 - manipulation a faire une fois sur l'ensemble des repertoires de test
-- modification des scenario selon evoilution de l'ergonomie de Khiops core
-- evaluation de l'impcat sur les performances d'une evolution des algorithme de Khiops core
+- modification des scenario selon evolution de l'ergonomie de Khiops core
+- evaluation de l'impact sur les performances d'une evolution des algorithme de Khiops core
 - ...
 """
 

--- a/test/LearningTestTool/py/_kht_results_management.py
+++ b/test/LearningTestTool/py/_kht_results_management.py
@@ -51,7 +51,7 @@ Examples d'ensemble correct de noms de repertoire
 
 """Variable globale de gestion du contexte des resultats de reference"""
 
-# Nombre de process utilisex
+# Nombre de process utilises
 process_number = 1
 
 # Memorisation d'une plateforme force pour la comparaison entre resultats de test de de reference

--- a/test/LearningTestTool/py/_kht_standard_instructions.py
+++ b/test/LearningTestTool/py/_kht_standard_instructions.py
@@ -727,13 +727,16 @@ def instruction_transform_cloud_results(test_dir, cloud_directory):
     relative_path = os.path.relpath(test_dir, home_dir).replace(os.sep, "/")
     cloud_test_dir = cloud_directory + "/" + relative_path
     cloud_results_dir = cloud_test_dir + "/" + kht.RESULTS
+    # exemple :
+    # home_dir = /.../LearningTest
+    # test_dir = /.../LearningTest/TestKhiops/Standard/Iris
+    # relative_path becomes TestKhiops/Standard/Iris
+    # cloud_test_dir becomes gs://bucket/LearningTest/TestKhiops/Standard/Iris
 
     # Repertoire local de resultats
     results_dir = os.path.join(test_dir, kht.RESULTS)
     if not os.path.isdir(results_dir):
         return
-
-    dataset_names = ["datasets", "MTdatasets", "TextDatasets"]
 
     for file_name in os.listdir(results_dir):
         file_path = os.path.join(results_dir, file_name)
@@ -745,11 +748,6 @@ def instruction_transform_cloud_results(test_dir, cloud_directory):
 
         if ".khj" in file_name:
             # Fichiers JSON: les slashes sont echappes avec '\'
-            for dataset_name in dataset_names:
-                file_data = file_data.replace(
-                    escape_for_json(cloud_directory + "/" + dataset_name + "/"),
-                    escape_for_json("../../../" + dataset_name + "/"),
-                )
             # Remplacement du repertoire de resultats cloud puis du repertoire du test
             file_data = file_data.replace(
                 escape_for_json(cloud_results_dir + "/"),
@@ -759,13 +757,13 @@ def instruction_transform_cloud_results(test_dir, cloud_directory):
                 escape_for_json(cloud_test_dir + "/"),
                 escape_for_json("./"),
             )
+            # Remplacement generique du prefixe cloud pour les chemins de donnees
+            file_data = file_data.replace(
+                escape_for_json(cloud_directory + "/"),
+                escape_for_json("../../../"),
+            )
         else:
             # Fichiers texte
-            for dataset_name in dataset_names:
-                file_data = file_data.replace(
-                    cloud_directory + "/" + dataset_name + "/",
-                    "../../../" + dataset_name + "/",
-                )
             file_data = file_data.replace(
                 cloud_results_dir + "/",
                 "./" + kht.RESULTS + "/",
@@ -773,6 +771,11 @@ def instruction_transform_cloud_results(test_dir, cloud_directory):
             file_data = file_data.replace(
                 cloud_test_dir + "/",
                 "./",
+            )
+            # Remplacement generique du prefixe cloud pour les chemins de donnees
+            file_data = file_data.replace(
+                cloud_directory + "/",
+                "../../../",
             )
 
         os.chmod(file_path, stat.S_IWRITE | stat.S_IREAD)

--- a/test/LearningTestTool/py/_kht_standard_instructions.py
+++ b/test/LearningTestTool/py/_kht_standard_instructions.py
@@ -19,6 +19,8 @@ Documentee et maintenues officiellement
 # Imports de pykhiops a effectuer au cas par cas dans chaque methode, car ralentissant trop les scripts
 # import pykhiops as pk
 
+# cloud directory URI used by 'transform-cloud-results'
+cloud_directory = None
 
 """
 Fonctions utilitaires generales
@@ -42,7 +44,7 @@ def file_compare(file_name1: str, file_name2: str, skip_patterns: list = None):
     """Comparaison du contenu de deux fichiers
     :param file_name1:
     :param file_name2:
-    :param skip_patterns: ne compâre les lignes contenant une des chaines de carcateres en parametres
+    :param skip_patterns: ne compare pas les lignes contenant une des chaines de carcateres en parametres
     :return:
     """
     compare_ok = os.path.isfile(file_name1) and os.path.isfile(file_name2)
@@ -714,25 +716,13 @@ def instruction_transform_hdfs_results(test_dir):
                     output_file.write(file_data)
 
 
-def instruction_transform_cloud_results(test_dir, cloud_directory):
+def instruction_transform_cloud_results(test_dir):
     """Remplace les chemins cloud dans les fichiers de resultats par les chemins locaux relatifs.
     Doit etre applique apres telechargement des resultats du cloud, avant kht_test check.
     """
 
     def escape_for_json(token):
         return token.replace("/", "\\/")
-
-    def normalize_cloud_directory_uri(cloud_uri):
-        """Normalise un URI cloud en supprimant les '/' terminaux.
-        Conserve le separateur de schema (ex: gs://).
-        """
-
-        normalized_uri = cloud_uri
-        while normalized_uri.endswith("/") and not normalized_uri.endswith("://"):
-            normalized_uri = normalized_uri[:-1]
-        return normalized_uri
-
-    cloud_directory = normalize_cloud_directory_uri(cloud_directory)
 
     # Calcul des chemins cloud correspondant a ce test
     home_dir = utils.get_home_dir(test_dir)

--- a/test/LearningTestTool/py/_kht_standard_instructions.py
+++ b/test/LearningTestTool/py/_kht_standard_instructions.py
@@ -495,7 +495,7 @@ def instruction_copy_ref(test_dir):
                 )
 
 
-def instruction_check_hdfs(test_dir):
+def instruction_check_cloud(test_dir):
     def parameter_exist(line, searched_keyword):
         # Test s'il y a au moins un parametre dans une ligne et une valeur pour ce parametre
         fields = (
@@ -505,7 +505,7 @@ def instruction_check_hdfs(test_dir):
         )
         return len(fields) > 0 and len(fields[0]) > 0
 
-    # Verification de l'adapation au systeme HDFS
+    # Verification de l'adapation aux chemins sur le cloud
     keywords = [
         "class_file_name",
         "ResultFilesDirectory",
@@ -551,169 +551,6 @@ def instruction_check_hdfs(test_dir):
                     if parameter_exist(s, keyword):
                         print(str(line_index) + ": \t" + s[:-1])
             line_index += 1
-
-
-def instruction_transform_hdfs(test_dir):
-    def parameter_exist(line, searched_keyword):
-        # Test s'il y a au moins un parametre dans une ligne et une valeur pour ce parametre
-        fields = (
-            line[line.find(searched_keyword) + len(searched_keyword)]
-            .strip()
-            .split("//")
-        )
-        return len(fields) > 0 and len(fields[0]) > 0
-
-    # Creation d'un nouveau fichier test.prm.hdfs compatible avec  hdfs
-    keywords = [
-        "class_file_name",
-        "ResultFilesDirectory",
-        ".database_name",
-        ".DataTableName",
-        "ReportFileName",
-        "InputCoclusteringFileName",
-    ]
-    # PostProcessedCoclusteringFileName CoclusteringDictionaryFileName supprime
-    # Le nom du dictionnaire de coclustering ne devrait pas etre un chemin
-    prm_file_path = os.path.join(test_dir, kht.TEST_PRM)
-    prm_file = open(prm_file_path, "r", errors="ignore")
-    prm_file_lines = prm_file.readlines()
-    prm_file.close()
-    prm_file = open(prm_file_path, "w", errors="ignore")
-    for s in prm_file_lines:
-        new_line = s
-        # Commentaires dans le scenario
-        if "//" in s:
-            comment_pos = s.find("//")
-            if (
-                comment_pos > 0
-                and s[comment_pos - 1] != " "
-                and s[comment_pos - 1] != "\t"
-            ):
-                if s[comment_pos + 2 :].find("//") >= 0:
-                    print(
-                        "\tWARNING: Multiple '//' in line (NO TRANSFkht.ORM) -> "
-                        + s[:-1]
-                    )
-                else:
-                    new_line = s.replace("//", " //")
-        # Test de chaque mot cle
-        for keyword in keywords:
-            if (
-                s.find(keyword) >= 0
-                and s.find(" ../../../datasets") <= 0
-                and s.find(" ../../../MTdatasets") <= 0
-                and s.find(" ./") <= 0
-            ):
-                if parameter_exist(s, keyword):
-                    space_pos = s.find(" ")
-                    new_line = s[: space_pos + 1] + "./" + s[space_pos + 1 :]
-                    break
-
-        # Cas special pour le mot cle "EvaluationFileName", ne doit pas etre confondu avec TestEvaluationFileName
-        if (
-            s.find("EvaluationFileName") == 0
-            and not s.find(" ./")
-            and parameter_exist(s, "EvaluationFileName")
-        ):
-            space_pos = s.find(" ")
-            new_line = s[: space_pos + 1] + "./" + s[space_pos + 1 :]
-
-        prm_file.write(new_line)
-    prm_file.close()
-    # Transformation du fichier d'erreur dans le repertoire des resultats de reference
-    do_it = False
-    results_ref_dir, _ = results.get_results_ref_dir(test_dir, show=True)
-    if results_ref_dir is not None:
-        results_ref_err_file_path = os.path.join(test_dir, results_ref_dir, kht.ERR_TXT)
-        if do_it and os.path.isfile(results_ref_err_file_path):
-            err_file = open(results_ref_err_file_path, "r", errors="ignore")
-            err_file_lines = err_file.readlines()
-            err_file.close()
-            err_file = open(results_ref_err_file_path, "w", errors="ignore")
-            for s in err_file_lines:
-                new_line = s
-                new_line = new_line.replace(
-                    " " + kht.RESULTS + "/", " ./" + kht.RESULTS + "/"
-                )
-                new_line = new_line.replace(
-                    " " + kht.RESULTS + "\\", " ./" + kht.RESULTS + "\\"
-                )
-                err_file.write(new_line)
-            err_file.close()
-
-
-def instruction_transform_hdfs_results(test_dir):
-    def escape_for_json(token):
-        return token.replace("/", "\\/")
-
-    hdfs_test_dir = "hdfs:///user/bguerraz/LearningTest/TestKhiops/"
-    hdfs_data_dir = "hdfs:///user/bguerraz/LearningTest/"
-
-    std_data_dir = "../../../"
-    datasets = "datasets"
-    mt_datasets = "MTdatasets"
-
-    head, sub_test_name = os.path.split(test_dir)
-    _, test_name = os.path.split(head)
-
-    hdfs_local_dir = hdfs_test_dir + test_name + "/" + sub_test_name
-
-    results_dir = os.path.join(test_dir, kht.RESULTS)
-    if os.path.isdir(results_dir):
-        for file_name in os.listdir(results_dir):
-            file_path = os.path.join(results_dir, file_name)
-
-            # Lecture du fichier
-            with open(file_path, "r", errors="ignore") as file:
-                file_data = file.read()
-
-                # Recherche et remplacement
-                if ".khj" in file_name:
-                    # Jeux de donnees
-                    file_data = file_data.replace(
-                        escape_for_json(hdfs_data_dir + datasets),
-                        escape_for_json(std_data_dir + datasets),
-                    )
-                    file_data = file_data.replace(
-                        escape_for_json(hdfs_data_dir + mt_datasets),
-                        escape_for_json(std_data_dir + mt_datasets),
-                    )
-
-                    # Repertoire courant ./
-                    file_data = file_data.replace(
-                        escape_for_json(hdfs_local_dir + "/" + kht.RESULTS),
-                        escape_for_json("./" + kht.RESULTS),
-                    )  # ou kht.RESULTS sans "./"" ?
-
-                    # Fichiers dans le repertoire courant
-
-                    # file_data = file_data.replace(escape_for_json(
-                    #    hdfs_local_dir+"/"), "")
-                    file_data = file_data.replace(
-                        escape_for_json(hdfs_local_dir + "/"), escape_for_json("./")
-                    )
-
-                else:
-                    # Jeux de donnees
-                    file_data = file_data.replace(
-                        hdfs_data_dir + datasets, std_data_dir + datasets
-                    )
-                    file_data = file_data.replace(
-                        hdfs_data_dir + mt_datasets, std_data_dir + mt_datasets
-                    )
-
-                    # Repertoire courant ./
-                    file_data = file_data.replace(
-                        hdfs_local_dir + "/" + kht.RESULTS, "./" + kht.RESULTS
-                    )
-
-                    # Fichiers dans le repertoire courant
-                    file_data = file_data.replace(hdfs_local_dir + "/", "./")
-
-                # Ecriture du fichier
-                os.chmod(file_path, stat.S_IWRITE | stat.S_IREAD)
-                with open(file_path, "w", errors="ignore") as output_file:
-                    output_file.write(file_data)
 
 
 def instruction_transform_cloud_results(test_dir):
@@ -883,21 +720,9 @@ def register_standard_instructions():
     )
     register_instruction(
         available_instructions,
-        "check-hdfs",
-        instruction_check_hdfs,
-        "check if parameter files are compliant with HDFS",
-    )
-    register_instruction(
-        available_instructions,
-        "transform-hdfs",
-        instruction_transform_hdfs,
-        "transform parameter files to be compliant with HDFS",
-    )
-    register_instruction(
-        available_instructions,
-        "transform-hdfs-results",
-        instruction_transform_hdfs_results,
-        "transform results files to be compliant with HDFS",
+        "check-cloud",
+        instruction_check_cloud,
+        "check if parameter files are compliant with data paths on cloud",
     )
     register_instruction(
         available_instructions,

--- a/test/LearningTestTool/py/_kht_standard_instructions.py
+++ b/test/LearningTestTool/py/_kht_standard_instructions.py
@@ -722,6 +722,18 @@ def instruction_transform_cloud_results(test_dir, cloud_directory):
     def escape_for_json(token):
         return token.replace("/", "\\/")
 
+    def normalize_cloud_directory_uri(cloud_uri):
+        """Normalise un URI cloud en supprimant les '/' terminaux.
+        Conserve le separateur de schema (ex: gs://).
+        """
+
+        normalized_uri = cloud_uri
+        while normalized_uri.endswith("/") and not normalized_uri.endswith("://"):
+            normalized_uri = normalized_uri[:-1]
+        return normalized_uri
+
+    cloud_directory = normalize_cloud_directory_uri(cloud_directory)
+
     # Calcul des chemins cloud correspondant a ce test
     home_dir = utils.get_home_dir(test_dir)
     relative_path = os.path.relpath(test_dir, home_dir).replace(os.sep, "/")

--- a/test/LearningTestTool/py/_kht_standard_instructions.py
+++ b/test/LearningTestTool/py/_kht_standard_instructions.py
@@ -20,7 +20,7 @@ Documentee et maintenues officiellement
 # import pykhiops as pk
 
 # cloud directory URI used by 'transform-cloud-results'
-cloud_directory = None
+cloud_dir = None
 
 """
 Fonctions utilitaires generales
@@ -44,7 +44,7 @@ def file_compare(file_name1: str, file_name2: str, skip_patterns: list = None):
     """Comparaison du contenu de deux fichiers
     :param file_name1:
     :param file_name2:
-    :param skip_patterns: ne compare pas les lignes contenant une des chaines de carcateres en parametres
+    :param skip_patterns: ne compare pas les lignes contenant une des chaines de caracteres en parametres
     :return:
     """
     compare_ok = os.path.isfile(file_name1) and os.path.isfile(file_name2)
@@ -561,10 +561,12 @@ def instruction_transform_cloud_results(test_dir):
     def escape_for_json(token):
         return token.replace("/", "\\/")
 
+    assert utils.check_cloud_dir(cloud_dir), "Invalid cloud directory " + str(cloud_dir)
+
     # Calcul des chemins cloud correspondant a ce test
     home_dir = utils.get_home_dir(test_dir)
     relative_path = os.path.relpath(test_dir, home_dir).replace(os.sep, "/")
-    cloud_test_dir = cloud_directory + "/" + relative_path
+    cloud_test_dir = cloud_dir + "/" + relative_path
     cloud_results_dir = cloud_test_dir + "/" + kht.RESULTS
     # exemple :
     # home_dir = /.../LearningTest
@@ -598,7 +600,7 @@ def instruction_transform_cloud_results(test_dir):
             )
             # Remplacement generique du prefixe cloud pour les chemins de donnees
             file_data = file_data.replace(
-                escape_for_json(cloud_directory + "/"),
+                escape_for_json(cloud_dir + "/"),
                 escape_for_json("../../../"),
             )
         else:
@@ -613,7 +615,7 @@ def instruction_transform_cloud_results(test_dir):
             )
             # Remplacement generique du prefixe cloud pour les chemins de donnees
             file_data = file_data.replace(
-                cloud_directory + "/",
+                cloud_dir + "/",
                 "../../../",
             )
 

--- a/test/LearningTestTool/py/_kht_standard_instructions.py
+++ b/test/LearningTestTool/py/_kht_standard_instructions.py
@@ -714,6 +714,75 @@ def instruction_transform_hdfs_results(test_dir):
                     output_file.write(file_data)
 
 
+def instruction_transform_cloud_results(test_dir, cloud_directory):
+    """Remplace les chemins cloud dans les fichiers de resultats par les chemins locaux relatifs.
+    Doit etre applique apres telechargement des resultats du cloud, avant kht_test check.
+    """
+
+    def escape_for_json(token):
+        return token.replace("/", "\\/")
+
+    # Calcul des chemins cloud correspondant a ce test
+    home_dir = utils.get_home_dir(test_dir)
+    relative_path = os.path.relpath(test_dir, home_dir).replace(os.sep, "/")
+    cloud_test_dir = cloud_directory + "/" + relative_path
+    cloud_results_dir = cloud_test_dir + "/" + kht.RESULTS
+
+    # Repertoire local de resultats
+    results_dir = os.path.join(test_dir, kht.RESULTS)
+    if not os.path.isdir(results_dir):
+        return
+
+    dataset_names = ["datasets", "MTdatasets", "TextDatasets"]
+
+    for file_name in os.listdir(results_dir):
+        file_path = os.path.join(results_dir, file_name)
+        if not os.path.isfile(file_path):
+            continue
+
+        with open(file_path, "r", errors="ignore") as f:
+            file_data = f.read()
+
+        if ".khj" in file_name:
+            # Fichiers JSON: les slashes sont echappes avec '\'
+            for dataset_name in dataset_names:
+                file_data = file_data.replace(
+                    escape_for_json(cloud_directory + "/" + dataset_name + "/"),
+                    escape_for_json("../../../" + dataset_name + "/"),
+                )
+            # Remplacement du repertoire de resultats cloud puis du repertoire du test
+            file_data = file_data.replace(
+                escape_for_json(cloud_results_dir + "/"),
+                escape_for_json("./" + kht.RESULTS + "/"),
+            )
+            file_data = file_data.replace(
+                escape_for_json(cloud_test_dir + "/"),
+                escape_for_json("./"),
+            )
+        else:
+            # Fichiers texte
+            for dataset_name in dataset_names:
+                file_data = file_data.replace(
+                    cloud_directory + "/" + dataset_name + "/",
+                    "../../../" + dataset_name + "/",
+                )
+            file_data = file_data.replace(
+                cloud_results_dir + "/",
+                "./" + kht.RESULTS + "/",
+            )
+            file_data = file_data.replace(
+                cloud_test_dir + "/",
+                "./",
+            )
+
+        os.chmod(file_path, stat.S_IWRITE | stat.S_IREAD)
+        with open(file_path, "w", errors="ignore") as f:
+            f.write(file_data)
+
+    # Nettoyage des references de version (normalement effectue par kht_test apres execution)
+    check.clean_version_from_results(results_dir)
+
+
 """
 Enregistrement des instructions
 """
@@ -824,5 +893,11 @@ def register_standard_instructions():
         "transform-hdfs-results",
         instruction_transform_hdfs_results,
         "transform results files to be compliant with HDFS",
+    )
+    register_instruction(
+        available_instructions,
+        "transform-cloud-results",
+        instruction_transform_cloud_results,
+        "replace cloud paths in results files with local relative paths (requires --cloud-directory in kht_apply)",
     )
     return available_instructions

--- a/test/LearningTestTool/py/_kht_utils.py
+++ b/test/LearningTestTool/py/_kht_utils.py
@@ -366,6 +366,18 @@ def argument_parser_add_limit_test_time_arguments(parser):
     )
 
 
+def argument_parser_add_cloud_directory(parser):
+    """Ajout de l'argument cloud_directory"""
+    parser.add_argument(
+        "--cloud-directory",
+        help="cloud directory URI used by 'transform-cloud-results' instruction"
+        " (e.g., gs://bucket/LearningTest, s3://bucket/LearningTest)",
+        type=str,
+        metavar="uri",
+        action="store",
+    )
+
+
 def argument_parser_check_source_argument(parser, source):
     """Verification de l'argument source, a appeler apres les verification standard de parse_args()
     On renvoie la decomposition du repertoire source sous la forme des champs:
@@ -440,6 +452,16 @@ def argument_parser_check_limit_test_time_arguments(
         parser.error("argument --min-test-time must be positive")
     if max_test_time is not None and max_test_time < 0:
         parser.error("argument --max-test-time must be positive")
+
+
+def argument_parser_check_uri(parser, uri):
+    """Verification de l'argument cloud_directory, a appeler apres les verification standard de parse_args()"""
+    if not is_valid_uri(uri):
+        parser.error(
+            "argument --cloud-directory: "
+            + uri
+            + " should be a cloud directory URI (e.g., gs://bucket/LearningTest, s3://bucket/LearningTest)"
+        )
 
 
 """
@@ -695,3 +717,23 @@ class Unbuffered:
 
     def __getattr__(self, attr):
         return getattr(self.stream, attr)
+
+
+"""
+Gestion des fichiers sur le cloud
+"""
+
+
+def normalize_cloud_directory_uri(cloud_directory):
+    """Normalise un URI cloud en supprimant les '/' terminaux.
+    Conserve le separateur de schema (ex: gs://).
+    """
+
+    normalized_uri = cloud_directory
+    while normalized_uri.endswith("/") and not normalized_uri.endswith("://"):
+        normalized_uri = normalized_uri[:-1]
+    return normalized_uri
+
+
+def is_valid_uri(uri):
+    return uri is not None and uri.startswith(("gs://", "s3://", "https://"))

--- a/test/LearningTestTool/py/_kht_utils.py
+++ b/test/LearningTestTool/py/_kht_utils.py
@@ -456,7 +456,7 @@ def argument_parser_check_limit_test_time_arguments(
 
 def argument_parser_check_uri(parser, uri):
     """Verification de l'argument cloud_directory, a appeler apres les verification standard de parse_args()"""
-    if not is_valid_uri(uri):
+    if not check_cloud_dir(uri):
         parser.error(
             "argument --cloud-directory: "
             + uri
@@ -724,16 +724,16 @@ Gestion des fichiers sur le cloud
 """
 
 
-def normalize_cloud_directory_uri(cloud_directory):
+def normalize_cloud_directory_uri(cloud_dir):
     """Normalise un URI cloud en supprimant les '/' terminaux.
     Conserve le separateur de schema (ex: gs://).
     """
 
-    normalized_uri = cloud_directory
+    normalized_uri = cloud_dir
     while normalized_uri.endswith("/") and not normalized_uri.endswith("://"):
         normalized_uri = normalized_uri[:-1]
     return normalized_uri
 
 
-def is_valid_uri(uri):
+def check_cloud_dir(uri):
     return uri is not None and uri.startswith(("gs://", "s3://", "https://"))

--- a/test/LearningTestTool/py/kht_apply.py
+++ b/test/LearningTestTool/py/kht_apply.py
@@ -278,7 +278,7 @@ def main():
             parser.error(
                 "instruction 'transform-cloud-results' requires --cloud-directory argument"
             )
-        standard_instructions.cloud_directory = utils.normalize_cloud_directory_uri(
+        standard_instructions.cloud_dir = utils.normalize_cloud_directory_uri(
             args.cloud_directory
         )
 

--- a/test/LearningTestTool/py/kht_apply.py
+++ b/test/LearningTestTool/py/kht_apply.py
@@ -236,15 +236,7 @@ def main():
     utils.argument_parser_add_processes_argument(parser)
     utils.argument_parser_add_forced_platform_argument(parser)
     utils.argument_parser_add_limit_test_time_arguments(parser)
-
-    # Argument cloud pour l'instruction transform-cloud-results
-    parser.add_argument(
-        "--cloud-directory",
-        help="cloud directory URI used by 'transform-cloud-results' instruction"
-        " (e.g., gs://bucket/LearningTest, s3://bucket/LearningTest)",
-        metavar="uri",
-        action="store",
-    )
+    utils.argument_parser_add_cloud_directory(parser)
 
     # Analyse de la ligne de commande
     args = parser.parse_args()
@@ -270,6 +262,8 @@ def main():
     utils.argument_parser_check_limit_test_time_arguments(
         parser, args.min_test_time, args.max_test_time
     )
+    if args.cloud_directory is not None:
+        utils.argument_parser_check_uri(parser, args.cloud_directory)
 
     # Memorisation des variables globales de gestion du contexte des resultats de reference
     results.process_number = args.n
@@ -284,11 +278,8 @@ def main():
             parser.error(
                 "instruction 'transform-cloud-results' requires --cloud-directory argument"
             )
-        # Redefinition de l'instruction pour capturer cloud_directory en parametre supplementaire
-        instruction_function = (
-            lambda test_dir: standard_instructions.instruction_transform_cloud_results(
-                test_dir, args.cloud_directory
-            )
+        standard_instructions.cloud_directory = utils.normalize_cloud_directory_uri(
+            args.cloud_directory
         )
 
     # Lancement de la commande

--- a/test/LearningTestTool/py/kht_apply.py
+++ b/test/LearningTestTool/py/kht_apply.py
@@ -237,6 +237,15 @@ def main():
     utils.argument_parser_add_forced_platform_argument(parser)
     utils.argument_parser_add_limit_test_time_arguments(parser)
 
+    # Argument cloud pour l'instruction transform-cloud-results
+    parser.add_argument(
+        "--cloud-directory",
+        help="cloud directory URI used by 'transform-cloud-results' instruction"
+        " (e.g., gs://bucket/LearningTest, s3://bucket/LearningTest)",
+        metavar="uri",
+        action="store",
+    )
+
     # Analyse de la ligne de commande
     args = parser.parse_args()
 
@@ -268,6 +277,19 @@ def main():
 
     # Acces a l'instruction a executer
     instruction_function, instruction_label = all_instructions[args.instruction]
+
+    # Cas particulier de l'instruction transform-cloud-results qui necessite --cloud-directory
+    if args.instruction == "transform-cloud-results":
+        if args.cloud_directory is None:
+            parser.error(
+                "instruction 'transform-cloud-results' requires --cloud-directory argument"
+            )
+        # Redefinition de l'instruction pour capturer cloud_directory en parametre supplementaire
+        instruction_function = (
+            lambda test_dir: standard_instructions.instruction_transform_cloud_results(
+                test_dir, args.cloud_directory
+            )
+        )
 
     # Lancement de la commande
     apply_instruction_on_learning_test_tree(

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -559,10 +559,9 @@ def evaluate_tool_on_test_dir(
             khiops_params.append("-j")
             khiops_params.append(kht.TEST_JSON)
         khiops_params.append("-e")
-        if cloud_results_dir is not None:
-            khiops_params.append(cloud_results_dir + "/" + kht.ERR_TXT)
-        else:
-            khiops_params.append(os.path.join(results_dir, kht.ERR_TXT))
+        # En mode cloud, err.txt reste local pour permettre un diagnostic rapide
+        # apres le run sans avoir a telecharger les resultats du cloud
+        khiops_params.append(os.path.join(results_dir, kht.ERR_TXT))
         if output_scenario:
             khiops_params.append("-o")
             if cloud_results_dir is not None:
@@ -836,6 +835,9 @@ def evaluate_tool_on_test_dir(
             + cloud_test_dir
             + "/"
             + kht.RESULTS
+            + " (local diagnostic: "
+            + os.path.join(results_dir, kht.ERR_TXT)
+            + ")"
         )
 
 

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -26,17 +26,6 @@ else:
     mpi_exe_name = "mpirun"
 
 
-def normalize_cloud_directory_uri(cloud_directory):
-    """Normalise un URI cloud en supprimant les '/' terminaux.
-    Conserve le separateur de schema (ex: gs://).
-    """
-
-    normalized_uri = cloud_directory
-    while normalized_uri.endswith("/") and not normalized_uri.endswith("://"):
-        normalized_uri = normalized_uri[:-1]
-    return normalized_uri
-
-
 def build_tool_exe_path(tool_binaries_dir, tool_name, use_khiops_env):
     """Construction du chemin de l'executable d'un outil a partir du repertoire des binaire
     Le premier parametre peut contenir plusieurs types de valeurs
@@ -336,9 +325,13 @@ def evaluate_tool_on_test_dir(
     cloud_test_dir = None
     cloud_results_dir = None
     if cloud_directory is not None:
-        cloud_directory = normalize_cloud_directory_uri(cloud_directory)
+        print("cloud_directory: " + cloud_directory)
+        if not utils.is_valid_uri(cloud_directory):
+            utils.fatal_error(
+                "cloud_directory argument must be a valid cloud URI starting with gs://, s3:// or https://"
+            )
         cloud_test_dir = (
-            cloud_directory
+            utils.normalize_cloud_directory_uri(cloud_directory)
             + "/"
             + tool_dir_name
             + "/"
@@ -1316,7 +1309,7 @@ def main():
 
     # Normalisation de l'URI cloud pour eviter les chemins avec double '/'
     if args.cloud_directory is not None:
-        args.cloud_directory = normalize_cloud_directory_uri(args.cloud_directory)
+        args.cloud_directory = utils.normalize_cloud_directory_uri(args.cloud_directory)
 
     # Verification des arguments optionnels
     utils.argument_parser_check_processes_argument(parser, args.n)

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -26,6 +26,17 @@ else:
     mpi_exe_name = "mpirun"
 
 
+def normalize_cloud_directory_uri(cloud_directory):
+    """Normalise un URI cloud en supprimant les '/' terminaux.
+    Conserve le separateur de schema (ex: gs://).
+    """
+
+    normalized_uri = cloud_directory
+    while normalized_uri.endswith("/") and not normalized_uri.endswith("://"):
+        normalized_uri = normalized_uri[:-1]
+    return normalized_uri
+
+
 def build_tool_exe_path(tool_binaries_dir, tool_name, use_khiops_env):
     """Construction du chemin de l'executable d'un outil a partir du repertoire des binaire
     Le premier parametre peut contenir plusieurs types de valeurs
@@ -325,6 +336,7 @@ def evaluate_tool_on_test_dir(
     cloud_test_dir = None
     cloud_results_dir = None
     if cloud_directory is not None:
+        cloud_directory = normalize_cloud_directory_uri(cloud_directory)
         cloud_test_dir = (
             cloud_directory
             + "/"
@@ -1301,6 +1313,10 @@ def main():
     # Verification de l'incompatibilite entre --cloud-directory et l'alias 'check'
     if args.cloud_directory is not None and binaries_dir == kht.ALIAS_CHECK:
         parser.error("argument --cloud-directory cannot be combined with 'check' alias")
+
+    # Normalisation de l'URI cloud pour eviter les chemins avec double '/'
+    if args.cloud_directory is not None:
+        args.cloud_directory = normalize_cloud_directory_uri(args.cloud_directory)
 
     # Verification des arguments optionnels
     utils.argument_parser_check_processes_argument(parser, args.n)

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -290,7 +290,7 @@ def evaluate_tool_on_test_dir(
     output_scenario=False,
     nop_output_scenario=False,
     user_interface=False,
-    cloud_directory=None,
+    cloud_dir=None,
     only_failed_tests=False,
 ):
     """Evaluation d'un outil sur un repertoire de test terminal et comparaison des resultats
@@ -298,6 +298,69 @@ def evaluate_tool_on_test_dir(
     - tool_exe_path: path de l'outil a tester, ou nul si on ne veut faire que la comparaison
     - suite_dir: repertoire racine du repertoire de test
     - test_dir_name: repertoire de test terminal"""
+
+    def build_cloud_dirs(cloud_dir, tool_dir_name, suite_dir_name, test_dir_name):
+        """Construction des repertoires cloud pour le test et les resultats"""
+        cloud_test_dir = None
+        cloud_results_dir = None
+        if cloud_dir is not None:
+            if not utils.check_cloud_dir(cloud_dir):
+                utils.fatal_error(
+                    "cloud_directory argument must be a valid cloud URI starting with gs://, s3:// or https://"
+                )
+            cloud_test_dir = (
+                utils.normalize_cloud_directory_uri(cloud_dir)
+                + "/"
+                + tool_dir_name
+                + "/"
+                + suite_dir_name
+                + "/"
+                + test_dir_name
+            )
+            cloud_results_dir = cloud_test_dir + "/" + kht.RESULTS
+        return cloud_test_dir, cloud_results_dir
+
+    def build_cloud_prm(cloud_dir, cloud_test_dir, tool_exe_path):
+        """Construction du scenario de test avec les chemins cloud, a partir du scenario de test original
+        et du scenario json si present.
+        """
+        # Les fichiers temporaires sont places dans un sous-repertoire tmp/ et supprimes apres execution
+        cloud_test_prm = None
+        if cloud_dir is not None:
+            # Paires de remplacement appliquees dans l'ordre par khiops via le flag -r :
+            # '../../../' en premier (remplace tous les chemins relatifs vers la racine LearningTest),
+            # './' en dernier (remplace les chemins vers le repertoire courant du test).
+            # Cet ordre est necessaire car '../../../' contient './' comme sous-chaine.
+            cloud_replace_pairs = [
+                "../../../:" + cloud_dir + "/",
+                "./" + ":" + cloud_test_dir + "/",
+            ]
+            # Etape 1 (si test.json existe): materialisation du scenario avec les parametres json
+            # Cette etape est necessaire car test.json peut contenir des chemins de donnees a remplacer
+            scenario_to_replace = kht.TEST_PRM
+            if os.path.isfile(kht.TEST_JSON):
+                scenario_to_replace = run_khiops_no_replay(
+                    [
+                        tool_exe_path,
+                        "-b",
+                        "-i",
+                        kht.TEST_PRM,
+                        "-j",
+                        kht.TEST_JSON,
+                    ],
+                    "JSON scenario expansion",
+                )
+            # Etape 2: remplacement des chemins locaux par les chemins cloud
+            prm_step2 = [tool_exe_path, "-b", "-i", scenario_to_replace]
+            for pair in cloud_replace_pairs:
+                prm_step2.extend(["-r", pair])
+            cloud_test_prm = run_khiops_no_replay(prm_step2, "cloud path replacement")
+            # Suppression du scenario intermediaire issu de l'expansion json
+            if scenario_to_replace != kht.TEST_PRM and os.path.isfile(
+                scenario_to_replace
+            ):
+                utils.remove_file(scenario_to_replace)
+        return cloud_test_prm
 
     # Verification du chemin de l'exe
     if tool_exe_path != kht.ALIAS_CHECK:
@@ -321,25 +384,10 @@ def evaluate_tool_on_test_dir(
     # Nom de l'outil
     tool_name = kht.TOOL_NAMES_PER_DIR_NAME.get(tool_dir_name)
 
-    # Calcul du repertoire cloud le cas echeant
-    cloud_test_dir = None
-    cloud_results_dir = None
-    if cloud_directory is not None:
-        print("cloud_directory: " + cloud_directory)
-        if not utils.is_valid_uri(cloud_directory):
-            utils.fatal_error(
-                "cloud_directory argument must be a valid cloud URI starting with gs://, s3:// or https://"
-            )
-        cloud_test_dir = (
-            utils.normalize_cloud_directory_uri(cloud_directory)
-            + "/"
-            + tool_dir_name
-            + "/"
-            + suite_dir_name
-            + "/"
-            + test_dir_name
-        )
-        cloud_results_dir = cloud_test_dir + "/" + kht.RESULTS
+    # Construction des repertoires cloud le cas echeant
+    cloud_test_dir, cloud_results_dir = build_cloud_dirs(
+        cloud_dir, tool_dir_name, suite_dir_name, test_dir_name
+    )
 
     # Recherche du chemin de l'executable et positionnement du path pour l'exe et la dll
     tool_exe_dir = os.path.dirname(tool_exe_path)
@@ -441,43 +489,8 @@ def evaluate_tool_on_test_dir(
             #  fault et si il n'existe pas on ne pourra pas ecrire dedans...)
             os.mkdir(results_dir)
 
-        # En mode cloud, creation des fichiers de scenario avec les chemins cloud
-        # Les fichiers temporaires sont places dans un sous-repertoire tmp/ et supprimes apres execution
-        cloud_test_prm = None
-        if cloud_directory is not None:
-            # Paires de remplacement appliquees dans l'ordre par khiops via le flag -r :
-            # '../../../' en premier (remplace tous les chemins relatifs vers la racine LearningTest),
-            # './' en dernier (remplace les chemins vers le repertoire courant du test).
-            # Cet ordre est necessaire car '../../../' contient './' comme sous-chaine.
-            cloud_replace_pairs = [
-                "../../../:" + cloud_directory + "/",
-                "./" + ":" + cloud_test_dir + "/",
-            ]
-            # Etape 1 (si test.json existe): materialisation du scenario avec les parametres json
-            # Cette etape est necessaire car test.json peut contenir des chemins de donnees a remplacer
-            scenario_to_replace = kht.TEST_PRM
-            if os.path.isfile(kht.TEST_JSON):
-                scenario_to_replace = run_khiops_no_replay(
-                    [
-                        tool_exe_path,
-                        "-b",
-                        "-i",
-                        kht.TEST_PRM,
-                        "-j",
-                        kht.TEST_JSON,
-                    ],
-                    "JSON scenario expansion",
-                )
-            # Etape 2: remplacement des chemins locaux par les chemins cloud
-            prm_step2 = [tool_exe_path, "-b", "-i", scenario_to_replace]
-            for pair in cloud_replace_pairs:
-                prm_step2.extend(["-r", pair])
-            cloud_test_prm = run_khiops_no_replay(prm_step2, "cloud path replacement")
-            # Suppression du scenario intermediaire issu de l'expansion json
-            if scenario_to_replace != kht.TEST_PRM and os.path.isfile(
-                scenario_to_replace
-            ):
-                utils.remove_file(scenario_to_replace)
+        # En mode cloud, creation du fichier de scenario avec les chemins cloud
+        cloud_test_prm = build_cloud_prm(cloud_dir, cloud_test_dir, tool_exe_path)
 
         # khiops en mode expert via une variable d'environnement
         os.environ[kht.KHIOPS_EXPERT_MODE] = "true"
@@ -816,7 +829,7 @@ def evaluate_tool_on_test_dir(
 
         # Nettoyage de toute reference a la version des fichiers de resultats
         # (ignore en mode cloud car les fichiers de resultats de khiops sont sur le cloud)
-        if cloud_directory is None:
+        if cloud_dir is None:
             check.clean_version_from_results(results_dir)
 
     # Restore initial path
@@ -827,7 +840,7 @@ def evaluate_tool_on_test_dir(
 
     # Comparaison des resultats
     os.chdir(suite_dir)
-    if cloud_directory is None:
+    if cloud_dir is None:
         check.check_results(test_dir)
     else:
         print(
@@ -1307,6 +1320,9 @@ def main():
     if args.cloud_directory is not None and binaries_dir == kht.ALIAS_CHECK:
         parser.error("argument --cloud-directory cannot be combined with 'check' alias")
 
+    if args.cloud_directory is not None:
+        utils.argument_parser_check_uri(parser, args.cloud_directory)
+
     # Normalisation de l'URI cloud pour eviter les chemins avec double '/'
     if args.cloud_directory is not None:
         args.cloud_directory = utils.normalize_cloud_directory_uri(args.cloud_directory)
@@ -1374,7 +1390,7 @@ def main():
         output_scenario=args.output_scenario,
         nop_output_scenario=args.nop_output_scenario,
         user_interface=args.user_interface,
-        cloud_directory=args.cloud_directory,
+        cloud_dir=args.cloud_directory,
     )
 
 

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -8,6 +8,7 @@ import platform
 import shlex
 import shutil
 import subprocess
+import tempfile
 import time
 import argparse
 
@@ -240,6 +241,43 @@ def is_test_failed(test_dir):
     return error_number > 0
 
 
+def run_khiops_no_replay(khiops_params, step_label):
+    """Execute a khiops -O (no-replay) command for scenario transformation.
+    Creates a temporary output scenario file and a temporary error log file
+    internally. Prints a warning if stdout, stderr or the error log contain
+    the word 'error'. The error log is removed after being read.
+    Returns the path of the output scenario file (caller is responsible for
+    removing it after use).
+    """
+    out_fd, out_path = tempfile.mkstemp(suffix=".prm", prefix="kht_no_replay_out_")
+    os.close(out_fd)
+    err_fd, err_file_path = tempfile.mkstemp(suffix=".txt", prefix="kht_no_replay_err_")
+    os.close(err_fd)
+    result = subprocess.run(
+        khiops_params + ["-O", out_path, "-e", err_file_path],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if result.stdout.strip():
+        print("Warning: unexpected output during " + step_label + ":\n" + result.stdout)
+    if result.stderr.strip():
+        print(
+            "Warning: unexpected error output during "
+            + step_label
+            + ":\n"
+            + result.stderr
+        )
+    if os.path.isfile(err_file_path):
+        with open(err_file_path, "r", errors="ignore") as err_f:
+            err_content = err_f.read()
+        if "error" in err_content.lower():
+            print("Warning: errors in " + step_label + " error log:\n" + err_content)
+        utils.remove_file(err_file_path)
+    return out_path
+
+
 def evaluate_tool_on_test_dir(
     tool_exe_path,
     suite_dir,
@@ -252,6 +290,7 @@ def evaluate_tool_on_test_dir(
     output_scenario=False,
     nop_output_scenario=False,
     user_interface=False,
+    cloud_directory=None,
     only_failed_tests=False,
 ):
     """Evaluation d'un outil sur un repertoire de test terminal et comparaison des resultats
@@ -281,6 +320,21 @@ def evaluate_tool_on_test_dir(
 
     # Nom de l'outil
     tool_name = kht.TOOL_NAMES_PER_DIR_NAME.get(tool_dir_name)
+
+    # Calcul du repertoire cloud le cas echeant
+    cloud_test_dir = None
+    cloud_results_dir = None
+    if cloud_directory is not None:
+        cloud_test_dir = (
+            cloud_directory
+            + "/"
+            + tool_dir_name
+            + "/"
+            + suite_dir_name
+            + "/"
+            + test_dir_name
+        )
+        cloud_results_dir = cloud_test_dir + "/" + kht.RESULTS
 
     # Recherche du chemin de l'executable et positionnement du path pour l'exe et la dll
     tool_exe_dir = os.path.dirname(tool_exe_path)
@@ -382,6 +436,44 @@ def evaluate_tool_on_test_dir(
             #  fault et si il n'existe pas on ne pourra pas ecrire dedans...)
             os.mkdir(results_dir)
 
+        # En mode cloud, creation des fichiers de scenario avec les chemins cloud
+        # Les fichiers temporaires sont places dans un sous-repertoire tmp/ et supprimes apres execution
+        cloud_test_prm = None
+        if cloud_directory is not None:
+            # Paires de remplacement appliquees dans l'ordre par khiops via le flag -r :
+            # '../../../' en premier (remplace tous les chemins relatifs vers la racine LearningTest),
+            # './' en dernier (remplace les chemins vers le repertoire courant du test).
+            # Cet ordre est necessaire car '../../../' contient './' comme sous-chaine.
+            cloud_replace_pairs = [
+                "../../../:" + cloud_directory + "/",
+                "./" + ":" + cloud_test_dir + "/",
+            ]
+            # Etape 1 (si test.json existe): materialisation du scenario avec les parametres json
+            # Cette etape est necessaire car test.json peut contenir des chemins de donnees a remplacer
+            scenario_to_replace = kht.TEST_PRM
+            if os.path.isfile(kht.TEST_JSON):
+                scenario_to_replace = run_khiops_no_replay(
+                    [
+                        tool_exe_path,
+                        "-b",
+                        "-i",
+                        kht.TEST_PRM,
+                        "-j",
+                        kht.TEST_JSON,
+                    ],
+                    "JSON scenario expansion",
+                )
+            # Etape 2: remplacement des chemins locaux par les chemins cloud
+            prm_step2 = [tool_exe_path, "-b", "-i", scenario_to_replace]
+            for pair in cloud_replace_pairs:
+                prm_step2.extend(["-r", pair])
+            cloud_test_prm = run_khiops_no_replay(prm_step2, "cloud path replacement")
+            # Suppression du scenario intermediaire issu de l'expansion json
+            if scenario_to_replace != kht.TEST_PRM and os.path.isfile(
+                scenario_to_replace
+            ):
+                utils.remove_file(scenario_to_replace)
+
         # khiops en mode expert via une variable d'environnement
         os.environ[kht.KHIOPS_EXPERT_MODE] = "true"
 
@@ -458,21 +550,37 @@ def evaluate_tool_on_test_dir(
         if not user_interface:
             khiops_params.append("-b")
         khiops_params.append("-i")
-        khiops_params.append(kht.TEST_PRM)
-        if os.path.isfile(kht.TEST_JSON):
+        if cloud_test_prm is not None:
+            khiops_params.append(cloud_test_prm)
+        else:
+            khiops_params.append(kht.TEST_PRM)
+        if cloud_test_prm is None and os.path.isfile(kht.TEST_JSON):
+            # En mode cloud, test.json est deja materialise dans cloud_test_prm
             khiops_params.append("-j")
             khiops_params.append(kht.TEST_JSON)
         khiops_params.append("-e")
-        khiops_params.append(os.path.join(results_dir, kht.ERR_TXT))
+        if cloud_results_dir is not None:
+            khiops_params.append(cloud_results_dir + "/" + kht.ERR_TXT)
+        else:
+            khiops_params.append(os.path.join(results_dir, kht.ERR_TXT))
         if output_scenario:
             khiops_params.append("-o")
-            khiops_params.append(os.path.join(results_dir, "output_test.prm"))
+            if cloud_results_dir is not None:
+                khiops_params.append(cloud_results_dir + "/output_test.prm")
+            else:
+                khiops_params.append(os.path.join(results_dir, "output_test.prm"))
         if nop_output_scenario:
             khiops_params.append("-O")
-            khiops_params.append(os.path.join(results_dir, "nop_output_test.prm"))
+            if cloud_results_dir is not None:
+                khiops_params.append(cloud_results_dir + "/nop_output_test.prm")
+            else:
+                khiops_params.append(os.path.join(results_dir, "nop_output_test.prm"))
         if task_file:
             khiops_params.append("-p")
-            khiops_params.append(os.path.join(results_dir, "task_progression.log"))
+            if cloud_results_dir is not None:
+                khiops_params.append(cloud_results_dir + "/task_progression.log")
+            else:
+                khiops_params.append(os.path.join(results_dir, "task_progression.log"))
 
         # Calcul d'un time_out en fonction du temps de reference, uniquement si celui est disponible
         timeout = None
@@ -698,8 +806,14 @@ def evaluate_tool_on_test_dir(
                 exception,
             )
 
+        # Suppression du scenario cloud temporaire apres execution
+        if cloud_test_prm is not None and os.path.isfile(cloud_test_prm):
+            utils.remove_file(cloud_test_prm)
+
         # Nettoyage de toute reference a la version des fichiers de resultats
-        check.clean_version_from_results(results_dir)
+        # (ignore en mode cloud car les fichiers de resultats de khiops sont sur le cloud)
+        if cloud_directory is None:
+            check.clean_version_from_results(results_dir)
 
     # Restore initial path
     if os.name == "nt":
@@ -709,7 +823,20 @@ def evaluate_tool_on_test_dir(
 
     # Comparaison des resultats
     os.chdir(suite_dir)
-    check.check_results(test_dir)
+    if cloud_directory is None:
+        check.check_results(test_dir)
+    else:
+        print(
+            tool_dir_name
+            + " "
+            + suite_dir_name
+            + " "
+            + test_dir_name
+            + " cloud results written to "
+            + cloud_test_dir
+            + "/"
+            + kht.RESULTS
+        )
 
 
 def evaluate_tool_on_suite_dir(
@@ -1135,6 +1262,16 @@ def main():
         action="store_true",
     )
 
+    # Mode cloud: lecture des donnees et ecriture des resultats sur le cloud
+    parser.add_argument(
+        "--cloud-directory",
+        help="cloud directory URI containing LearningTest data and receiving results"
+        " (e.g., gs://bucket/LearningTest, s3://bucket/LearningTest);"
+        " cannot be combined with 'check' alias",
+        metavar="uri",
+        action="store",
+    )
+
     # Analyse de la ligne de commande
     args = parser.parse_args()
 
@@ -1158,6 +1295,10 @@ def main():
         binaries_dir = args.binaries
     else:
         binaries_dir = os.path.abspath(args.binaries)
+
+    # Verification de l'incompatibilite entre --cloud-directory et l'alias 'check'
+    if args.cloud_directory is not None and binaries_dir == kht.ALIAS_CHECK:
+        parser.error("argument --cloud-directory cannot be combined with 'check' alias")
 
     # Verification des arguments optionnels
     utils.argument_parser_check_processes_argument(parser, args.n)
@@ -1222,6 +1363,7 @@ def main():
         output_scenario=args.output_scenario,
         nop_output_scenario=args.nop_output_scenario,
         user_interface=args.user_interface,
+        cloud_directory=args.cloud_directory,
     )
 
 


### PR DESCRIPTION
Introduce a `--cloud-directory` URI option to `kht_test` and `kht_apply` so that LearningTest non-regression tests can run with datasets stored on GCS, S3 or Azure while keeping scenarios and reference results local.

`kht_test --cloud-directory`:
- Before each test, Khiops is called with -O (no-replay) to produce a temporary scenario where all relative dataset paths (../../../) and output paths (./) are replaced by cloud URIs via the -r flag.
- If test.json exists, a two-step expansion first bakes JSON parameters into the scenario (avoiding the -j/-r mutual-exclusion constraint), then applies path replacement.
- All Khiops-written files (err.txt, .khj, .kdic, output scenarios…) land on the cloud; Python-written diagnostic files (stdout_error.log, time.log, …) remain local.
- Comparison and clean_version_from_results are skipped in cloud mode.

`kht_apply transform-cloud-results --cloud-directory`:
- New instruction in _kht_standard_instructions.py that replaces cloud URIs in downloaded result files with local relative paths, handling both plain-text files and .khj JSON files (escaped slashes).
- Also calls clean_version_from_results so results are ready for kht_test check without further processing.

README.md:
- New section "Testing with datasets on the cloud" documents the full 4-step workflow (run, download, normalize, compare) with concrete shell examples for GCS and S3, and a warning about time.log.

Workflow:
```bash
kht_test LearningTest r --cloud-directory gs://bucket/LearningTest -p 4 
gcloud storage cp -r "gs://bucket/LearningTest/TestKhiops/*/results" ./LearningTest/TestKhiops/ 
kht_apply LearningTest transform-cloud-results --cloud-directory gs://bucket/LearningTest 
kht_test LearningTest check
 ```