### PR TITLE
Add LearningTest tolerance to report variations in aucValues

### DIFF
--- a/test/LearningTestTool/py/_kht_check_results.py
+++ b/test/LearningTestTool/py/_kht_check_results.py
@@ -1042,7 +1042,7 @@ def check_results(test_dir, forced_context=None):
                     assert test_file_lines is not None
                     assert ref_file_lines is not None
                     # Extraction des champs qui correspondent au calcul de l'AUC et des courbes de ROC
-                    for key in ["auc", "values"]:
+                    for key in ["auc", "aucs", "values"]:
                         # Selection d'un champ selon sa valeur
                         selected_test_file_lines = (
                             extract_key_matching_lines_in_json_file(


### PR DESCRIPTION
Suite au merge de la PR #1134 sur l'ajout des auc detaillees par classe cible dans les rapports .khc, il reste un jeu de donnees avec des variations sans importance, quand il n'y a pas assez de memoire pour le calcul exact de l'AUC: LearningTest\TestKhiops\ParallelTask\ClassifierEvaluationLimits

Correction dans kht_check_results.py:
- dans ce cas deja traite des variations de valeur d'AUC, on ajoute la nouvelle section "aucValues" a la liste des sections a ignorer dans ce cas pour la comparaison des rapports .khj