### PR TITLE
1109 use   no index with pip install   find links

### DIFF
--- a/.github/workflows/pack-pip.yml
+++ b/.github/workflows/pack-pip.yml
@@ -69,6 +69,8 @@ jobs:
           else
             source "$KHIOPS_INSTALL_DIR/bin/activate"
           fi
+          # --only-deps requires pip>=26.2
+          python -m pip install --upgrade "pip>=26.2"
           # Install the wheel itself only from the local wheelhouse, then resolve its
           # runtime dependencies (e.g. openmpi) from PyPI
           python -m pip install --find-links=wheelhouse --no-index --no-deps khiops-core
@@ -219,6 +221,8 @@ jobs:
             source "$KHIOPS_INSTALL_DIR/bin/activate"
             echo "BIN_DIR=$KHIOPS_INSTALL_DIR/bin" >> "$GITHUB_OUTPUT"
           fi
+          # --only-deps requires pip>=26.2
+          $PYTHON -m pip install --upgrade "pip>=26.2"
           # Install the wheels themselves only from the local wheelhouse, then resolve their
           # runtime dependencies (e.g. openmpi) from PyPI
           $PYTHON -m pip install --find-links=wheelhouse --no-index --no-deps khiops-core khiops-kni khiops-knitransfer
@@ -266,6 +270,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install khiops-kni wheel
         run: |
+          # --only-deps requires pip>=26.2
+          python -m pip install --upgrade "pip>=26.2"
           # Install the wheel itself only from the local wheelhouse, then resolve its
           # runtime dependencies from PyPI
           python -m pip install --find-links=wheelhouse --no-index --no-deps khiops-kni

--- a/.github/workflows/pack-pip.yml
+++ b/.github/workflows/pack-pip.yml
@@ -201,7 +201,7 @@ jobs:
               apt-get install -y python3 > /dev/null
             else
               yum check-update || true
-              yum install -y python3.11
+              yum install -y python3.14
             fi
           fi
           echo "PYTHON=python3" >> "$GITHUB_ENV"

--- a/.github/workflows/pack-pip.yml
+++ b/.github/workflows/pack-pip.yml
@@ -72,7 +72,7 @@ jobs:
           # Install the wheel itself only from the local wheelhouse, then resolve its
           # runtime dependencies (e.g. openmpi) from PyPI
           python -m pip install --find-links=wheelhouse --no-index --no-deps khiops-core
-          python -m pip install --find-links=wheelhouse khiops-core
+          python -m pip install --only-deps khiops-core
           pip show -f khiops-core
       - name: Export BIN_DIR
         id: export_bin_dir
@@ -222,7 +222,7 @@ jobs:
           # Install the wheels themselves only from the local wheelhouse, then resolve their
           # runtime dependencies (e.g. openmpi) from PyPI
           $PYTHON -m pip install --find-links=wheelhouse --no-index --no-deps khiops-core khiops-kni khiops-knitransfer
-          $PYTHON -m pip install --find-links=wheelhouse khiops-core khiops-kni khiops-knitransfer
+          $PYTHON -m pip install --only-deps khiops-core khiops-kni khiops-knitransfer
           $PYTHON -m pip show -f khiops-core
           $PYTHON -m pip show -f khiops-kni
       - name: Run standard tests on the Core and KNI packages
@@ -269,7 +269,7 @@ jobs:
           # Install the wheel itself only from the local wheelhouse, then resolve its
           # runtime dependencies from PyPI
           python -m pip install --find-links=wheelhouse --no-index --no-deps khiops-kni
-          python -m pip install --find-links=wheelhouse khiops-kni
+          python -m pip install --only-deps khiops-kni
           python -m pip show -f khiops-kni
       - name: Run python mono-table example
         shell: bash

--- a/.github/workflows/pack-pip.yml
+++ b/.github/workflows/pack-pip.yml
@@ -69,6 +69,9 @@ jobs:
           else
             source "$KHIOPS_INSTALL_DIR/bin/activate"
           fi
+          # Install the wheel itself only from the local wheelhouse, then resolve its
+          # runtime dependencies (e.g. openmpi) from PyPI
+          python -m pip install --find-links=wheelhouse --no-index --no-deps khiops-core
           python -m pip install --find-links=wheelhouse khiops-core
           pip show -f khiops-core
       - name: Export BIN_DIR
@@ -216,17 +219,10 @@ jobs:
             source "$KHIOPS_INSTALL_DIR/bin/activate"
             echo "BIN_DIR=$KHIOPS_INSTALL_DIR/bin" >> "$GITHUB_OUTPUT"
           fi
