### PR TITLE
Add cloud dataset support to LearningTestTool (bis)

### DIFF
--- a/test/LearningTestTool/README.md
+++ b/test/LearningTestTool/README.md
@@ -1,8 +1,7 @@
-# Khiops test tool: LearningTest and LearningTestTool
-
+# Khiops Test Tool: LearningTest and LearningTestTool
 LearningTest
 - created in March 2009
-- automated test of Khiops tools
+- automated tests for Khiops tools
 - versions synchronized with delivered Khiops versions
   - one version per delivered Khiops version, with same tag
   - one version for the current branch under development
@@ -10,10 +9,41 @@ LearningTest
 Non-regression tests consist of over 600 test sets organized into around 40 suites, mainly for Khiops, but also for Khiops coclustering and the KNI DLL.
 They collectively occupy around 10 GB, including 5 GB for the databases and 3.5 GB for the test scripts with the reference results.
 
-The following components are involved in the Khiops tests
+The following components are involved in the Khiops tests:
 - tool binaries: binaries of the tools (Khiops, Coclustering and KNI) to test
-- LearningTestTool: scripts that launch the tests and analyse the results
-- LearningTest: datasets, tool scnearios that describe the tests and reference results
+- LearningTestTool: scripts that launch the tests and analyze the results
+- LearningTest: datasets, tool scenarios that describe the tests and reference results
+
+## Table of Contents
+
+- [LearningTest](#learningtest)
+  - [LearningTest directory tree](#learningtest-directory-tree)
+  - [Test dirs](#test-dirs)
+  - [Normalisation of paths in scenarios](#normalisation-of-paths-in-scenarios)
+  - [Variants of reference results](#variants-of-reference-results)
+- [LearningTestTool](#learningtesttool)
+  - [Terminology](#terminology)
+- [LearningTest commands](#learningtest-commands)
+  - [LearningTestTool directory tree](#learningtesttool-directory-tree)
+  - [Implementation of LearningTestTool](#implementation-of-learningtesttool)
+- [Running Khiops tests](#running-khiops-tests)
+- [Main usages](#main-usages)
+  - [Test methodology](#test-methodology)
+  - [Non-regression tests for development](#non-regression-tests-for-development)
+  - [Non-regression tests for release](#non-regression-tests-for-release)
+  - [Portability on new platform](#portability-on-new-platform)
+  - [CI/CD](#cicd)
+- [Evolutions of LearningTest](#evolutions-of-learningtest)
+  - [New test dir](#new-test-dir)
+  - [New test suite](#new-test-suite)
+  - [Evolution of scenarios](#evolution-of-scenarios)
+  - [Evolution of reference results](#evolution-of-reference-results)
+- [Management of LearningTest and LearningTestTool](#management-of-learningtest-and-learningtesttool)
+  - [Cloud URI Support in LearningTest](#cloud-uri-support-in-learningtest)
+    - [Cloudification process](#cloudification-process)
+    - [Step-by-step workflow](#step-by-step-workflow)
+
+
 
 
 ## LearningTest
@@ -22,16 +52,16 @@ The LearningTest directory stores all the datasets, tool scenarios and reference
 
 ### LearningTest directory tree
 
-The _LearningTest dir_ contains one sub-directory per _collection of datasets_:
+The _LearningTest dir_ contains one subdirectory per _dataset collection_:
 - datasets: standard datasets
 - MTdatasets: multi-table datasets
 - TextDatasets: text datasets
 - UnusedDatasets: datasets not currently in use
 
-And one _tool dir_ per set of tests related to each tool
+And one _tool dir_ per set of tests related to each tool:
 - TestKhiops: tests for Khiops
 - TestCoclustering: tests for Coclustering
-- TestKNI: test for KNI
+- TestKNI: tests for KNI
 
 Each tool dir is a two-level tree:
 - Level 1: one _suite dir_ per test suite, e.g. _TestKhiops/Standard_
@@ -48,12 +78,12 @@ Each test dir is organized as follows:
 - readme.txt: optional file with short information relative to the test
 - results: sub-directory containing the results of running the tool with the script
 - results.ref: sub-directory containing reference results
-- comparisonResults.log: comparisonb report obtained by comparing results and results.ref
+- comparisonResults.log: comparison report obtained by comparing results and results.ref
 
 ### Normalisation of paths in scenarios
 
 The test.prm scenario files must be written independently of the LearningTest localization, by specifying
-the paths of the files concerned, which must be relative to the LearningTest tree structure, with linux-type syntax.
+the paths of the relevant files, which must be relative to the LearningTest tree structure, using Linux-style syntax.
 
 For example:
 - `./SNB_Modeling.kdic` to access a specific local dictionary in the test dir
@@ -62,17 +92,17 @@ For example:
 - `../../../datasets/Adult/Adult.txt` to access a dataset data file from a collection of datasets
 - `./results/T_Adult.txt` for a result in the results sub-directory
 
-### Variants of references results
+### Variants of reference results
 
-The references results in `results.ref` dir may have variations, depending on the context
+The reference results in the `results.ref` dir may vary depending on the context:
 - computing type: sequential, parallel,
 - platform: Windows, Linux, Darwin (macOS)
 
 In this case, multiple reference result directories are used to store the results:
-- naming convention: `results_ref<-(computing type)><-(plateforms)>`
-  - the '-' char is used to separate the context informations
-  - the '_' car is used in case of several values per context
-- the set of `results.ref` directories muts cover all possible contexts
+- naming convention: `results_ref<-(computing type)><-(platforms)>`
+  - the '-' character is used to separate context information
+  - the '_' character is used when several values exist for a given context
+- the set of `results.ref` directories must cover all possible contexts
   - the base `results.ref` dir (without context) is used when specific contexts are not necessary
 - examples of valid results.ref directories:
   - `results.ref-sequential`, `results.ref-parallel`
@@ -80,14 +110,14 @@ In this case, multiple reference result directories are used to store the result
   - `results.ref-parallel-Darwin_Linux`
 - examples of valid sets of results.ref directories
   - [results.ref]: standard case
-  - [results.ref, results.ref-parallel]: specialisation in case of parallel computing
-  - [results.ref, results.ref-Darwin_Linux]: specialisation for Linux and Mac platforms
+  - [results.ref, results.ref-parallel]: specialization for parallel computing
+  - [results.ref, results.ref-Darwin_Linux]: specialization for Linux and Mac platforms
   - [results.ref, results.ref-Parallel, results.ref-Parallel-Darwin_Linux]: more complex contexts
 
 
 ## LearningTestTool
 
-The LearningTestTool directory stores all the scripts to test the Khiops tools and analyse the results, using a LearningTest directory.
+The LearningTestTool directory stores all the scripts used to test Khiops tools and analyze the results using a LearningTest directory.
 
 ### Terminology
 
@@ -106,8 +136,8 @@ The following terminology is used throughout the test environment:
   - `full`: suites used for non-regression tests (default family), around one hour of overall execution time
   - `fullNoKNI`: same as `full`, without the KNI tool (e.g. to test the tool binaries of an installed Khiops desktop application)
   - `complete`: same as `full`, plus large scale tests, around one day of overall execution time
-  - `all`: all suites (used to managed test dirs exhaustively, not to run tests)
-- divers
+  - `all`: all suites (used to manage test dirs exhaustively, not to run tests)
+- miscellaneous
   - `command`: one of the LearningTest scripts
   - `instruction`: instruction to perform on test dirs (e.g. `errors` to collect error stats)
   - `dataset collection`: collection of datasets (e.g. `datasets`, `MTdatasets`,...)
@@ -150,6 +180,13 @@ Available LearningTest commands are
   - options:
         - export types: _all_, _scripts_, _references_, _datasets_ (default: _all_)
 	- family
+	- cloud-directory: cloudify dataset paths to a cloud URI (gs://, s3://, https://, etc.)
+    - export is performed first, then the exported tree is transformed in a second step
+	  - generates test-cloud.prm with cloudified dataset paths (alongside test.prm)
+	  - cloudifies dataset paths in results.ref* reference result files
+	  - detects and prevents re-cloudification of already-processed test trees
+	  - requires --binaries option for JSON parameter expansion via khiops -j
+	- binaries: required when --cloud-directory is specified; path to Khiops tool binaries directory or release/debug alias
 - **_kht_env_**
   - show the status of the main environment variables used by the tool binaries
 - **_kht_help_**
@@ -185,16 +222,16 @@ Naming conventions
   - files: error_file_name vs error_file_path
   - directories: suite_dir_name vs suite_dir (path not used in variable name)
 
-All command are implemented using the python language:
+All commands are implemented in Python:
 - LearningTestTool/py
-  - one (command).py file per command
+  - one `<command>.py` file per command
   - plus internal python files, prefixed by '_'
 	- _kht_constants.py: common constants
 	- _kht_utils.py: common utility functions
 	- _kht_families.py: definition of families
 	- _kht_results_management.py: management of context of reference results, sequential vs parallel and platform
-	- _kht_standard_instructions.py: standard maintained instruction functions for kht_apply  command
-	- _kht_one_shot_instructions.py: one-shot instruction functions for kht_apply  command
+  - _kht_standard_instructions.py: standard maintained instruction functions for the kht_apply command
+  - _kht_one_shot_instructions.py: one-shot instruction functions for the kht_apply command
 	- _kht_check_results.py: deep check by comparison of test and reference results
 - LearningTestTool/cmd
   - one (command).cmd file per command
@@ -213,37 +250,37 @@ The kht_test.py source file:
 
 The _kht_check_results.py source file is the most critical one
 - objective:
-  - resilient cross-plateform comparison of test and reference results
-  - fully automatic, while beeing as robust as a human expert comparison
+  - resilient cross-platform comparison of test and reference results
+  - fully automatic, while being as robust as a human expert comparison
 - by far the most complex portion of code
   - but pragmatic code fast to implement and test, avoiding over-design
-  - constrained by fast evolution, reuse by copy-past is acceptable
-  - it it sometimes simpler to rework the content of specific test dirs
-- main features to be robust to changes accross contexts, with relience to
+  - constrained by fast evolution; reuse by copy-paste is acceptable
+  - it is sometimes simpler to rework the content of specific test dirs
+- main features to remain robust across contexts, with resilience to
   - value of the tool version is ignored everywhere
   - computing times in err.txt file are ignored
-  - varying results depending on the context, sequentiel vs parallel, plus platform, with dedidate results.ref directories
+  - varying results depending on the context, sequential vs parallel, plus platform, with dedicated `results.ref` directories
   - messages in relation to resource limits, which may vary slightly depending on execution modes and platforms
   - "normal" failure in scenario ("Batch mode failure")
-  - byte encoding of file names across plateforms
+  - byte encoding of file names across platforms
   - poor handling of accented file names by zip
   - varying patterns in error messages
   - specific messages that occur only in sequential mode (100th, 1000th warning...)
   - varying order of messages in some rare cases, in parallel mode
   - approximate AUC estimate in the event of limited resources
-  - espilon variation of numerical results
+  - epsilon variation of numerical results
   - ...
 
 A difficult task is to design the Khiops algorithms with the aim of being reproducible, which has so far been achieved:
 - using a portability layer that provides an abstraction of the underlying platform
-- using the Parallel library that guaranties the same results whatever the ressources (RAM, number of cores)
+- using the Parallel library that guarantees the same results whatever the resources are (RAM, number of cores)
   - a few exceptions:
-	- for optimisation purposes, some tasks are only run in parallel mode (e.g. pre-indexation of files)
+  - for optimization purposes, some tasks are only run in parallel mode (e.g. pre-indexation of files)
 	- the AUC criterion can be evaluated on a subset of the database when there is not enough RAM
 - using truncations in some numerical results
 - fixing the random seeds
-- using sort with secondary sort criterions n case of equality, including fixed random values when a random choice is used
-  - this is important, because the Ansi sort function exploits a stable sort only on some plateforms
+- using sort with secondary sort criteria in case of equality, including fixed random values when a random choice is used
+  - this is important because the ANSI sort function exploits a stable sort only on some platforms
 - ...
 
 ## Running Khiops tests
@@ -259,7 +296,7 @@ Installing LearningTest on a new machine
 - Install python
   - add python to the path
 
-All commands are directly callable from any plateform.
+All commands can be called directly from any platform.
 
 ## Main usages
 
@@ -270,7 +307,7 @@ In practice, the tests are run in stages:
 - **scale**
   - elementary: TestKhiops/Standard/IrisLight, around one second, even in debug mode
   - standard: TestKhiops/Standard, around one minute
-  - _full_ familly (default family): all non-regression tests, around one hour
+  - _full_ family (default family): all non-regression tests, around one hour
   - _complete_ family: same as full, plus large scale tests, around one day
 - **execution mode**
   - _full_ using sequential or parallel computing (use process number = 4)
@@ -278,7 +315,7 @@ In practice, the tests are run in stages:
 - **portability**
   - _full_ under different platforms
 - **stress tests**
-  - huge scale: monster datasets (tens to hundreds of Gb) on powerfull servers are sometimes used for stress tests:
+  - huge scale: monster datasets (tens to hundreds of GB) on powerful servers are sometimes used for stress tests:
 	- datasets from the large scale learning challenge (DNA, 50 millions of instances with 200 records per instances)
 	- Criteo (45 millions of instances)
 	- OrangeCDR: 100000 instances with 35 million CDRs
@@ -286,7 +323,7 @@ In practice, the tests are run in stages:
   - parallelization and performance: the same test scenario is used, but with different resources, RAM and number of processes.
   - ...
 
-### Non-regression tests for developpement
+### Non-regression tests for development
 
 The aim is to quickly check that the new source code has not introduced any regressions.
 
@@ -311,16 +348,16 @@ The tests must be run on the new platform, using the _full_ family.
 
 ### CI/CD
 
-The tests can be run at different steps of the developpement process:
-- pull request: automatic run of the tests using the _basic_ familly
-  - minimum check that the code compiles and run on three plateforms on standard test dirs
+The tests can be run at different steps of the development process:
+- pull request: automatic run of the tests using the _basic_ family
+  - minimum check that the code compiles and runs on three platforms on standard test dirs
   - rapid and sufficient in most cases
   - in some cases, the requirement may be higher
 	- for example, in the case of a major feature
 	- it is up to the reviewer to impose this requirement, in agreement with the developer
 	- the tests can be run manually using the _full_ family on the developer's platform
 - release
-  - the test must be run using the _full_ familly on all the supported plateforms
+  - the test must be run using the _full_ family on all supported platforms
   - this must be triggered manually before the release
   - this can also be triggered periodically (for example, once a month), for verification purposes
 
@@ -332,7 +369,7 @@ A new test dir may be necessary in the following case:
 - fix a bug
 - new minor feature
 
-In this case, a new test dir is first developped in a temporary working suite,
+In this case, a new test dir is first developed in a temporary working suite,
 (e.g. `LearningTest/TestKhiops/z_Work`).
 
 When the new test dir is completed with its scenario and reference results dir, it can be copied in an existing suite,
@@ -345,7 +382,7 @@ It might be referenced in the commit notes of the relevant github issue.
 A new test dir may be necessary in the following case:
 - new major feature
 
-In this case, a new test suite is first developped in a new temporary working suite,
+In this case, a new test suite is first developed in a new temporary working suite,
 (e.g. `LearningTest/TestKhiops/z_TextVariables`).
 
 When the development of the major feature is completed, the new test suite can become an "official suite"
@@ -365,7 +402,7 @@ In this case, the scenarios `test.prm` within each test dir have to be updated:
 - implement manually a prototype of the new scenario
   - copy one representative test dir in working suite
     (ex: `LearningTest/TestKhiops/Standard/Adult` in `LearningTest/TestKhiops/z_Work`)
-  - register the new scenario using the tool in user interface mdoe with the -o option
+  - register the new scenario using the tool in user interface mode with the `-o` option
   - adapt the scenario to the LearningTest constraints, such as normalisation of paths...
 - implement a one-shot instruction (ex: `transformPrm`) in python source file `_kht_one_shot_instructions.py`
   to automatically transform the scenario from its old version to its new version
@@ -390,19 +427,19 @@ In this case, the reference results within each dir have to be updated:
 - first, save all the current LearningTest directory tree
   - using git lab
   - or locally on your disk using the kht_export command
-- test your new algorithm on temporay work suites first
+- test your new algorithm on temporary work suites first
 - compare your test and results manually by double-checking the results
   - on one representative test dir (ex: `LearningTest/TestKhiops/Standard/Adult`)
   - on one representative test suite (ex: `LearningTest/TestKhiops/Standard`)
-  - on some carefully choosen additional test dirs, representative of potential difficulties
+  - on some carefully chosen additional test dirs, representative of potential difficulties
 - implement a one-shot instruction (ex: `compareSNBResults`) in python source file `_kht_one_shot_instructions.py`
   to automatically compare the new test results to the old reference results
   - ensure that anything except the new feature is unchanged (ex: data preparation results should be unchanged if the SNB only has evolved)
-  - check that the new perfomance indicators (accuracy, auc...) remain close from the old ones
-  - check that the new computing times remain close from the old ones
+  - check that the new performance indicators (accuracy, AUC...) remain close to the old ones
+  - check that the new computing times remain close to the old ones
 - use the test methodology to apply the `compareSNBResults` instruction by increasing scale, up to all the test dirs
 - when all is validated and double checked, update the new references using the `makeref` instruction
-- _be rigouros and paranoid: the quality of the reference results is critical_
+- _be rigorous and paranoid: the quality of the reference results is critical_
 
 ## Management of LearningTest and LearningTestTool
 
@@ -415,29 +452,90 @@ but their pace of development is different:
 - LearningTestTool rarely evolves
   - resilience methods sometimes need to be maintained as Khiops algorithms or output reports evolve
 
-Currently, LearningTestTool and a tiny part of LearningTest (`basic` family)
-are maintained in the Khiops github repo https://github.com/KhiopsML/khiops
+Currently, LearningTestTool and a tiny part of LearningTest (`basic` family) are maintained in the [Khiops github repo](https://github.com/KhiopsML/khiops)
 
 The full LearningTest directory tree cannot be embedded in the Khiops github repo for the following reasons:
 - scalability issue: around ten GB are necessary to store a snapshot of one version of LearningTest
 - confidentiality: some datasets or test dir contain confidential data
 - cost: storing and managing a large number of tests on dozens of platforms can be expensive in an external cloud
 
-A solution must be defined to meet the requirements of the processes summarised in this document.
+The full LearningTest is stored and versioned in an internal GitLab repository.
 
-A potential solution, for a start:
-- keep the developpement of LearningTest on the Khiops repo, with the `basic` sub-part of LearningTest
-- exploit a gitlab repo to store and manage LearningTest: process to specify
-  - all file except scenarios (test.prm) managed using LFS
-  - synchronisation of version between the Khiops and LearningTest repos: use the closest former version
-  - keep a full snapshot of LearningTest for past versions of Khiops
-  - for the current dev branch of Khiops:
-	- keep only a few last version of LearningTest
-	- clean the preceeding former deprecated versions of LearningTest if necessary (never used again)
-  - ...
-- exploit the system initialized by Stephane G to launch the tests on many plateforms
-- ...
+### Cloud URI Support in LearningTest
 
+The LearningTest export tool supports exporting test trees with cloudified paths, where datasets are
+read from a cloud storage URI (gs://, s3://, https://, etc.) while Khiops runs locally.
 
+**What needs to be on the cloud**: datasets and directory hierarchy without results.ref.*
+Reference results (results.ref* directories) and scenario files can remain local.
 
+**Recommended workflow** (simplified): keep a single cloudified LearningTest tree on the local machine,
+mirroring what is on the cloud. This simplifies path management and avoids maintaining separate trees.
 
+#### Cloudification process
+
+When exporting with `--cloud-directory`, the tool uses a two-step process:
+1. **Standard export**: the requested LearningTest subtree is exported locally exactly as in a normal `kht_export` run
+2. **Cloudification of the exported tree**: the exported files are then transformed in place
+
+The cloudification step itself performs two operations:
+1. **JSON parameter expansion**: Khiops scenarios (`test.prm`) that include JSON parameter files (`test.json`) are expanded using `khiops -j`
+2. **Path substitution**: local dataset paths are replaced with cloud URIs in both scenario files and reference result files
+
+Generated files per test dir:
+- `test-cloud.prm`: scenario file with cloudified dataset paths, placed alongside test.prm
+- `results.ref*/` files: reference result files updated with cloudified paths
+
+When `kht_test` detects a `test-cloud.prm` file in a test dir, it uses that instead of `test.prm`.
+
+#### Step-by-step workflow
+
+1. **Export the LearningTest tree locally, then cloudify that exported tree automatically in a second step**:
+   ```bash
+   kht_export /home/bob/LearningTest -f basic --cloud-directory gs://khiops-test/LearningTest \
+   --binaries build/macos-clang-release/bin/ /tmp
+   ```
+  This creates `/tmp/LearningTest`. The command first copies the selected LearningTest content, then rewrites the exported tree to add `test-cloud.prm` and cloudified `results.ref*` files.
+
+2. **Upload the whole cloudified LearningTest tree** to cloud storage (datasets, scenarios, reference results):
+   ```bash
+   # Google Cloud Storage
+   gcloud storage cp -r /tmp/LearningTest gs://khiops-test/LearningTest
+   # Amazon S3
+   aws s3 sync /tmp/LearningTest s3://khiops-test/LearningTest
+   # Azure Blob Storage
+   azcopy sync /tmp/LearningTest https://<account>.blob.core.windows.net/khiops-test/LearningTest
+   ```
+   The local `/tmp/LearningTest` and the cloud bucket are now synchronized mirrors.
+
+3. **Run tests** with Khiops reading datasets from the cloud:
+   ```bash
+   kht_test /tmp/LearningTest -f basic build/macos-clang-release/bin/
+   ```
+   Scenario-driven output files whose paths are defined inside the scenario, such as `.khj`, `.kdic`, `.xls`, and other files written under `./results/`, are written to the cloudified result paths. On the other hand, `err.txt`, output scenarios (`output_test.prm`, `nop_output_test.prm`), the task file (`task_progression.log`), and all Python diagnostic files (`stdout_error.log`, `stderr_error.log`, `return_code_error.log`, `process_timeout_error.log`, `time.log`) are written **locally**. The automatic comparison at the end of `kht_test` is skipped in this mode, because the full `results/` directory is not yet available locally.
+    > [!NOTE] Automatically clean results with native cloud command
+    > Before launching Khiops, `kht_test` cleans the local `results/` directory and also removes the remote cloud `results/` directory using the native cloud command for the corresponding URI scheme (`gcloud storage rm` for `gs://`, `aws s3 rm` for `s3://`, `azcopy rm` for `https://`). This avoids stale result files from a previous run remaining on the cloud. Khiops then resolves dataset paths from the cloud URIs in `test-cloud.prm`.
+4. **Sync the cloudified LearningTest tree back** before comparison.
+   To avoid unnecessary recopies, prefer checksum-based comparison when the cloud tool supports it.
+   ```bash
+   # Google Cloud Storage
+   gcloud storage rsync -r --checksums-only gs://khiops-test/LearningTest /tmp/LearningTest
+
+   # Amazon S3
+   # No exact checksum-only equivalent in aws s3 sync
+   aws s3 sync s3://khiops-test/LearningTest /tmp/LearningTest
+
+   # Azure Blob Storage
+   azcopy sync 'https://<account>.blob.core.windows.net/khiops-test/LearningTest' '/tmp/LearningTest' \
+     --compare-hash=MD5
+   ```
+
+5. **Compare results** against reference explicitly after synchronization:
+   ```bash
+   kht_test /tmp/LearningTest check -f basic
+   ```
+
+6. **Inspect failures** as usual if needed:
+   ```bash
+   kht_apply errors /tmp/LearningTest -f basic
+   ```

--- a/test/LearningTestTool/py/_kht_cloud_utils.py
+++ b/test/LearningTestTool/py/_kht_cloud_utils.py
@@ -1,0 +1,361 @@
+# Copyright (c) 2023-2026 Orange. All rights reserved.
+# This software is distributed under the BSD 3-Clause-clear License, the text of which is available
+# at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
+
+import os
+import stat
+import subprocess
+import shutil
+import tempfile
+
+import _kht_constants as kht
+import _kht_results_management as results
+import _kht_utils as utils
+from kht_test import build_tool_exe_path
+
+"""
+Fonctions pour la cloudification et le nettoyage de l'arborescence LearningTest
+"""
+
+
+# Prefixes valides pour un URI de repertoire cloud
+_CLOUD_URI_PREFIXES = ("gs://", "s3://", "https://")
+
+
+# --- URI cloud : validation et normalisation ---
+def check_cloud_dir(uri):
+    """Retourne True si l'URI est un URI cloud valide (gs://, s3://, https://)"""
+    return uri is not None and uri.startswith(_CLOUD_URI_PREFIXES)
+
+
+def normalize_cloud_directory_uri(cloud_dir):
+    """Supprime les '/' terminaux d'un URI cloud en preservant le separateur de schema (ex: gs://)"""
+    normalized = cloud_dir
+    while normalized.endswith("/") and not normalized.endswith("://"):
+        normalized = normalized[:-1]
+    return normalized
+
+
+# --- Detection de cloudification dans une arborescence LearningTest ---
+def is_cloudified_test_dir(test_dir):
+    """Retourne True si le repertoire de test contient un scenario cloud (test-cloud.prm)"""
+    return os.path.isfile(os.path.join(test_dir, kht.TEST_CLOUD_PRM))
+
+
+def is_cloudified_home_dir(home_dir):
+    """Retourne True si au moins un repertoire de test de l'arborescence est cloudifie"""
+    for tool_dir_name in kht.TOOL_DIR_NAMES.values():
+        tool_dir = os.path.join(home_dir, tool_dir_name)
+        if not os.path.isdir(tool_dir):
+            continue
+        for suite_name in os.listdir(tool_dir):
+            suite_dir = os.path.join(tool_dir, suite_name)
+            if not os.path.isdir(suite_dir):
+                continue
+            for test_name in os.listdir(suite_dir):
+                test_dir = os.path.join(suite_dir, test_name)
+                if is_cloudified_test_dir(test_dir):
+                    return True
+    return False
+
+
+# --- Helpers internes de transformation de contenu ---
+def run_khiops_no_replay(khiops_params, step_label):
+    """Execute khiops -O (no-replay) pour transformer le scenario; retourne le chemin du fichier .prm de sortie."""
+    out_fd, out_path = tempfile.mkstemp(suffix=".prm", prefix="kht_no_replay_out_")
+    os.close(out_fd)
+    err_fd, err_file_path = tempfile.mkstemp(suffix=".txt", prefix="kht_no_replay_err_")
+    os.close(err_fd)
+    result = subprocess.run(
+        khiops_params + ["-O", out_path, "-e", err_file_path],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if result.stdout.strip():
+        print("Warning: unexpected output during " + step_label + ":\n" + result.stdout)
+    if result.stderr.strip():
+        print(
+            "Warning: unexpected error output during "
+            + step_label
+            + ":\n"
+            + result.stderr
+        )
+    if os.path.isfile(err_file_path):
+        with open(err_file_path, "r", errors="ignore") as err_f:
+            err_content = err_f.read()
+        if "error" in err_content.lower():
+            print("Warning: errors in " + step_label + " error log:\n" + err_content)
+        utils.remove_file(err_file_path)
+    return out_path
+
+
+def cloudify_file_content(content, cloud_dir, cloud_test_dir, is_json):
+    """Remplace les chemins locaux par des URIs cloud dans le contenu d'un fichier.
+    L'ordre est crucial : '../../../' avant './' car './' est une sous-chaine.
+    """
+    cloud_results_dir = cloud_test_dir + "/" + kht.RESULTS
+    if is_json:
+        # Dans les fichiers JSON les '/' sont echappes en '\/'
+        def esc(s):
+            return s.replace("/", "\\/")
+
+        content = content.replace(esc("../../../"), esc(cloud_dir + "/"))
+        content = content.replace(
+            esc("./" + kht.RESULTS + "/"), esc(cloud_results_dir + "/")
+        )
+        content = content.replace(esc("./"), esc(cloud_test_dir + "/"))
+    else:
+        content = content.replace("../../../", cloud_dir + "/")
+        content = content.replace("./" + kht.RESULTS + "/", cloud_results_dir + "/")
+        content = content.replace("./", cloud_test_dir + "/")
+    return content
+
+
+def cloudify_prm_content(content, cloud_dir, cloud_test_dir):
+    """Remplace les chemins locaux par des URIs cloud dans un scenario Khiops.
+    L'ordre est crucial : '../../../' doit etre traite avant './' car './' est une sous-chaine.
+    """
+    content = content.replace("../../../", cloud_dir + "/")
+    content = content.replace("./", cloud_test_dir + "/")
+    return content
+
+
+# --- API de cloudification pour l'export LearningTest (kht_export) ---
+def generate_cloud_prm(
+    source_test_dir, target_test_dir, cloud_dir, cloud_test_dir, tool_exe_path
+):
+    """Genere test-cloud.prm dans target_test_dir a partir de test.prm (et test.json si present).
+    Etape 1 : expansion de test.json via khiops -j (si binaire fourni) ou heuristique Python.
+    Etape 2 : remplacement des chemins locaux par les URIs cloud via cloudify_prm_content.
+    Retourne True si le fichier a ete genere.
+    """
+    src_prm = os.path.join(source_test_dir, kht.TEST_PRM)
+    if not os.path.isfile(src_prm):
+        return False
+
+    src_json = os.path.join(source_test_dir, kht.TEST_JSON)
+    expanded_prm = None  # fichier temporaire a nettoyer si cree
+
+    if os.path.isfile(src_json):
+        # Expansion via khiops -j : khiops connait la semantique exacte des parametres JSON
+        expanded_prm = run_khiops_no_replay(
+            [tool_exe_path, "-b", "-i", src_prm, "-j", src_json],
+            "JSON scenario expansion",
+        )
+        with open(expanded_prm, "r", errors="ignore") as f:
+            content = f.read()
+    else:
+        with open(src_prm, "r", errors="ignore") as f:
+            content = f.read()
+
+    content = cloudify_prm_content(content, cloud_dir, cloud_test_dir)
+
+    target_cloud_prm = os.path.join(target_test_dir, kht.TEST_CLOUD_PRM)
+    with open(target_cloud_prm, "w", errors="ignore") as f:
+        f.write(content)
+
+    if expanded_prm is not None and os.path.isfile(expanded_prm):
+        utils.remove_file(expanded_prm)
+    return True
+
+
+def cloudify_results_ref_dirs(target_test_dir, cloud_dir, cloud_test_dir):
+    """Recrit les chemins locaux en URIs cloud dans tous les fichiers de tous les results.ref*."""
+    for name in os.listdir(target_test_dir):
+        ref_dir = os.path.join(target_test_dir, name)
+        if not (os.path.isdir(ref_dir) and results.is_candidate_results_ref_dir(name)):
+            continue
+        for file_name in os.listdir(ref_dir):
+            file_path = os.path.join(ref_dir, file_name)
+            if not os.path.isfile(file_path):
+                continue
+            with open(file_path, "r", errors="ignore") as f:
+                content = f.read()
+            is_json = file_name.endswith(".khj")
+            new_content = cloudify_file_content(
+                content, cloud_dir, cloud_test_dir, is_json
+            )
+            if new_content != content:
+                os.chmod(file_path, stat.S_IWRITE | stat.S_IREAD)
+                with open(file_path, "w", errors="ignore") as f:
+                    f.write(new_content)
+
+
+def cloudify_learning_test_tree(home_dir, cloud_dir, tool_exe_path):
+    """Ajoute les scenarios cloud et reecrit les references dans une arborescence deja exportee."""
+    for tool_dir_name in kht.TOOL_DIR_NAMES.values():
+        tool_dir = os.path.join(home_dir, tool_dir_name)
+        if not os.path.isdir(tool_dir):
+            continue
+        for suite_dir_name in os.listdir(tool_dir):
+            suite_dir = os.path.join(tool_dir, suite_dir_name)
+            if not os.path.isdir(suite_dir):
+                continue
+            for test_dir_name in os.listdir(suite_dir):
+                test_dir = os.path.join(suite_dir, test_dir_name)
+                if not os.path.isdir(test_dir):
+                    continue
+                test_prm_path = os.path.join(test_dir, kht.TEST_PRM)
+                if not os.path.isfile(test_prm_path):
+                    continue
+                cloud_test_dir = (
+                    cloud_dir
+                    + "/"
+                    + tool_dir_name
+                    + "/"
+                    + suite_dir_name
+                    + "/"
+                    + test_dir_name
+                )
+                generate_cloud_prm(
+                    test_dir,
+                    test_dir,
+                    cloud_dir,
+                    cloud_test_dir,
+                    tool_exe_path=tool_exe_path,
+                )
+                cloudify_results_ref_dirs(test_dir, cloud_dir, cloud_test_dir)
+
+
+def resolve_cloudify_options(cloud_directory, home_dir):
+    """
+    Guard contre la double-cloudification d'une arborescence deja cloudifiee
+    Renvoie un couple (cloudify, normalized_cloud_directory) ou cloudify est un booleen indiquant si on doit cloudifier
+     et normalized_cloud_directory est le chemin normalise du repertoire cloudifie cible si cloudify est vrai, None sinon
+    """
+    cloudify = cloud_directory is not None
+    if cloudify:
+        normalized_cloud_directory = normalize_cloud_directory_uri(cloud_directory)
+        if is_cloudified_home_dir(home_dir):
+            utils.fatal_error(
+                "source directory "
+                + home_dir
+                + " is already a cloudified LearningTest; cannot cloudify again"
+            )
+    return cloudify, normalized_cloud_directory if cloudify else None
+
+
+# --- Integration CLI: option --cloud-directory et --binaries ---
+def argument_parser_add_cloud_directory_arguments(parser):
+    """Ajout des arguments --cloud-directory et --binaries"""
+    parser.add_argument(
+        "--cloud-directory",
+        help="cloud URI of the exported LearningTest root, triggers cloudification"
+        " (e.g., gs://bucket/LearningTest, s3://bucket/LearningTest)",
+        type=str,
+        metavar="uri",
+        action="store",
+    )
+
+    # Binaire Khiops pour l'expansion JSON lors de la cloudification
+    parser.add_argument(
+        "--binaries",
+        dest="binaries",
+        help="Khiops binary directory or alias, used with --cloud-directory"
+        " to expand test.json parameters via khiops -j",
+        type=str,
+        metavar="path",
+        action="store",
+    )
+
+
+def argument_parser_check_cloud_directory_arguments(parser, cloud_directory, binaries):
+    """Verification des arguments --cloud-directory et --binaries"""
+    if cloud_directory is not None and not check_cloud_dir(cloud_directory):
+        parser.error(
+            "argument --cloud-directory: '"
+            + cloud_directory
+            + "' must be a cloud URI starting with "
+            + ", ".join(_CLOUD_URI_PREFIXES)
+        )
+
+    # --binaries est obligatoire avec --cloud-directory (expansion JSON via khiops -j)
+    tool_exe_path = None
+    if cloud_directory is not None and binaries is None:
+        parser.error("argument --binaries is required with --cloud-directory")
+    if binaries is not None:
+        if cloud_directory is None:
+            parser.error("argument --binaries requires --cloud-directory")
+        tool_exe_path, error_message = build_tool_exe_path(
+            binaries, kht.KHIOPS, use_khiops_env=False
+        )
+        if tool_exe_path is None:
+            parser.error("argument --binaries: " + error_message)
+
+
+# --- Nettoyage sur le cloud avant de l'execution des tests (kht_test cloudification) : extraction et nettoyage du repertoire results ---
+def get_cloud_results_dir(test_dir):
+    """Retourne l'URI cloud du repertoire results cible par test-cloud.prm."""
+    cloud_prm_path = os.path.join(test_dir, kht.TEST_CLOUD_PRM)
+    if not os.path.isfile(cloud_prm_path):
+        return None
+
+    with open(cloud_prm_path, "r", errors="ignore") as cloud_prm_file:
+        content = cloud_prm_file.read()
+
+    cloud_results_dirs = []
+    separators = " \t\r\n'\""
+    for uri_prefix in ["gs://", "s3://", "https://"]:
+        start = 0
+        while True:
+            start = content.find(uri_prefix, start)
+            if start < 0:
+                break
+            end = start + len(uri_prefix)
+            while end < len(content) and content[end] not in separators:
+                end += 1
+            uri = content[start:end].rstrip(",;")
+            results_pattern = "/" + kht.RESULTS + "/"
+            results_pos = uri.find(results_pattern)
+            if results_pos >= 0:
+                cloud_results_dir = uri[: results_pos + len(results_pattern) - 1]
+                if cloud_results_dir not in cloud_results_dirs:
+                    cloud_results_dirs.append(cloud_results_dir)
+            start = end
+
+    if len(cloud_results_dirs) == 0:
+        return None
+    if len(cloud_results_dirs) > 1:
+        utils.fatal_error(
+            "multiple cloud results dirs found in "
+            + cloud_prm_path
+            + ": "
+            + utils.list_to_label(cloud_results_dirs)
+        )
+    return cloud_results_dirs[0]
+
+
+def clean_cloud_results_dir(test_dir):
+    """Nettoie le repertoire results cible sur le cloud avant l'execution du test."""
+    cloud_results_dir = get_cloud_results_dir(test_dir)
+    if cloud_results_dir is None:
+        return
+
+    if cloud_results_dir.startswith("gs://"):
+        command = ["gcloud", "storage", "rm", "--recursive", cloud_results_dir]
+    elif cloud_results_dir.startswith("s3://"):
+        command = ["aws", "s3", "rm", cloud_results_dir, "--recursive"]
+    elif cloud_results_dir.startswith("https://"):
+        command = ["azcopy", "rm", cloud_results_dir, "--recursive=true"]
+    else:
+        utils.fatal_error("unsupported cloud results dir " + cloud_results_dir)
+
+    if shutil.which(command[0]) is None:
+        utils.fatal_error(
+            "cloud cleanup command not found for "
+            + cloud_results_dir
+            + ": "
+            + command[0]
+        )
+
+    result = subprocess.run(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if result.returncode != 0:
+        utils.write_message(message="Cloud cleanup command failed:\n" + result.stderr)

--- a/test/LearningTestTool/py/_kht_constants.py
+++ b/test/LearningTestTool/py/_kht_constants.py
@@ -20,6 +20,8 @@ RESULTS_REF = "results.ref"
 """ Fichiers se trouvant d'un repertoire de test """
 TEST_PRM = "test.prm"
 TEST_JSON = "test.json"
+# Scenario genere par kht_export --cloud-directory ; prend la precedence sur TEST_PRM quand present
+TEST_CLOUD_PRM = "test-cloud.prm"
 COMPARISON_RESULTS_LOG = "comparisonResults.log"
 
 """ Fichiers se trouvant d'un repertoire de resultats """

--- a/test/LearningTestTool/py/kht_export.py
+++ b/test/LearningTestTool/py/kht_export.py
@@ -11,6 +11,8 @@ import _kht_constants as kht
 import _kht_utils as utils
 import _kht_families as test_families
 import _kht_results_management as results
+import _kht_cloud_utils as cloud_utils
+from kht_test import build_tool_exe_path
 
 """
 Export de la sous-partie d'un repertoire LearningTest pour la famille de test specifiee
@@ -474,6 +476,7 @@ def main():
 
     # Arguments optionnels standards
     utils.argument_parser_add_family_argument(parser)
+    cloud_utils.argument_parser_add_cloud_directory_arguments(parser)
 
     # Argument sur le types d'export
     parser.add_argument(
@@ -499,6 +502,16 @@ def main():
     # Verification de l'argument destination
     utils.argument_parser_check_destination_dir(parser, home_dir, args.dest)
 
+    # Verification des arguments --cloud-directory et --binaries
+    cloud_utils.argument_parser_check_cloud_directory_arguments(
+        parser, args.cloud_directory, args.binaries
+    )
+
+    # Resolution des options de cloudification
+    cloudify, cloud_directory = cloud_utils.resolve_cloudify_options(
+        args.cloud_directory, home_dir
+    )
+
     # Lancement de la commande
     export_learning_test_tree(
         home_dir,
@@ -509,6 +522,17 @@ def main():
         args.family,
         args.export_type,
     )
+
+    # Cloudification de l'arborescence exportee si necessaire
+    if cloudify:
+        target_home_dir = os.path.join(args.dest, kht.LEARNING_TEST)
+        tool_exe_path, _ = build_tool_exe_path(
+            args.binaries, kht.KHIOPS, use_khiops_env=False
+        )  # la methode a deja ete appelee dans argument_parser_check_cloud_directory_arguments,
+        # pas besoin de regarder le message d'erreur ici
+        cloud_utils.cloudify_learning_test_tree(
+            target_home_dir, cloud_directory, tool_exe_path=tool_exe_path
+        )
 
 
 if __name__ == "__main__":

--- a/test/LearningTestTool/py/kht_test.py
+++ b/test/LearningTestTool/py/kht_test.py
@@ -12,6 +12,7 @@ import time
 import argparse
 
 import _kht_constants as kht
+import _kht_cloud_utils as cloud_utils
 import _kht_utils as utils
 import _kht_families as test_families
 import _kht_results_management as results
@@ -370,6 +371,10 @@ def evaluate_tool_on_test_dir(
             )
             return
 
+        # Nettoyage des resultats sur le cloud si le repertoire de test est cloudifie
+        if cloud_utils.is_cloudified_test_dir(test_dir):
+            cloud_utils.clean_cloud_results_dir(test_dir)
+
         # Nettoyage du repertoire de resultats
         results_dir = os.path.join(test_dir, kht.RESULTS)
         if os.path.isdir(results_dir):
@@ -458,10 +463,14 @@ def evaluate_tool_on_test_dir(
         if not user_interface:
             khiops_params.append("-b")
         khiops_params.append("-i")
-        khiops_params.append(kht.TEST_PRM)
-        if os.path.isfile(kht.TEST_JSON):
-            khiops_params.append("-j")
-            khiops_params.append(kht.TEST_JSON)
+        # test-cloud.prm prend la precedence: JSON deja integre, chemins cloud deja substitues
+        if os.path.isfile(kht.TEST_CLOUD_PRM):
+            khiops_params.append(kht.TEST_CLOUD_PRM)
+        else:
+            khiops_params.append(kht.TEST_PRM)
+            if os.path.isfile(kht.TEST_JSON):
+                khiops_params.append("-j")
+                khiops_params.append(kht.TEST_JSON)
         khiops_params.append("-e")
         khiops_params.append(os.path.join(results_dir, kht.ERR_TXT))
         if output_scenario:
@@ -709,9 +718,15 @@ def evaluate_tool_on_test_dir(
     else:
         os.environ["LD_LIBRARY_PATH"] = initial_path
 
-    # Comparaison des resultats
+    # Comparaison des resultats (sauf sur le cloud ou on n'a pas acces aux resultats)
     os.chdir(suite_dir)
-    check.check_results(test_dir)
+    if tool_exe_path != kht.ALIAS_CHECK and cloud_utils.is_cloudified_test_dir(
+        test_dir
+    ):
+        print("--Comparison skipped: results are in the cloud")
+        print("")
+    else:
+        check.check_results(test_dir)
 
 
 def evaluate_tool_on_suite_dir(


### PR DESCRIPTION
This is a new fix of #944 based on the comments of the previous PR #1093 

- Add `--cloud-directory` and `--binaries` arguments to `kht_export` for cloud URI support
- Update documentation

close #944 