### PR TITLE
Macos gui

### DIFF
--- a/src/Norm/NormGUI/src/normGUI/engine/GUIUnit.java
+++ b/src/Norm/NormGUI/src/normGUI/engine/GUIUnit.java
@@ -1100,9 +1100,15 @@ import javax.swing.SwingUtilities;
         private static Stack<GUIUnit> openedGUIUnitsStack = new Stack<GUIUnit>();
 
         /**
-         * Verrou de fermeture gestion des fenetres
+         * Verrou utilise sur les plateformes non-macOS (thread non-EDT) pour attendre la fermeture de la fenetre
          */
         Object closeLock = null;
+
+        /**
+         * Boucle secondaire utilisee sur macOS (thread EDT) pour traiter les evenements AppKit tout en attendant la
+         * fermeture
+         */
+        private java.awt.SecondaryLoop secondaryLoop = null;
 
         /**
          * Initialise et ouvre l'unite Gestion de la synchronisation entre Java et C++,
@@ -1160,10 +1166,9 @@ import javax.swing.SwingUtilities;
                 // Ouverture dans le cas standard
                 addTrace("Open start");
 
-                // Creation du verrou
-                closeLock = new Object();
-
                 // Creation et ouverture de la fenetre
+                // openGUI est appele directement sur le thread appelant (hors AWT EDT sur macOS
+                // avec jniThread) pour que l'EDT reste libre lors des callbacks AppKit
                 openGUI(parentOpenedFrame);
                 addTrace("openGUI finished: frame " + frame.getTitle());
 
@@ -1171,39 +1176,55 @@ import javax.swing.SwingUtilities;
                 assert (frame != null);
                 openedGUIUnitsStack.push(this);
 
-                // Creation d'un thread de synchronisation, permettant d'attendre la fermeture
-                // de la fenetre
-                Thread closeThread = new Thread() {
-                        public void run()
-                        {
-                                synchronized (closeLock) {
-                                        addTrace("close lock thread start: " + frame.getTitle() + " " +
-                                                 frame.isVisible());
-                                        while (frame.isVisible())
-                                                try {
-                                                        closeLock.wait();
-                                                } catch (InterruptedException e) {
-                                                }
-                                        addTrace("close lock thread stop: " + frame.getTitle() + " " +
-                                                 frame.isVisible());
+                // Sur macOS avec -XstartOnFirstThread, open() est appele depuis l'EDT :
+                // on utilise une SecondaryLoop pour traiter les evenements AppKit tout en attendant la
+                // fermeture.
+                if (SwingUtilities.isEventDispatchThread()) {
+                        java.awt.EventQueue eq = java.awt.Toolkit.getDefaultToolkit().getSystemEventQueue();
+                        secondaryLoop = eq.createSecondaryLoop();
+                        addTrace("secondary loop enter");
+                        secondaryLoop.enter();
+                        addTrace("secondary loop exit");
+                        secondaryLoop = null;
+                } else {
+                        // Sur les autres plateformes, open() est appele depuis un thread non-EDT :
+                        // utiliser un thread de fermeture classique synchronise via closeLock.
+
+                        // Creation du verrou
+                        closeLock = new Object();
+
+                        // Creation d'un thread de synchronisation, permettant d'attendre la fermeture de la fenetre
+                        Thread closeThread = new Thread() {
+                                public void run()
+                                {
+                                        synchronized (closeLock) {
+                                                addTrace("close lock thread start: " + frame.getTitle() + " " +
+                                                         frame.isVisible());
+                                                while (frame.isVisible())
+                                                        try {
+                                                                closeLock.wait();
+                                                        } catch (InterruptedException e) {
+                                                        }
+                                                addTrace("close lock thread stop: " + frame.getTitle() + " " +
+                                                         frame.isVisible());
+                                        }
                                 }
+                        };
+
+                        // Lancement du thread de synchronisation de la fermeture
+                        try {
+                                closeThread.start();
+                        } catch (Exception ex) {
                         }
-                };
+                        // Attente de la fin du thread
+                        try {
+                                closeThread.join();
+                        } catch (Exception ex) {
+                        }
 
-                // Lancement du thread de synchronisation de la fermeture
-                try {
-                        closeThread.start();
-                } catch (Exception ex) {
+                        // On remet le verrou a null
+                        closeLock = null;
                 }
-
-                // Attente de la fin du thread
-                try {
-                        closeThread.join();
-                } catch (Exception ex) {
-                }
-
-                // On remet le verrou a null
-                closeLock = null;
 
                 // On depile de la liste des frames ouverte
                 GUIUnit popedGUIUnit;
@@ -1405,17 +1426,23 @@ import javax.swing.SwingUtilities;
                                 }
                                 addTrace("windowClosing after execute " + exitAction);
 
-                                // On ferme la fenetre en gerant le verrou de synchronisation
-                                synchronized (parentRoot.closeLock) {
-                                        addTrace("windowClosing notify");
-                                        // Memorisation de la position affichee
-                                        lastVisibleLocationX =
-                                          parentRoot.frame.getX() + parentRoot.frame.getWidth() / 2;
-                                        lastVisibleLocationY =
-                                          parentRoot.frame.getY() + parentRoot.frame.getHeight() / 2;
-                                        // Fermeture de la fenetre
-                                        parentRoot.frame.dispose();
-                                        parentRoot.closeLock.notify();
+                                // Memorisation de la position affichee
+                                lastVisibleLocationX = parentRoot.frame.getX() + parentRoot.frame.getWidth() / 2;
+                                lastVisibleLocationY = parentRoot.frame.getY() + parentRoot.frame.getHeight() / 2;
+                                // Fermeture de la fenetre
+                                parentRoot.frame.dispose();
+                                // Deblocage de open() : secondaryLoop sur macOS (EDT), closeLock sur les autres
+                                // plateformes
+                                if (parentRoot.secondaryLoop != null) {
+                                        // MacOS
+                                        addTrace("windowClosing secondary loop exit");
+                                        parentRoot.secondaryLoop.exit();
+                                } else {
+                                        // Linux/windows
+                                        synchronized (parentRoot.closeLock) {
+                                                addTrace("windowClosing notify");
+                                                parentRoot.closeLock.notify();
+                                        }
                                 }
                                 addTrace("closeGUI " + getLabel() + " stop");
                         }

--- a/src/Norm/base/CMakeLists.txt
+++ b/src/Norm/base/CMakeLists.txt
@@ -33,3 +33,9 @@ target_include_directories(base PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 if(NOT MSVC)
   target_link_libraries(base PUBLIC ${CMAKE_DL_LIBS})
 endif(NOT MSVC)
+
+# Added "-framework AppKit" and the required Objective-C runtime libraries to link options on macOS, needed for the
+# objc_msgSend / dispatch_async calls in UIUnit.cpp.
+if(APPLE)
+  target_link_libraries(base PUBLIC "-framework CoreFoundation" "-framework AppKit")
+endif()

--- a/src/Norm/base/MacosGUI.cpp
+++ b/src/Norm/base/MacosGUI.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023-2026 Orange. All rights reserved.
+// This software is distributed under the BSD 3-Clause-clear License, the text of which is available
+// at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
+
+#define UIDEV
+#include "MacosGUI.h"
+
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#include <dispatch/dispatch.h>
+#include <objc/runtime.h>
+#include <objc/message.h>
+#include <pthread.h>
+#include <thread>
+#include <unistd.h>
+#endif
+
+void MacosOpenGUIUnit(JNIEnv* env, jobject guiObject, jmethodID mid)
+{
+#ifdef __APPLE__
+	// Sur macOS, le thread principal doit traiter les evenements AppKit via
+	// [NSApp run]. On cree jniThread pour appeler Java open() pendant que
+	// le thread principal tourne dans la boucle AppKit.
+	// openGUI est appele directement depuis jniThread (hors AWT EDT) pour
+	// que l'EDT reste libre lors des callbacks AppKit natifs.
+	if (pthread_main_np())
+	{
+		// Installer UITaskProgression maintenant que AppKit va demarrer
+		if (TaskProgression::GetManager() == NULL and not TaskProgression::IsStarted())
+			TaskProgression::SetManager(UITaskProgression::GetManager());
+
+		JavaVM* jvm = NULL;
+		env->GetJavaVM(&jvm);
+		assert(jvm != NULL);
+		jobject globalGuiObject = env->NewGlobalRef(guiObject);
+
+		id nsApp = ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSApplication"),
+							   sel_registerName("sharedApplication"));
+		if (nsApp)
+		{
+			// NSApplicationActivationPolicyRegular = 0: icone Dock, focus normal
+			((void (*)(id, SEL, long))objc_msgSend)(nsApp, sel_registerName("setActivationPolicy:"), 0L);
+		}
+
+		std::thread jniThread(
+		    [jvm, globalGuiObject, mid, nsApp]()
+		    {
+			    JNIEnv* threadEnv = NULL;
+			    jvm->AttachCurrentThread((void**)&threadEnv, NULL);
+			    threadEnv->CallVoidMethod(globalGuiObject, mid);
+			    threadEnv->DeleteGlobalRef(globalGuiObject);
+			    jvm->DetachCurrentThread();
+			    if (nsApp)
+				    dispatch_async(dispatch_get_main_queue(), ^{
+				      ((void (*)(id, SEL, id))objc_msgSend)(nsApp, sel_registerName("stop:"), (id)nil);
+				    });
+		    });
+
+		if (nsApp)
+		{
+			// Completer la sequence de lancement pour que l'activation soit reconnue par macOS
+			((void (*)(id, SEL))objc_msgSend)(nsApp, sel_registerName("finishLaunching"));
+			((void (*)(id, SEL, BOOL))objc_msgSend)(nsApp, sel_registerName("activateIgnoringOtherApps:"),
+								(BOOL)1);
+			// L'init AWT reinitialise l'activation pendant la creation des peers natifs; re-activer apres
+			dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 300 * NSEC_PER_MSEC), dispatch_get_main_queue(),
+				       ^{
+					 ((void (*)(id, SEL, BOOL))objc_msgSend)(
+					     nsApp, sel_registerName("activateIgnoringOtherApps:"), (BOOL)1);
+				       });
+			((void (*)(id, SEL))objc_msgSend)(nsApp, sel_registerName("run"));
+		}
+		jniThread.join();
+	}
+	else
+	{
+		// Thread worker deja attache a la JVM: appel direct
+		env->CallVoidMethod(guiObject, mid);
+	}
+#endif
+}
+
+void MacosSetJavaStartedOnFirstThread()
+{
+#ifdef __APPLE__
+	char sEnvVarName[64];
+	snprintf(sEnvVarName, sizeof(sEnvVarName), "JAVA_STARTED_ON_FIRST_THREAD_%d", (int)getpid());
+	setenv(sEnvVarName, "1", 1);
+#endif
+}

--- a/src/Norm/base/MacosGUI.h
+++ b/src/Norm/base/MacosGUI.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2023-2026 Orange. All rights reserved.
+// This software is distributed under the BSD 3-Clause-clear License, the text of which is available
+// at https://spdx.org/licenses/BSD-3-Clause-Clear.html or see the "LICENSE" file for more details.
+
+#pragma once
+
+#include "UserInterface.h"
+
+// Appel de la methode Java open() en gerant la boucle AppKit sur le thread principal macOS
+void MacosOpenGUIUnit(JNIEnv* env, jobject guiObject, jmethodID mid);
+
+// Positionne JAVA_STARTED_ON_FIRST_THREAD_<pid> pour que l'AWT utilise le thread courant comme EDT
+void MacosSetJavaStartedOnFirstThread();

--- a/src/Norm/base/TaskProgression.cpp
+++ b/src/Norm/base/TaskProgression.cpp
@@ -50,17 +50,23 @@ void TaskProgression::Start()
 		tStartRequested = clock();
 		bIsManagerStarted = false;
 
-		// Initialisation du manager
-		if (currentManager != NULL)
+		// En mode silencieux, il est inutile d'initaliser les managers
+		// De plus, dans le cas de la GUI Mac, cela evite de creer des composants AWT
+		// avant que la boucle d'evenements AppKit soit lancee
+		if (not bSilentMode)
 		{
-			// Parametrage initial du manager courant
-			currentManager->SetTitle(sTitle);
-			currentManager->SetLevelNumber(nDisplayedLevelNumber);
-		}
-		if (currentFileManager != NULL)
-		{
-			currentFileManager->SetTitle(sTitle);
-			currentFileManager->SetLevelNumber(nDisplayedLevelNumber);
+			// Initialisation du manager
+			if (currentManager != NULL)
+			{
+				// Parametrage initial du manager courant
+				currentManager->SetTitle(sTitle);
+				currentManager->SetLevelNumber(nDisplayedLevelNumber);
+			}
+			if (currentFileManager != NULL)
+			{
+				currentFileManager->SetTitle(sTitle);
+				currentFileManager->SetLevelNumber(nDisplayedLevelNumber);
+			}
 		}
 	}
 	bIsStarted = true;

--- a/src/Norm/base/UIObject.cpp
+++ b/src/Norm/base/UIObject.cpp
@@ -4,6 +4,7 @@
 
 #define UIDEV
 #include "UserInterface.h"
+#include "MacosGUI.h"
 
 const ALString UIObject::GetClassLabel() const
 {
@@ -1140,6 +1141,9 @@ JNIEnv* UIObject::GetJNIEnv()
 		vm_iargs.nOptions = nOptionNumber;
 		vm_iargs.ignoreUnrecognized = JNI_FALSE;
 
+		// macOS: Positionne JAVA_STARTED_ON_FIRST_THREAD_<pid> pour que l'AWT utilise le thread courant comme EDT
+		MacosSetJavaStartedOnFirstThread();
+
 		// Lancement de la JVM
 		res = -1;
 		res = ptrCreateJavaVM(&jvm, (void**)&env, &vm_iargs);
@@ -1180,13 +1184,7 @@ JNIEnv* UIObject::GraphicGetJNIEnv()
 	static boolean bGraphicIsLoaded = false;
 
 	cls = 0;
-
-#ifdef __APPLE__
-	Global::AddError("Java", "GUI", "Java GUI is not available on MacOS");
-	env = NULL;
-#else
 	env = GetJNIEnv();
-#endif
 
 	if (env != NULL and not bGraphicIsLoaded)
 	{
@@ -2215,9 +2213,12 @@ void UIObject::InitializeMessageManagers()
 		    Error::GetDisplayErrorFunction() == Error::GetDefaultDisplayErrorFunction())
 			Error::SetDisplayErrorFunction(UIObjectDisplayErrorFunction);
 
+#ifndef __APPLE__
 		// Parametrage du gestionnaire de suivi de progression
+		// Installe UITaskProgression; sur macOS, l'installation est differee apres le lancement de la boucle AppKit
 		if (TaskProgression::GetManager() == NULL and not TaskProgression::IsStarted())
 			TaskProgression::SetManager(UITaskProgression::GetManager());
+#endif
 	}
 	// Parametrage en mode textuel
 	else

--- a/src/Norm/base/UIUnit.cpp
+++ b/src/Norm/base/UIUnit.cpp
@@ -4,6 +4,7 @@
 
 #define UIDEV
 #include "UserInterface.h"
+#include "MacosGUI.h"
 
 boolean UIUnit::Check() const
 {
@@ -385,7 +386,6 @@ void UIUnit::Open()
 	// Ouverture de la fenetre, selon le mode (inutile si action Exit rejouee)
 	if (not bActionExit)
 	{
-		// Mode graphique
 		if (GetUIMode() == Graphic)
 		{
 			JNIEnv* env;
@@ -404,10 +404,13 @@ void UIUnit::Open()
 			// Recherche de la methode open
 			mid = GraphicGetMethodID(cls, "GUIUnit", "open", "()V");
 
+#ifdef __APPLE__
 			// Appel de la methode JAVA open, qui sera executee dans un nouveau thread
 			// et provoquera la suite de l'execution de la methode C++ courante
+			MacosOpenGUIUnit(env, guiObject, mid);
+#else
 			env->CallVoidMethod(guiObject, mid);
-
+#endif
 			// On libere l'objet fiche cote Java, et sa classe
 			env->DeleteLocalRef(guiObject);
 			env->DeleteLocalRef(cls);


### PR DESCRIPTION
## macOS GUI fixes

Enables the Khiops GUI on macOS when the binary embeds the JVM via JNI. Previously, all binaries (basetest, MODL, …) would either show nothing or freeze on startup.

### Root causes and fixes

#### 1. `src/Norm/base/UIUnit.cpp` — AppKit event loop

**Problem:** AppKit requires its event loop on the main thread. Calling `env->CallVoidMethod(guiObject, mid)` from the main thread blocks it in JNI, so AppKit events are never processed → no window.

**Fix:** For the master window (`pthread_main_np()`), spawn a `jniThread` to call Java `open()` and run `[NSApp run]` on the main thread to pump AppKit events. When the window closes, jniThread dispatches `[NSApp stop:]` via GCD and joins. Sub-windows (opened from Java worker threads) call `open()` directly as on Linux/Windows.

**Key detail:** `openGUI()` is called **directly from jniThread** (not via `SwingUtilities.invokeAndWait`). This keeps the AWT EDT free while AppKit creates native peers (`JTabbedPane`, etc.). If `openGUI` ran on the AWT EDT, AppKit's `dispatch_sync(main_queue)` callbacks back to the EDT would find it blocked → deadlock (the MODL-specific freeze for complex windows with tabs).

#### 2. `src/Norm/base/UIObject.cpp` — `UITaskProgression` installation timing

**Problem:** `ParseMainParameters()` → `InitializeMessageManagers()` installed `UITaskProgression` as the task-progression manager immediately after creating the JVM. When domain code later called `SetObject()` → `FillAttributeValues()` → `TaskProgression::Start()`, `UITaskProgression` tried to create a `GUITaskProgression` JFrame via JNI — before `[NSApp run]` was running — so AWT initialization blocked → freeze (`KWLearningProblemView.cpp:426`).

**Fix (two parts):**
- On macOS, `InitializeMessageManagers()` does **not** install `UITaskProgression` at startup (`#ifndef __APPLE__` guard).
- `UITaskProgression` is installed inside `UIUnit::Open()`, right before the jniThread + `[NSApp run]` pair starts. At that point AppKit is about to run, so all subsequent JNI calls from task progression are safe.

Also sets the `JAVA_STARTED_ON_FIRST_THREAD_<PID>` env-var before JVM creation (recognized by OpenJDK ≤ 21 `CToolkit` as equivalent to `-XstartOnFirstThread`).

#### 3. `src/Norm/base/TaskProgression.cpp` — silent-mode guard

**Problem:** `TaskProgression::Start()` unconditionally called `currentManager->SetTitle()` / `SetLevelNumber()` even in silent mode. `FillAttributeValues()` (help-list population) always uses silent mode but still triggered `UITaskProgression` JNI calls before AppKit was running.

**Fix:** Wrap the manager initialization calls with `if (not bSilentMode)`. In silent mode those calls are meaningless for display anyway.

#### 4. `src/Norm/NormGUI/src/normGUI/engine/GUIUnit.java` — `SecondaryLoop` + close mechanism

**Problem:** The original `open()` blocked the calling thread via a `closeThread` + `closeLock.wait()` loop. This worked on Linux/Windows where the main thread is never the AWT EDT, but not on macOS where it is (with `-XstartOnFirstThread`).

**Fixes:**
- Added `SecondaryLoop` support: when `open()` is called from the AWT EDT, it uses `EventQueue.createSecondaryLoop()` so the EDT continues processing events while the window is open.
- `closeGUI()` now exits via `secondaryLoop.exit()` or `closeLock.notify()` depending on the path used.
- Removed `SwingUtilities.invokeAndWait(() -> openGUI(...))` — `openGUI()` is now called directly on the calling thread to avoid the MODL deadlock described above.

#### 5. `src/Norm/base/CMakeLists.txt` — macOS link frameworks

Added `AppKit` framework and required Objective-C runtime libraries to the `base` library's link options on macOS, needed for the `objc_msgSend` / `dispatch_async` calls added to `UIUnit.cpp`.

### Files changed

| File | Change |
|---|---|
| `src/Norm/base/UIUnit.cpp` | jniThread + `[NSApp run]` for master window; direct `openGUI` call from jniThread; `UITaskProgression` installed before AppKit starts |
| `src/Norm/base/UIObject.cpp` | Don't install `UITaskProgression` at startup on macOS; set `JAVA_STARTED_ON_FIRST_THREAD_<PID>` env-var |
| `src/Norm/base/TaskProgression.cpp` | Skip manager `SetTitle`/`SetLevelNumber` calls in silent mode |
| `src/Norm/NormGUI/.../GUIUnit.java` | `SecondaryLoop` path for EDT callers; direct `openGUI` call; dual close mechanism |
| `src/Norm/base/CMakeLists.txt` | Link AppKit + ObjC frameworks on macOS |