### PR TITLE
fix issues in OutputBufferedFile::Write and WriteSubPart

### DIFF
--- a/src/Norm/base/OutputBufferedFile.cpp
+++ b/src/Norm/base/OutputBufferedFile.cpp
@@ -304,7 +304,9 @@ boolean OutputBufferedFile::Write(const char* sValue, int nCharNumber)
 		while (not IsError() and nBeginChar < nCharNumber)
 		{
 			// Cas d'un buffer entier a ecrire
-			nEndChar = nBeginChar + nBufferSize;
+			// Calcul correct de la fin : le buffer peut contenir un reste du flush (partiel) precedent
+			assert(nCurrentBufferSize <= nBufferSize);
+			nEndChar = nBeginChar + (nBufferSize - nCurrentBufferSize);
 			if (nEndChar <= nCharNumber)
 			{
 				for (i = nBeginChar; i < nEndChar; i++)
@@ -391,8 +393,10 @@ boolean OutputBufferedFile::WriteSubPart(const CharVector* cvValue, int nBeginOf
 		while (not IsError() and nBeginChar < nLastChar)
 		{
 			// Cas d'un buffer entier a ecrire
-			nEndChar = nBeginChar + nBufferSize;
-			assert(nCurrentBufferSize == 0);
+			// Calcul correct de la fin : le buffer peut contenir un reste du flush (partiel) precedent
+			assert(nCurrentBufferSize <= nBufferSize);
+			nEndChar = nBeginChar + (nBufferSize - nCurrentBufferSize);
+
 			if (nEndChar <= nLastChar)
 			{
 				while (nBeginChar < nEndChar)

--- a/src/Norm/base/OutputBufferedFile.h
+++ b/src/Norm/base/OutputBufferedFile.h
@@ -79,8 +79,8 @@ public:
 protected:
 	// Ecriture du contenu du buffer dans le fichier
 	// Peut provoquer une erreur
-	// Lorsque la taille du cache est plus grande que GetPreferredBufferSize,
-	// seule un multiple de GetPreferredBufferSize est ecrit, le reste a ecrire est recopie
+	// Attention : Lorsque la taille du cache est plus grande que GetPreferredBufferSize,
+	// seul un multiple de GetPreferredBufferSize est ecrit, le reste a ecrire est recopie
 	// au debut du cache
 	virtual boolean FlushCache();
 


### PR DESCRIPTION
# Fix Summary: OutputBufferedFile Crash on Partial Buffer Flush

## Overview

**Issue**: Segmentation fault in `OutputBufferedFile` when writing large files during concatenation, triggered by GCS temporary directory support.

**Root Cause**: Latent bug in `OutputBufferedFile::Write()` and `OutputBufferedFile::WriteSubPart()` that assumes buffers are always flushed completely, which is violated when `nBufferSize > GetPreferredBufferSize()`.

**Solution**: Fix the buffer chunk calculation to correctly account for remainders after partial flushes.

**Files Modified**: 
- `src/Norm/base/OutputBufferedFile.cpp`

---

## Root Cause Analysis

### The Bug

The latent bug exists in two methods in `OutputBufferedFile.cpp`:
- `OutputBufferedFile::Write(const char* sValue, int nCharNumber)` (line ~309)
- `OutputBufferedFile::WriteSubPart(const CharVector* cvValue, int nBeginOffset, int nLength)` (line ~407)

Both methods contain this pattern after calling `FlushCache()`:

```cpp
while (not IsError() and nBeginChar < nCharNumber)  // or nLastChar
{
    nEndChar = nBeginChar + nBufferSize;  // BUG: assumes nCurrentBufferSize == 0
    assert(nCurrentBufferSize == 0);       // Only enforced in debug builds!
    if (nEndChar <= nCharNumber)           // or nLastChar
    {
        // Write exactly nBufferSize chars
        ...
    }
    FlushCache();
}
```

**The Hidden Assumption**: These methods assume that after `FlushCache()` completes, `nCurrentBufferSize == 0` (buffer is completely empty). This allows them to safely write exactly `nBufferSize` characters in the next iteration.

### When the Assumption Breaks

The assumption holds **only** when `FlushCache()` always writes all buffered content to disk. But in `FlushCache()`, there's a partial flush optimization:

```cpp
// src/Norm/base/OutputBufferedFile.cpp, lines ~538-543
if (nBufferSize > GetPreferredBufferSize())
    nSizeToWrite = (nCurrentBufferSize / GetPreferredBufferSize()) * GetPreferredBufferSize();
else
    nSizeToWrite = nCurrentBufferSize;

WriteToFile(nSizeToWrite);  // Only writes a multiple of GetPreferredBufferSize()
```

When `nBufferSize > GetPreferredBufferSize()`:
- Only a multiple of `GetPreferredBufferSize()` is written to disk
- The remainder stays in the buffer (`nCurrentBufferSize` remains non-zero)
- The assertion `assert(nCurrentBufferSize == 0)` fails in debug builds
- **In release builds**, the assertion is silently ignored, and the next write iteration incorrectly assumes an empty buffer

### The Buffer Overflow

After a partial flush with remainder:
1. `nCurrentBufferSize` = (remainder, e.g., 0.5 MB)
2. Next iteration: `nEndChar = nBeginChar + nBufferSize` (e.g., 1.5 MB)
3. The loop writes `nBufferSize` characters starting at position `nCurrentBufferSize`
4. This writes beyond the allocated buffer size → **heap corruption**

The corrupted `pValueBlocks` pointer array causes a crash when `fcCache.cvBuffer.ExportBuffer()` tries to dereference it.

---

## Why GCS Triggered This Bug

Prior to cloud temporary directory support, this condition (`nBufferSize > GetPreferredBufferSize()`) was rare:

1. **Before**: All preferred buffer sizes were ~1 MB (local ANSI driver)
   - Both input and output: 1 MB
   - Threshold in `PLFileConcatenater::Concatenate`: `lRemainingMemory >= 2 MB`
   - Easy to meet on modern machines
   - Else branch (causing oversized buffer) rarely triggered

2. **After**: GCS temp directory introduces 8 MB preferred buffer size
   - Input (GCS chunks): 8 MB
   - Output (local): 1 MB
   - Threshold: `lRemainingMemory >= 9 MB`
   - Much harder to satisfy under memory pressure
   - Else branch triggered more frequently, creating oversized output buffer

In `PLFileConcatenater::Concatenate()` (line ~190):

```cpp
if (lRemainingMemory >= (longint)nInputPreferredSize + nOutputPreferredSize)
{
    nOutputBufferSize = nOutputPreferredSize;  // 1 MB
}
else  // Now more likely with GCS (9 MB threshold)
{
    lInputBufferSize = lRemainingMemory / 2;
    nOutputBufferSize = (int)(lRemainingMemory - lInputBufferSize);  // Could be 1.5 MB, 3 MB, etc.
}
```

Result: `nOutputBufferSize = 1.5 MB > nPreferredBufferSize = 1 MB` → partial flush → remainder → **crash**.

---

## The Crash

**Stack Trace**:
```
OutputBufferedFile::WriteToFile(int)
  fcCache.cvBuffer.ExportBuffer(...)
    MemVector::ExportBuffer(...)
      memcpy(..., pValueBlocks[nSourcePos / nBlockSize][nSourcePos % nBlockSize], ...)
        
Crash at: 0x3009300930093009 (= '\t0\t0\t0\t0' — actual file data misinterpreted as pointer)
```

The pointer `0x3009300930093009` is the Dorothea tabular output file data being read as a memory address. This indicates:
1. Heap buffer was overwritten with file content
2. The overwritten `pValueBlocks` pointer array now contains garbage (file bytes)
3. Next memory access attempts to dereference this garbage

---

## The Fix

### Changes to `OutputBufferedFile::Write()`

**Before** (line ~309):
```cpp
while (not IsError() and nBeginChar < nCharNumber)
{
    // Cas d'un buffer entier a ecrire
    nEndChar = nBeginChar + nBufferSize;
    if (nEndChar <= nCharNumber)
    {
        for (i = nBeginChar; i < nEndChar; i++)
        {
            fcCache.SetAt(nCurrentBufferSize, sValue[i]);
            nCurrentBufferSize++;
        }
        nBeginChar = nEndChar;
        FlushCache();
    }
    ...
}
```

**After**:
```cpp
while (not IsError() and nBeginChar < nCharNumber)
{
    // Cas d'un buffer entier a ecrire
    // Calcul correct de la fin: le buffer peut contenir un reste de la flush partielle precedente
    nEndChar = nBeginChar + (nBufferSize - nCurrentBufferSize);
    if (nEndChar <= nCharNumber)
    {
        for (i = nBeginChar; i < nEndChar; i++)
        {
            fcCache.SetAt(nCurrentBufferSize, sValue[i]);
            nCurrentBufferSize++;
        }
        nBeginChar = nEndChar;
        FlushCache();
    }
    ...
}
```

**Key Change**: `nEndChar = nBeginChar + (nBufferSize - nCurrentBufferSize)`

This correctly computes how many characters can be added to the buffer, accounting for any remainder from a partial flush.

### Changes to `OutputBufferedFile::WriteSubPart()`

**Before** (line ~407):
```cpp
while (not IsError() and nBeginChar < nLastChar)
{
    // Cas d'un buffer entier a ecrire
    nEndChar = nBeginChar + nBufferSize;
    assert(nCurrentBufferSize == 0);  // FAILS after partial flush
    if (nEndChar <= nLastChar)
    {
        while (nBeginChar < nEndChar)
        {
            fcCache.SetAt(nCurrentBufferSize, cvValue->GetAt(nBeginChar));
            nCurrentBufferSize++;
            nBeginChar++;
        }
        assert(nBeginChar == nEndChar);
        FlushCache();
    }
    ...
}
```

**After**:
```cpp
while (not IsError() and nBeginChar < nLastChar)
{
    // Cas d'un buffer entier a ecrire
    // Calcul correct de la fin: le buffer peut contenir un reste de la flush partielle precedente
    nEndChar = nBeginChar + (nBufferSize - nCurrentBufferSize);
    assert(nCurrentBufferSize <= nBufferSize);  // Changed: allows non-zero remainder
    if (nEndChar <= nLastChar)
    {
        while (nBeginChar < nEndChar)
        {
            fcCache.SetAt(nCurrentBufferSize, cvValue->GetAt(nBeginChar));
            nCurrentBufferSize++;
            nBeginChar++;
        }
        assert(nBeginChar == nEndChar);
        FlushCache();
    }
    ...
}
```

**Key Changes**:
1. `nEndChar = nBeginChar + (nBufferSize - nCurrentBufferSize)` — accounts for remainder
2. `assert(nCurrentBufferSize <= nBufferSize)` — relaxed assertion acknowledges that remainder can exist

### Why This Fix Works

With the fix, if a partial flush leaves a remainder:

**Before Fix**:
- Buffer has 0.5 MB remainder from previous partial flush
- Next iteration: write 1.5 MB starting at position 0.5 MB
- Total written: 2 MB into 1.5 MB buffer → **overflow**

**After Fix**:
- Buffer has 0.5 MB remainder from previous partial flush
- Next iteration: write (1.5 - 0.5) = **1 MB** starting at position 0.5 MB
- Total written: 1.5 MB into 1.5 MB buffer → **correct**

The buffer never overflows because we always respect `nCurrentBufferSize + bytes_to_write <= nBufferSize`.

---

## Testing and Verification

### Test Case

The Dorothea test in the GCS temporary directory branch:
```bash
python test/LearningTestTool/py/kht_test.py ../LearningTest/TestKhiops/SparseData/Dorothea r -p 1
```

This test:
- Transfers a large sparse dataset (800 records × ~100k features)
- Writes output in tabular format (~160+ MB)
- Previously crashed with segfault due to the buffer overflow

### Expected Result

After the fix:
- ✅ Test completes without segfault
- ✅ Output file is valid and matches expected comparison results
- ✅ No heap corruption or memory errors

---

## Impact

### Scope of the Fix

**Affected Scenarios**:
- Any `OutputBufferedFile` write where `nBufferSize > GetPreferredBufferSize()`
  - GCS temporary directory (8 MB preferred size, oversized output buffer possible)
  - Low-memory environments (else branch in `PLFileConcatenater::Concatenate`)
  - Custom code using `OutputBufferedFile` with large buffer sizes

**Not Affected**:
- Normal use cases where `nBufferSize <= GetPreferredBufferSize()` (partial flushes don't occur)
- `InputBufferedFile` (similar structure but no equivalent bug discovered)

### Benefits

1. **Robustness**: Code now correctly handles any buffer size, even if `nBufferSize > GetPreferredBufferSize()`
2. **Simplification**: No need for workaround capping in `PLFileConcatenater` (Option A avoided)
3. **Correctness**: Proper accounting of buffer state eliminates latent invariant violation

---

## Technical Details

### Memory Segmentation

`OutputBufferedFile` uses `FileCache`, which uses `CharVector`, which uses segmented memory allocation:

- **Single-block**: `nAllocSize <= nBlockSize` (e.g., ≤ 65 KB)
  - Direct `char* pValues` pointer
- **Multi-block**: `nAllocSize > nBlockSize`
  - `pValueBlocks` is a pointer array: `pValueBlocks[i]` points to segment i
  - Each segment is `nBlockSize` (65 KB) bytes

When `nCurrentBufferSize` is beyond allocated segments due to buffer overflow, `pValueBlocks[index]` points to invalid memory. This is what caused the crash at `0x3009300930093009`.

### Preferred Buffer Size

Each file driver has a `GetSystemPreferredBufferSize()` that optimizes I/O performance:
- **ANSI driver** (local files): 1 MB
- **GCS driver** (Google Cloud Storage): 8 MB (larger block sizes on cloud)

`FlushCache()` uses this to batch writes for efficiency, but the optimization only works when the flush doesn't leave a remainder.

---

## Conclusion

This fix addresses a latent buffer management bug in `OutputBufferedFile` that became critical with GCS temporary directory support. The bug existed in the codebase before but was never triggered under typical conditions (both input and output used 1 MB preferred size). By fixing the underlying invariant violation, we ensure correct behavior regardless of buffer size configuration and enable robust cloud-based temporary directories.
