### PR TITLE
Fix khiops installation for tests by pinning the version

### DIFF
--- a/.github/workflows/pack-pip.yml
+++ b/.github/workflows/pack-pip.yml
@@ -216,7 +216,17 @@ jobs:
             source "$KHIOPS_INSTALL_DIR/bin/activate"
             echo "BIN_DIR=$KHIOPS_INSTALL_DIR/bin" >> "$GITHUB_OUTPUT"
           fi
-          $PYTHON -m pip install --find-links=wheelhouse khiops-core khiops-kni khiops-knitransfer
+          # Pip install the wheels from the wheelhouse directory, using the exact versions of the built wheels
+          # If we don't specify the exact versions, pip may install a different version if it is already present
+          # in the pypi repository, which would not be the version we just built.
+          CORE_VERSION=$(ls wheelhouse/khiops_core-*.whl | head -1 | xargs basename | cut -d- -f2)
+          KNI_VERSION=$(ls wheelhouse/khiops_kni-*.whl | head -1 | xargs basename | cut -d- -f2)
+          KNITRANSFER_VERSION=$(ls wheelhouse/khiops_knitransfer-*.whl | head -1 | xargs basename | cut -d- -f2)
+          $PYTHON -m pip install \
+            --find-links=wheelhouse \
+            "khiops-core==$CORE_VERSION" \
+            "khiops-kni==$KNI_VERSION" \
+            "khiops-knitransfer==$KNITRANSFER_VERSION"
           $PYTHON -m pip show -f khiops-core
           $PYTHON -m pip show -f khiops-kni
       - name: Run standard tests on the Core and KNI packages


### PR DESCRIPTION
Tests fail due to wrong version of khiops being installed. This is due to the behavior of pip that prefers repository packages over local files.
This is more a fragile workaround than a fix: we explicitly pin the versions to be installed by using the locally built version numbers. If such versions do not exist in pypi registry the local versions will be installed.