-          # Pip install the wheels from the wheelhouse directory, using the exact versions of the built wheels
-          # If we don't specify the exact versions, pip may install a different version if it is already present
-          # in the pypi repository, which would not be the version we just built.
-          CORE_VERSION=$(ls wheelhouse/khiops_core-*.whl | head -1 | xargs basename | cut -d- -f2)
-          KNI_VERSION=$(ls wheelhouse/khiops_kni-*.whl | head -1 | xargs basename | cut -d- -f2)
-          KNITRANSFER_VERSION=$(ls wheelhouse/khiops_knitransfer-*.whl | head -1 | xargs basename | cut -d- -f2)
-          $PYTHON -m pip install \
-            --find-links=wheelhouse \
-            "khiops-core==$CORE_VERSION" \
-            "khiops-kni==$KNI_VERSION" \
-            "khiops-knitransfer==$KNITRANSFER_VERSION"
+          # Install the wheels themselves only from the local wheelhouse, then resolve their
+          # runtime dependencies (e.g. openmpi) from PyPI
+          $PYTHON -m pip install --find-links=wheelhouse --no-index --no-deps khiops-core khiops-kni khiops-knitransfer
+          $PYTHON -m pip install --find-links=wheelhouse khiops-core khiops-kni khiops-knitransfer
           $PYTHON -m pip show -f khiops-core
           $PYTHON -m pip show -f khiops-kni
       - name: Run standard tests on the Core and KNI packages
@@ -269,7 +265,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install khiops-kni wheel
-        run: python -m pip install --find-links=wheelhouse khiops-kni
+        run: |
+          # Install the wheel itself only from the local wheelhouse, then resolve its
+          # runtime dependencies from PyPI
+          python -m pip install --find-links=wheelhouse --no-index --no-deps khiops-kni
+          python -m pip install --find-links=wheelhouse khiops-kni
+          python -m pip show -f khiops-kni
       - name: Run python mono-table example
         shell: bash
         run: |

--- a/.github/workflows/pack-pip.yml
+++ b/.github/workflows/pack-pip.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.1.0
       - name: install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.14'
       - name: Install built wheel in a custom directory
@@ -122,7 +122,7 @@ jobs:
           path: wheelhouse
       - name: Install Python
         if: env.SIGN_WINDOWS_WHEELS == 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.14'
       - name: Install wheel package
@@ -261,7 +261,7 @@ jobs:
           path: tutorial
           ref: main
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install khiops-kni wheel

--- a/.github/workflows/pack-pip.yml
+++ b/.github/workflows/pack-pip.yml
@@ -170,7 +170,7 @@ jobs:
         setup:
           - {os: ubuntu-24.04, image: ''}
           - {os: ubuntu-24.04-arm, image: ''}
-          - {os: ubuntu-22.04, image: rockylinux:9}
+          - {os: ubuntu-22.04, image: rockylinux/rockylinux:10}
           - {os: windows-2025-vs2026, image: ''}
           - {os: macos-15, image: ''}
           - {os: macos-15-intel, image: ''}

--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -10,6 +10,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v7
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
       - name: Run pre-commit checks
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/update-kni-tutorial.yml
+++ b/.github/workflows/update-kni-tutorial.yml
@@ -1,9 +1,9 @@
 ---
 name: Update KNI-tutorial repository
-# It allows you to update the KNI-tutorial repo. 
-# It automatically generates the code samples (Java and C) and the readme.md (it only changes the version number with CMake). 
-# Finally, it performs a commit to the main branch and a tag with the current version of Khiops. 
-# Obviously, the action must be triggered from a branch of Khiops with the appropriate version. 
+# It allows you to update the KNI-tutorial repo.
+# It automatically generates the code samples (Java and C) and the readme.md (it only changes the version number with CMake).
+# Finally, it performs a commit to the main branch and a tag with the current version of Khiops.
+# Obviously, the action must be triggered from a branch of Khiops with the appropriate version.
 on:
   workflow_dispatch:
 jobs:
@@ -37,7 +37,7 @@ jobs:
           cp khiops/src/Learning/KNITransfer/KNIRecodeFile.h tutorial/cpp/
           cp khiops/src/Learning/KNITransfer/KNIRecodeMTFiles.h tutorial/cpp/
       - name: Setup Python for documentation generation
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
       - name: Generate Python API documentation

--- a/packaging/pip/pyproject-knitransfer.toml
+++ b/packaging/pip/pyproject-knitransfer.toml
@@ -72,9 +72,8 @@ skip = ["*musllinux*", "*win32*"]
 [tool.cibuildwheel.linux]
 # Repair wheel to convert linux_* tags to manylinux_* (required by PyPI)
 # Exclude KNI library from bundling since it is provided at runtime by the kni pip package
-# Note: the .so suffix (11) must match the project major version; cibuildwheel only expands
-# {wheel} and {dest_dir} here, so the version number cannot be derived automatically
-repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} --exclude libKhiopsNativeInterface.so.11"
+# Major version for the .so suffix is extracted from KWKhiopsVersion.h so it never gets out of sync
+repair-wheel-command = 'MAJOR=$(sed -n "s/.*KHIOPS_VERSION KHIOPS_STR(\([0-9]*\)\..*/\1/p" src/Learning/KWUtils/KWKhiopsVersion.h) && auditwheel repair -w {dest_dir} {wheel} --exclude libKhiopsNativeInterface.so.$MAJOR'
 
 [tool.cibuildwheel.macos]
 # No dependency


### PR DESCRIPTION
fix: install wheels from the local wheelhouse
Install the wheel with 2 steps:
- install the wheel itself only from the local wheelhouse with --find-links.
   The flag --no-index is used to ignore the packages index (and then from installing old wheels).
- install the runtime dependencies (not found in the previous install without the packages index)

Out of scope:
- In pyproject-knitransfer.toml: extract the version of kni from KWKhiopsVersion.h 