### PR TITLE
Improve initialisation time in SNB training task

### DIFF
--- a/src/Learning/KWDataPreparation/KWClassStats.cpp
+++ b/src/Learning/KWDataPreparation/KWClassStats.cpp
@@ -26,6 +26,7 @@ KWClassStats::KWClassStats()
 	dataTableSliceSet = NULL;
 	svSymbolTargetValues = NULL;
 	cvContinuousTargetValues = NULL;
+	CleanWorkingData();
 }
 
 KWClassStats::~KWClassStats()
@@ -435,14 +436,14 @@ boolean KWClassStats::ComputeStats()
 	return bIsStatsComputed;
 }
 
-ObjectArray* KWClassStats::GetAllPreparedStats()
+const ObjectArray* KWClassStats::GetAllPreparedStats() const
 {
 	require(IsStatsComputed());
 
 	return &oaAllPreparedStats;
 }
 
-ObjectArray* KWClassStats::GetAttributeStats()
+const ObjectArray* KWClassStats::GetAttributeStats() const
 {
 	require(IsStatsComputed());
 
@@ -456,21 +457,21 @@ KWAttributeStats* KWClassStats::LookupAttributeStats(const ALString& sAttributeN
 	return cast(KWAttributeStats*, odAttributeStats.Lookup(sAttributeName));
 }
 
-ObjectArray* KWClassStats::GetAttributePairStats()
+const ObjectArray* KWClassStats::GetAttributePairStats() const
 {
 	require(IsStatsComputed());
 
 	return &oaAttributePairStats;
 }
 
-ObjectArray* KWClassStats::GetTextAttributeStats()
+const ObjectArray* KWClassStats::GetTextAttributeStats() const
 {
 	require(IsStatsComputed());
 
 	return &oaTextAttributeStats;
 }
 
-ObjectArray* KWClassStats::GetTreeAttributeStats()
+const ObjectArray* KWClassStats::GetTreeAttributeStats() const
 {
 	require(IsStatsComputed());
 
@@ -492,26 +493,28 @@ int KWClassStats::GetConstructedAttributeNumber() const
 {
 	KWAttributeStats* attributeStats;
 	KWAttribute* attribute;
-	int nConstructedAttributeNumber;
 	int nAttribute;
 
 	require(IsStatsComputed());
 
-	// Comptage des attributs construit
-	nConstructedAttributeNumber = 0;
-	for (nAttribute = 0; nAttribute < oaAttributeStats.GetSize(); nAttribute++)
+	// Comptage des attributs construits si necessaire
+	if (nConstructedAttributeNumber == -1)
 	{
-		attributeStats = cast(KWAttributeStats*, oaAttributeStats.GetAt(nAttribute));
-		assert(attributeStats->GetAttributeNumber() == 1);
-		assert(KWType::IsSimple(attributeStats->GetAttributeType()));
-
-		// Attribut construit s'il possede une regle de derivation avec cout non nul
-		attribute = GetClass()->LookupAttribute(attributeStats->GetAttributeName());
-		if (attribute != NULL and attribute->GetAnyDerivationRule() != NULL)
+		nConstructedAttributeNumber = 0;
+		for (nAttribute = 0; nAttribute < oaAttributeStats.GetSize(); nAttribute++)
 		{
-			// Tous les attributs construits (regle utilisateur ou construction automatique)
-			// sont pris en compte: plus facile a interpreter pour l'utilisateur final
-			nConstructedAttributeNumber++;
+			attributeStats = cast(KWAttributeStats*, oaAttributeStats.GetAt(nAttribute));
+			assert(attributeStats->GetAttributeNumber() == 1);
+			assert(KWType::IsSimple(attributeStats->GetAttributeType()));
+
+			// Attribut construit s'il possede une regle de derivation avec cout non nul
+			attribute = GetClass()->LookupAttribute(attributeStats->GetAttributeName());
+			if (attribute != NULL and attribute->GetAnyDerivationRule() != NULL)
+			{
+				// Tous les attributs construits (regle utilisateur ou construction automatique)
+				// sont pris en compte: plus facile a interpreter pour l'utilisateur final
+				nConstructedAttributeNumber++;
+			}
 		}
 	}
 	return nConstructedAttributeNumber;
@@ -519,40 +522,55 @@ int KWClassStats::GetConstructedAttributeNumber() const
 
 int KWClassStats::GetTotalInformativeAttributeNumber() const
 {
-	int nInformativeAttributeNumber;
-
 	require(IsStatsComputed());
 
-	// Comptage des attributs informatifs
-	nInformativeAttributeNumber = ComputeInformativeDataPreparationStats(&oaAllPreparedStats);
-	assert(nInformativeAttributeNumber == GetInformativeAttributeNumber() + GetInformativeTextAttributeNumber() +
-						  GetInformativeTreeAttributeNumber() +
-						  GetInformativeAttributePairNumber());
-	return nInformativeAttributeNumber;
+	// Comptage du nombre total d'attributs informatifs si necessaire
+	if (nTotalInformativeAttributeNumber == -1)
+		nTotalInformativeAttributeNumber = ComputeInformativeDataPreparationStats(&oaAllPreparedStats);
+	assert(nTotalInformativeAttributeNumber ==
+	       GetInformativeAttributeNumber() + GetInformativeTextAttributeNumber() +
+		   GetInformativeTreeAttributeNumber() + GetInformativeAttributePairNumber());
+	return nTotalInformativeAttributeNumber;
 }
 
 int KWClassStats::GetInformativeAttributeNumber() const
 {
 	require(IsStatsComputed());
-	return ComputeInformativeDataPreparationStats(&oaAttributeStats);
+
+	// Comptage des attributs informatifs si necessaire
+	if (nInformativeAttributeNumber == -1)
+		nInformativeAttributeNumber = ComputeInformativeDataPreparationStats(&oaAttributeStats);
+	return nInformativeAttributeNumber;
 }
 
 int KWClassStats::GetInformativeTextAttributeNumber() const
 {
 	require(IsStatsComputed());
-	return ComputeInformativeDataPreparationStats(&oaTextAttributeStats);
+
+	// Comptage des attributs informatifs de type texte si necessaire
+	if (nInformativeTextAttributeNumber == -1)
+		nInformativeTextAttributeNumber = ComputeInformativeDataPreparationStats(&oaTextAttributeStats);
+	return nInformativeTextAttributeNumber;
 }
 
 int KWClassStats::GetInformativeTreeAttributeNumber() const
 {
 	require(IsStatsComputed());
-	return ComputeInformativeDataPreparationStats(&oaTreeAttributeStats);
+
+	// Comptage des attributs informatifs de type arbre si necessaire
+	if (nInformativeTreeAttributeNumber == -1)
+		nInformativeTreeAttributeNumber = ComputeInformativeDataPreparationStats(&oaTreeAttributeStats);
+	return nInformativeTreeAttributeNumber;
 }
 
 int KWClassStats::GetInformativeAttributePairNumber() const
 {
 	require(IsStatsComputed());
-	return ComputeInformativeDataPreparationStats(&oaAttributePairStats);
+
+	// Comptage des attributs informatifs de type paire si necessaire
+	if (nInformativeAttributePairNumber == -1)
+		nInformativeAttributePairNumber = ComputeInformativeDataPreparationStats(&oaAttributePairStats);
+	return nInformativeAttributePairNumber;
 }
 
 int KWClassStats::GetUsedAttributeNumberForType(int nType) const
@@ -1503,6 +1521,14 @@ void KWClassStats::CleanWorkingData()
 	nkdRecursivelySelectedDataPreparationStats.RemoveAll();
 	timerTotal.Reset();
 	bIsStatsComputed = false;
+
+	// Reinitialisation des statistiques sur la preparation a -1, pour forcer leur recalcul
+	nConstructedAttributeNumber = -1;
+	nTotalInformativeAttributeNumber = -1;
+	nInformativeAttributeNumber = -1;
+	nInformativeTextAttributeNumber = -1;
+	nInformativeTreeAttributeNumber = -1;
+	nInformativeAttributePairNumber = -1;
 }
 
 KWAttributeStats* KWClassStats::TreeAttributeStats() const

--- a/src/Learning/KWDataPreparation/KWClassStats.h
+++ b/src/Learning/KWDataPreparation/KWClassStats.h
@@ -94,7 +94,7 @@ public:
 	// Acces a toutes les statistiques de preparation disponibles (univariee initiaux, multi-table ou texte, arbres,
 	// bivariees) Accessible uniquement si statistiques calculees Le tableau contient des objets
 	// KWDataPreparationStats Memoire: le tableau retourne et son contenu appartiennent a l'appele
-	ObjectArray* GetAllPreparedStats();
+	const ObjectArray* GetAllPreparedStats() const;
 
 	// Acces aux statistiques univariees par attributs
 	// Concerne les attributs de type initiaux ou multi-table uniquement
@@ -102,7 +102,7 @@ public:
 	// Accessible uniquement si statistiques calculees
 	// Le tableau contient des objets KWAttributeStats
 	// Memoire: le tableau retourne et son contenu appartiennent a l'appele
-	ObjectArray* GetAttributeStats();
+	const ObjectArray* GetAttributeStats() const;
 
 	// Acces par nom aux attributs de type initiaux ou multi-tables uniquement (acces rapide par dictionnaire)
 	// Renvoie NULL si non trouve
@@ -111,17 +111,17 @@ public:
 	// Acces aux statistiques bivariees par paire d'attributs
 	// Dans chaque paire, les attributs sont ordonnes par ordre alphabetique
 	// Le tableau contient des objets KWAttributePairStats
-	ObjectArray* GetAttributePairStats();
+	const ObjectArray* GetAttributePairStats() const;
 
 	// Acces aux statistiques univaries par attribut de type texte
 	// Ces attributs crees n'apparaissent pas dans le rapport de preparation
 	// Le tableau contient des objets KWAttributeStats
-	ObjectArray* GetTextAttributeStats();
+	const ObjectArray* GetTextAttributeStats() const;
 
 	// Acces aux statistiques univaries par attribut de type arbre
 	// Ces attributs crees n'apparaissent pas dans le rapport de preparation
 	// Le tableau contient des objets KWAttributeStats
-	ObjectArray* GetTreeAttributeStats();
+	const ObjectArray* GetTreeAttributeStats() const;
 
 	// Nombre d'attributs evalues, natifs (y compris dans les blocs natifs) et construits
 	int GetEvaluatedAttributeNumber() const;
@@ -385,6 +385,18 @@ protected:
 
 	// Gestion des stats des attributs de type arbre
 	ObjectArray oaTreeAttributeStats;
+
+	// Statistiques sur les stats des attributs prepares
+	// Ces statistiques, initialisees a -1, sont calculeees a la volee
+	// et bufferisees par les methodes correspondantes
+	// Les variables de statistique sont en mutable pour etre appelles par
+	// les methodes correspondantes qui sont const
+	mutable int nConstructedAttributeNumber;
+	mutable int nTotalInformativeAttributeNumber;
+	mutable int nInformativeAttributeNumber;
+	mutable int nInformativeTextAttributeNumber;
+	mutable int nInformativeTreeAttributeNumber;
+	mutable int nInformativeAttributePairNumber;
 
 	// Tache de construction des attributs de type arbre
 	KDDataPreparationAttributeCreationTask* attributeTreeConstructionTask;

--- a/src/Learning/KWDataPreparation/KWDataPreparationBivariateTask.h
+++ b/src/Learning/KWDataPreparation/KWDataPreparationBivariateTask.h
@@ -179,7 +179,7 @@ protected:
 	KWClassStats* masterClassStats;
 
 	// Ensemble de toutes preparations univariee en entree de la tache
-	ObjectArray* oaMasterInputAttributeStats;
+	const ObjectArray* oaMasterInputAttributeStats;
 
 	// Ensemble des resultats de preparations bivariees pour toutes les paires d'attribut analysees
 	// Ces resultats seront rendu directement a l'appelant de la tache

--- a/src/Learning/KWTest/KWHierarchicalMultinomialStudy.cpp
+++ b/src/Learning/KWTest/KWHierarchicalMultinomialStudy.cpp
@@ -244,23 +244,24 @@ void KWHierarchicalMultinomialStudy::StudyDatasetBivariate(const ALString& sClas
 			if (nPair > nPairNumber)
 				break;
 
-			// Messafe d'avancement
+			// Message d'avancement
 			Global::AddSimpleMessage(sTmp + "Pair " + IntToString(nPair) + ": " + attribute1->GetName() +
 						 " x " + attribute2->GetName());
 
 			// Parametrage des stats sur la paire d'attributs, dans le cas standard
+			// On insere la paire dans le classStats pour beneficier du rapport
 			attributePairStatsS = new KWAttributePairStatsStudy;
 			attributePairStatsS->SetLearningSpec(&learningSpec);
 			attributePairStatsS->SetAttributeName1(attribute1->GetName());
 			attributePairStatsS->SetAttributeName2(attribute2->GetName());
-			classStatsS.GetAttributePairStats()->Add(attributePairStatsS);
+			cast(ObjectArray*, classStatsS.GetAttributePairStats())->Add(attributePairStatsS);
 
 			// Parametrage des stats sur la paire d'attributs, dans le cas hierarchique
 			attributePairStatsH = new KWAttributePairStatsStudy;
 			attributePairStatsH->SetLearningSpec(&learningSpec);
 			attributePairStatsH->SetAttributeName1(attribute1->GetName());
 			attributePairStatsH->SetAttributeName2(attribute2->GetName());
-			classStatsH.GetAttributePairStats()->Add(attributePairStatsH);
+			cast(ObjectArray*, classStatsH.GetAttributePairStats())->Add(attributePairStatsH);
 
 			// Chargement des tuples
 			tupleTableLoader.LoadBivariate(attributePairStatsS->GetAttributeName1(),

--- a/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.cpp
+++ b/src/Learning/SNBPredictor/SNBDataTableBinarySliceSet.cpp
@@ -818,7 +818,7 @@ longint SNBDataTableBinarySliceSetSchema::GetUsedMemory() const
 longint SNBDataTableBinarySliceSetSchema::ComputeNecessaryMemory(KWClassStats* classStats)
 {
 	longint lSchemaMemory;
-	ObjectArray* oaAllPreparedStats;
+	const ObjectArray* oaAllPreparedStats;
 	int nAttribute;
 	KWDataPreparationStats* dataPreparationStats;
 	longint lTargetValueNumber;

--- a/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.cpp
+++ b/src/Learning/SNBPredictor/SNBPredictorSelectiveNaiveBayesTrainingTask.cpp
@@ -639,7 +639,7 @@ longint SNBPredictorSelectiveNaiveBayesTrainingTask::ComputeOverallAttributeStat
 {
 	longint lOverallDataPreparatrionStatsMemory;
 	ObjectDictionary dummyDictionary;
-	ObjectArray* oaAllPreparedStats;
+	const ObjectArray* oaAllPreparedStats;
 	int nAttribute;
 	KWDataPreparationStats* dataPreparationStats;
 
@@ -660,7 +660,7 @@ longint SNBPredictorSelectiveNaiveBayesTrainingTask::ComputeOverallAttributeStat
 longint SNBPredictorSelectiveNaiveBayesTrainingTask::ComputeDataPreparationClassNecessaryMemory()
 {
 	int nAttribute;
-	ObjectArray* oaAllPreparedStats;
+	const ObjectArray* oaAllPreparedStats;
 	KWDataPreparationStats* attributeStats;
 	longint lDataPreparationClassMemory;
 


### PR DESCRIPTION
Contexte :
- Profiling d'une tache de classification supervisee sur le corpus de texte 20newsgroups,
  utilisant 100 000 n-grams, avec 10 coeurs CPU et 20 GB de RAM.
- L'analyse dure environ 13 minutes au total (~800 secondes), avec tous les coeurs actifs
  simultanement pendant une grande partie du temps.
- Cependant, il y a une période d'environ 1/3 du temps (260s) ou un seul processeur est actif, ce qui semble anormal.

Identification du probleme
- activation du profiling (cf. test\MemoryStatsVisualizer et kht_env qui rapelle les variable d'environnement KhiopsMemStats...)
  - on identifie que tout le temps perdu se trouve dans deux methodes de la tache SNB
    - ComputeResourceRequirements : 150 s
    - MasterInitialize : 110 s (les esclaves, bien que lances, sont en attente du maitre)
- ajout de trace dans les deux methode concernees de la classe SNBPredictorSelectiveNaiveBayesTrainingTask
   - trace du type `AddSimpleMessage(sTmp + "ComputeResourceRequirements\t" + "ComputeMaxSlaveProcessNumber\t" + DoubleToString(timer.GetElapsedTime()));`
   - appele en debut, fin de methode, et apres chaque appel d'une sous-methode
   - ajout ensuite de trace dans les sous-methodes anormalement longues, ou a titre de verification
- identification de la methode racine du probleme
  - SNBPredictorSelectiveNaiveBayes::ComputeTrainingSparseAttributeNumber
    - boucle sur les attributs avec comparaison au resultat de ComputeTrainingAttributeNumber,
      qui elle meme appelle GetClassStats()->GetTotalInformativeAttributeNumber() qui effectue une boucle
      sur les attributs
    - cette double boucle sur les attributs est ici critique en temps dans le cas de 100000 attributs, dont 70000 informatifs

Correction dans KWClasstats
- les methodes de stats sur la preparation (nombre d'attributs informatifs par type de preparation)
  ont desormais leur calcul bufferise via des attributs mutables, ce qui permet de les appeler meme dans une boucle
  ```
  	// Statistiques sur les stats des attributs prepares
  	// Ces statistiques, initialisees a -1, sont calculeees a la volee
  	// et bufferisees par les methodes correspondantes
  	// Les variables correspondantes sont en mutable pour etre appellees par
  	// les methodes correspondantes qui sont const
  ```
- passage en const des tableaux de preparation renvoyes par la classe, pour s'assurer qu'ils ne sont pas modifies par les appelants

Verification:
- en relancant le test dans les memes conditions, le temps dans les deux methodes problematiques
  passe de 260 s a environ 5 s
- il reste essentiellement la construction des dictionnaires de recodage, de tres grande taille,
  leur sauvegarde sur disque et leur compiation